### PR TITLE
Support reporting on User's Departments

### DIFF
--- a/src/main/resources/db/changelog/changes/v1.0.0/entity-type-definitions.xml
+++ b/src/main/resources/db/changelog/changes/v1.0.0/entity-type-definitions.xml
@@ -44,6 +44,9 @@
     <sqlFile path="sql/entity-type-definitions/insert-users-group-definition.sql" relativeToChangelogFile="true"/>
   </changeSet>
 
+  <changeSet id="insert-users-departments-definition" author="bsharp@ebsco.com">
+    <sqlFile path="sql/entity-type-definitions/insert-users-departments-definition.sql" relativeToChangelogFile="true"/>
+  </changeSet>
 
   <changeSet id="insert-loan-status-definition" author="kjain@ebsco.com">
     <sqlFile path="sql/entity-type-definitions/insert-loan-status-definition.sql" relativeToChangelogFile="true"/>

--- a/src/main/resources/db/changelog/changes/v1.0.0/harvested-views.xml
+++ b/src/main/resources/db/changelog/changes/v1.0.0/harvested-views.xml
@@ -111,4 +111,13 @@
     </createView>
   </changeSet>
 
+  <changeSet id="create_view_users_departments" author="bsharp@ebsco.com">
+    <preConditions onFail="CONTINUE">
+      <tableExists tableName = "departments" schemaName="${tenant_id}_mod_users"/>
+    </preConditions>
+    <createView viewName="src_users_departments">
+      SELECT * FROM ${tenant_id}_mod_users.departments
+    </createView>
+  </changeSet>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.0.0/sql/derived-tables/create-view-user-details.sql
+++ b/src/main/resources/db/changelog/changes/v1.0.0/sql/derived-tables/create-view-user-details.sql
@@ -1,35 +1,38 @@
 CREATE OR REPLACE VIEW drv_user_details
- AS
+AS
 SELECT
-
-        UserDetails.jsonb -> 'personal' ->> 'firstName' as first_name,
-        UserDetails.jsonb -> 'personal' ->> 'lastName' as last_name,
-        UserDetails.jsonb ->>'barcode' as barcode,
-        UserDetails.jsonb ->>'username' as username,
-        UserDetails.id as id,
-        UserDetails.jsonb ->> 'externalSystemId' as external_system_id,
-        UserDetails.jsonb ->> 'active' as active,
-        UserDetails.jsonb -> 'personal' ->> 'email' as email,
-        UserDetails.jsonb ->> 'createdDate' as created_date,
-        UserDetails.jsonb ->> 'updatedDate' as updated_date,
-        UserDetails.jsonb -> 'personal' ->> 'preferredFirstName' as preferred_first_name,
-        UserDetails.jsonb -> 'personal' ->> 'middleName' as middle_name,
-        UserDetails.jsonb -> 'personal' ->> 'phone' as phone,
-        UserDetails.jsonb -> 'personal' ->> 'mobilePhone' as mobile_phone,
-        UserDetails.jsonb -> 'personal' ->> 'dateOfBirth' as date_of_birth,
-        UserDetails.jsonb ->> 'expirationDate'::text AS expiration_date,
-        UserDetails.jsonb ->> 'enrollmentDate'::text AS enrollment_date,
+        userDetails.jsonb -> 'personal' ->> 'firstName' as first_name,
+        userDetails.jsonb -> 'personal' ->> 'lastName' as last_name,
+        userDetails.jsonb ->>'barcode' as barcode,
+        userDetails.jsonb ->>'username' as username,
+        userDetails.id as id,
+        userDetails.jsonb ->> 'externalSystemId' as external_system_id,
+        userDetails.jsonb ->> 'active' as active,
+        userDetails.jsonb -> 'personal' ->> 'email' as email,
+        userDetails.jsonb ->> 'createdDate' as created_date,
+        userDetails.jsonb ->> 'updatedDate' as updated_date,
+        userDetails.jsonb -> 'personal' ->> 'preferredFirstName' as preferred_first_name,
+        userDetails.jsonb -> 'personal' ->> 'middleName' as middle_name,
+        userDetails.jsonb -> 'personal' ->> 'phone' as phone,
+        userDetails.jsonb -> 'personal' ->> 'mobilePhone' as mobile_phone,
+        userDetails.jsonb -> 'personal' ->> 'dateOfBirth' as date_of_birth,
+        userDetails.jsonb ->> 'expirationDate'::text AS expiration_date,
+        userDetails.jsonb ->> 'enrollmentDate'::text AS enrollment_date,
         patron_id_ref_data.jsonb ->> 'group'::text AS user_patron_group,
         patron_id_ref_data.id::text AS user_patron_group_id,
         UserDetails.jsonb -> 'personal' ->> 'preferredContactTypeId' as preferred_contact_type_id,
         CASE UserDetails.jsonb -> 'personal' ->> 'preferredContactTypeId'
-        WHEN '001' THEN 'mail'
-        WHEN '002' THEN 'email'
-        WHEN '003' THEN 'text'
-        WHEN '004' THEN 'phone'
-        WHEN '005' THEN 'mobile'
-        ELSE 'unknown'
-    END AS preferred_contact_type
-FROM src_users_users UserDetails
-  LEFT JOIN src_users_groups patron_id_ref_data ON patron_id_ref_data.id = (UserDetails.jsonb ->> 'patronGroup')::uuid
+          WHEN '001' THEN 'mail'
+          WHEN '002' THEN 'email'
+          WHEN '003' THEN 'text'
+          WHEN '004' THEN 'phone'
+          WHEN '005' THEN 'mobile'
+          ELSE 'unknown'
+        END AS preferred_contact_type,
+        array_agg(temp_departments.id::text) FILTER (where temp_departments.id is not null) as department_ids,
+        array_agg(temp_departments.jsonb ->> 'name') FILTER (where temp_departments.jsonb ->> 'name' is not null) as department_names
+FROM src_users_users userdetails
+        LEFT JOIN src_users_groups patron_id_ref_data ON patron_id_ref_data.id = ((userdetails.jsonb ->> 'patronGroup'::text)::uuid)
+        LEFT JOIN src_users_departments as temp_departments ON userdetails.jsonb -> 'departments' ?? temp_departments.id::text
+GROUP BY userdetails.id, userdetails.jsonb, patron_id_ref_data.id, patron_id_ref_data.jsonb
 

