### PR TITLE
Refactor to prevent mod-lists from accessing FQM schema

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -57,6 +57,16 @@
           "permissionsRequired": ["fqm.query.async.results.get"]
         },
         {
+          "methods": ["GET"],
+          "pathPattern": "/query/{query-id}/sortedIds",
+          "permissionsRequired": ["fqm.query.async.results.get"]
+        },
+        {
+          "methods": ["POST"],
+          "pathPattern": "/query/contents",
+          "permissionsRequired": ["fqm.query.async.results.get"]
+        },
+        {
           "methods": ["POST"],
           "pathPattern": "/query",
           "permissionsRequired": ["fqm.query.async.post"]

--- a/src/main/java/org/folio/fqm/config/BeanConfigurations.java
+++ b/src/main/java/org/folio/fqm/config/BeanConfigurations.java
@@ -5,6 +5,7 @@ import org.folio.fqm.lib.FQM;
 import org.folio.fqm.lib.service.FqlValidationService;
 import org.folio.fqm.lib.service.FqmMetaDataService;
 import org.folio.fqm.lib.service.QueryProcessorService;
+import org.folio.fqm.lib.service.QueryResultsSorterService;
 import org.folio.fqm.lib.service.ResultSetService;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
@@ -26,13 +27,18 @@ public class BeanConfigurations {
   }
 
   @Bean
+  public QueryResultsSorterService queryResultsSorterService(@Qualifier("readerDataSource") DataSource dataSource) {
+    return FQM.queryResultsSorterService(dataSource);
+  }
+
+  @Bean
   public ResultSetService getResultSetService(@Qualifier("readerDataSource") DataSource dataSource) {
     return FQM.resultSetService(dataSource);
   }
 
   @Bean
-  public FqlValidationService fqlValidationService(@Qualifier("readerDataSource") DataSource dataSource) {
-    return FQM.fqlValidationService(dataSource);
+  public FqlValidationService fqlValidationService() {
+    return FQM.fqlValidationService();
   }
 
   @Bean

--- a/src/main/java/org/folio/fqm/resource/FqlQueryController.java
+++ b/src/main/java/org/folio/fqm/resource/FqlQueryController.java
@@ -2,17 +2,18 @@ package org.folio.fqm.resource;
 
 import lombok.RequiredArgsConstructor;
 import org.folio.fqm.service.QueryManagementService;
+import org.folio.querytool.domain.dto.ContentsRequest;
 import org.folio.querytool.domain.dto.QueryDetails;
 import org.folio.querytool.domain.dto.QueryIdentifier;
 import org.folio.querytool.domain.dto.ResultsetPage;
 import org.folio.querytool.domain.dto.SubmitQuery;
-import org.folio.spring.FolioExecutionContext;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
 import org.folio.querytool.rest.resource.FqlQueryApi;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -21,7 +22,6 @@ import java.util.UUID;
 public class FqlQueryController implements FqlQueryApi {
 
   private final QueryManagementService queryManagementService;
-  private final FolioExecutionContext executionContext;
 
   @Override
   public ResponseEntity<QueryIdentifier> runFqlQueryAsync(SubmitQuery submitQuery) {
@@ -33,6 +33,18 @@ public class FqlQueryController implements FqlQueryApi {
     Optional<QueryDetails> queryDetails = queryManagementService.getQuery(queryId, Boolean.TRUE.equals(includeResults), offset, limit);
     return queryDetails.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
   }
+
+  @Override
+  public ResponseEntity<List<Map<String, Object>>> getContents(ContentsRequest contentsRequest) {
+    return ResponseEntity.ok(queryManagementService.getContents(contentsRequest.getEntityTypeId(),
+      contentsRequest.getFields(), contentsRequest.getIds()));
+  }
+
+  @Override
+  public ResponseEntity<List<UUID>> getSortedIds(UUID queryId, Integer offset, Integer limit){
+    return ResponseEntity.ok(queryManagementService.getSortedIds(queryId, offset, limit));
+  }
+
 
   @Override
   public ResponseEntity<ResultsetPage> runFqlQuery(String query, UUID entityTypeId, List<String> fields,


### PR DESCRIPTION
## Purpose
mod-list-app: Use the FQM API instead of going to its DB schema

Implementation of above ticket requires these changes in mod-fqm-manager.

## Testing
- [x] All unit tests passed
- [x] List refreshes and exports work with the new APIs