### PR TITLE
MODFQMMGR-11 Remove the _READER settings from MD

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -185,12 +185,6 @@
       { "name": "DB_PORT",
         "value": "5432"
       },
-      { "name": "DB_HOST_READER",
-        "value": "postgres"
-      },
-      { "name": "DB_PORT_READER",
-        "value": "5432"
-      },
       { "name": "DB_USERNAME",
         "value": "folio_admin"
       },


### PR DESCRIPTION
In environments that use the module descriptor for basic config, if there is no read node for the DB, the default provided in the module descriptor breaks the fallback behavior that is supposed to make FQM use the write node