### PR TITLE
MODFQMMGR-12 Add CREATE EXTENSION for unaccent

### DIFF
--- a/src/main/resources/db/changelog/changes/v1.0.0/sql/create-f-unaccent-function.sql
+++ b/src/main/resources/db/changelog/changes/v1.0.0/sql/create-f-unaccent-function.sql
@@ -1,3 +1,4 @@
+CREATE EXTENSION IF NOT EXISTS unaccent WITH SCHEMA public;
 CREATE OR REPLACE FUNCTION f_unaccent(
 	text)
     RETURNS text


### PR DESCRIPTION
The missing CREATE EXTENSION for unaccent is causing issues because there's no guarantee that the extension was actually set up before the create-f-unaccent-function.sql script gets run