--- a/src/main/resources/db/changelog/changes/v1.0.0/sql/entity-type-definitions/insert-item-details-definition.sql
+++ b/src/main/resources/db/changelog/changes/v1.0.0/sql/entity-type-definitions/insert-item-details-definition.sql
@@ -301,7 +301,11 @@ INSERT INTO entity_type_definition (id, derived_table_name, definition)
                  },
                  {
                     "columnName": "instance_primary_contributor",
-                   "direction": "ASC"
+                    "direction": "ASC"
+                 },
+                 {
+                    "columnName": "id",
+                    "direction": "ASC"
                  }
                ]
          }');

--- a/src/main/resources/db/changelog/changes/v1.0.0/sql/entity-type-definitions/insert-loan-details-definition.sql
+++ b/src/main/resources/db/changelog/changes/v1.0.0/sql/entity-type-definitions/insert-loan-details-definition.sql
@@ -297,6 +297,10 @@ INSERT INTO entity_type_definition (id, derived_table_name, definition)
                 {
                     "columnName": "loan_due_date",
                     "direction": "ASC"
+                },
+                {
+                    "columnName": "id",
+                    "direction": "ASC"
                 }
               ]
          }');

--- a/src/main/resources/db/changelog/changes/v1.0.0/sql/entity-type-definitions/insert-user-details-definition.sql
+++ b/src/main/resources/db/changelog/changes/v1.0.0/sql/entity-type-definitions/insert-user-details-definition.sql
@@ -143,7 +143,7 @@ INSERT INTO entity_type_definition (id, derived_table_name, definition)
                        "dataType":{
                          "dataType":"stringType"
                        },
-                       "labelAlias": "User preferred contact type id ",
+                       "labelAlias": "User preferred contact type id",
                        "visibleByDefault": false
                  },
                 {
@@ -177,6 +177,39 @@ INSERT INTO entity_type_definition (id, derived_table_name, definition)
                       },
                       "labelAlias": "Username",
                       "visibleByDefault": true
+                },
+                {
+                      "name": "department_ids",
+                      "dataType": {
+                        "dataType":"arrayType",
+                        "itemDataType": {
+                          "dataType": "rangedUUIDType"
+                        }
+                      },
+                      "labelAlias": "Department Ids",
+                      "visibleByDefault": false
+                },
+                {
+                      "name": "department_names",
+                      "dataType":{
+                        "dataType":"arrayType",
+                        "itemDataType": {
+                          "dataType": "stringType"
+                        }
+                      },
+                      "idColumnName": "department_ids",
+                       "source": {
+                              "entityTypeId": "c8364551-7e51-475d-8473-88951181452d",
+                              "columnName": "department"
+                       },
+                      "labelAlias": "Department Names",
+                      "visibleByDefault": true
                 }
+             ],
+             "defaultSort": [
+               {
+                   "columnName": "id",
+                   "direction": "ASC"
+               }
              ]
          }');

--- a/src/main/resources/db/changelog/changes/v1.0.0/sql/entity-type-definitions/insert-users-departments-definition.sql
+++ b/src/main/resources/db/changelog/changes/v1.0.0/sql/entity-type-definitions/insert-users-departments-definition.sql
@@ -1,0 +1,30 @@
+INSERT INTO entity_type_definition (id, derived_table_name, definition)
+    VALUES ('c8364551-7e51-475d-8473-88951181452d','src_users_departments', '{
+        "id": "c8364551-7e51-475d-8473-88951181452d",
+        "name": "src_users_departments",
+        "labelAlias": "Departments",
+        "root": true,
+        "private" : true,
+        "columns": [
+            {
+                "name": "id",
+                "dataType":{
+                    "dataType": "rangedUUIDType"
+                },
+                "labelAlias": "Id",
+                "visibleByDefault": true
+            },
+            {
+                "name": "department",
+                "dataType":{
+                    "dataType": "stringType"
+                },
+                "valueGetter": {
+                    "type": "rmb_jsonb",
+                    "param": "name"
+                },
+                "labelAlias": "Department",
+                "visibleByDefault": true
+            }
+        ]
+}');


### PR DESCRIPTION
## Purpose
 To enable query and reporting on user's Departments.  One user can have multiple departments they are associated with, so we need to handle the complexity of this one-to-many relationship.  

## Testing
- [x] All unit tests passed
- [x] Array fields are created for department_ids and department_names in drv_user_details view:
<img width="1220" alt="Screenshot 2023-09-06 at 12 08 08 PM" src="https://github.com/folio-org/mod-fqm-manager/assets/97990858/a1a0155c-6d17-4c41-9464-5aeb540c10b4">

**------------------------------------------------------------------------**

- [x] Array fields are returned correctly from getContents API:
<img width="696" alt="Screenshot 2023-09-06 at 12 09 43 PM" src="https://github.com/folio-org/mod-fqm-manager/assets/97990858/5d840e07-9eb3-4316-a82c-a4c4e7cabeba">


NOTE: department_ids and department_names will not necessarily be in the same order. For example, the getContents API may return
```
"department_ids": ["id1", "id2],
"department_names": ["name2", "name1"]
```