### PR TITLE
MODFQMMGR-2: Clean up sonarqube code smells

### DIFF
--- a/src/main/java/org/folio/fqm/resource/PurgeQueryController.java
+++ b/src/main/java/org/folio/fqm/resource/PurgeQueryController.java
@@ -5,7 +5,6 @@ import org.folio.fqm.service.QueryManagementService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
-import org.folio.fqm.resource.PurgeQueryApi;
 import org.folio.fqm.domain.dto.PurgedQueries;
 
 @RestController

--- a/src/test/java/org/folio/fqm/repository/QueryRepositoryTest.java
+++ b/src/test/java/org/folio/fqm/repository/QueryRepositoryTest.java
@@ -92,9 +92,8 @@ class QueryRepositoryTest {
     Query updatedQuery = new Query(queryId, UUID.randomUUID(), fqlQuery, fields,
       UUID.randomUUID(), null, OffsetDateTime.now(), QueryStatus.SUCCESS, null);
     repo.updateQuery(updatedQuery.queryId(), updatedQuery.status(), updatedQuery.endDate(), updatedQuery.failureReason());
-    TimeUnit.SECONDS.sleep(1);
     List<UUID> expectedIds = List.of(queryId);
-    List<UUID> actualIds = repo.getQueryIdsCompletedBefore(Duration.ofMillis(100));
+    List<UUID> actualIds = repo.getQueryIdsCompletedBefore(Duration.ofMillis(0));
     assertEquals(expectedIds, actualIds);
   }
 


### PR DESCRIPTION
This commit cleans up code smells identified by Sonarqube in 2 files:
- PurgeQueryController - Unnecessary import
- QueryRepositoryTest - Usage of TimeUnit.sleep()