### PR TITLE
MODFQMMGR-25: Hide address fields for User entity type

### DIFF
--- a/src/main/resources/db/changelog/changes/v1.0.0/sql/entity-type-definitions/insert-user-details-definition.sql
+++ b/src/main/resources/db/changelog/changes/v1.0.0/sql/entity-type-definitions/insert-user-details-definition.sql
@@ -5,152 +5,24 @@ INSERT INTO entity_type_definition (id, derived_table_name, definition)
              "labelAlias" : "Users",
              "private" : false,
              "columns": [
-                 {
-                       "name": "address_ids",
-                       "dataType": {
-                         "dataType":"arrayType",
-                         "itemDataType": {
-                           "dataType": "rangedUUIDType"
-                         }
-                       },
-                       "labelAlias": "Address IDs",
-                       "visibleByDefault": false
-                 },
-                 {
-                       "name": "address_line1",
-                       "dataType":{
-                         "dataType":"arrayType",
-                         "itemDataType": {
-                           "dataType": "stringType"
-                         }
-                       },
-                       "labelAlias": "Address line1",
-                       "visibleByDefault": false
-                 },
-                 {
-                       "name": "address_line2",
-                       "dataType":{
-                         "dataType":"arrayType",
-                         "itemDataType": {
-                           "dataType": "stringType"
-                         }
-                       },
-                       "labelAlias": "Address line2",
-                       "visibleByDefault": false
-                 },
                 {
-                       "name": "address_type_names",
-                       "dataType":{
-                         "dataType":"arrayType",
-                         "itemDataType": {
-                           "dataType": "stringType"
-                         }
-                       },
-                       "labelAlias": "Address type names",
-                       "visibleByDefault": false,
-                       "idColumnName": "address_ids",
-                        "source": {
-                               "entityTypeId": "e627a89b-682b-41fe-b532-f4262020a451",
-                               "columnName": "addressType"
-                        }
-                 },
-                {
-                      "name": "cities",
-                      "dataType":{
-                        "dataType":"arrayType",
-                        "itemDataType": {
-                          "dataType": "stringType"
-                        }
-                      },
-                      "labelAlias": "City",
-                      "visibleByDefault": false
-                },
-                {
-                      "name": "country_ids",
-                      "dataType":{
-                        "dataType":"arrayType",
-                        "itemDataType": {
-                          "dataType": "stringType"
-                        }
-                      },
-                      "labelAlias": "Country ID",
-                      "visibleByDefault": false
-                },
-                {
-                      "name": "department_ids",
-                      "dataType": {
-                        "dataType":"arrayType",
-                        "itemDataType": {
-                          "dataType": "rangedUUIDType"
-                        }
-                      },
-                      "labelAlias": "Department IDs",
-                      "visibleByDefault": false
-                },
-                {
-                      "name": "department_names",
-                      "dataType":{
-                        "dataType":"arrayType",
-                        "itemDataType": {
-                          "dataType": "stringType"
-                        }
-                      },
-                      "idColumnName": "department_ids",
-                       "source": {
-                              "entityTypeId": "c8364551-7e51-475d-8473-88951181452d",
-                              "columnName": "department"
-                       },
-                      "labelAlias": "Department names",
-                      "visibleByDefault": false
-                },
-               {
-                      "name": "postal_codes",
-                      "dataType":{
-                        "dataType":"arrayType",
-                        "itemDataType": {
-                          "dataType": "stringType"
-                        }
-                      },
-                      "labelAlias": "Postal code",
-                      "visibleByDefault": false
-                },
-                {
-                      "name": "primary_address",
-                      "dataType":{
-                        "dataType":"stringType"
-                      },
-                      "labelAlias": "Primary address",
-                      "visibleByDefault": false
-                },
-                {
-                      "name": "regions",
-                      "dataType":{
-                        "dataType":"arrayType",
-                        "itemDataType": {
-                          "dataType": "stringType"
-                        }
-                      },
-                      "labelAlias": "Region",
-                      "visibleByDefault": false
-                },
-              {
-                      "name": "active",
-                      "dataType":{
-                        "dataType":"booleanType"
-                      },
-                      "labelAlias": "User active",
-                      "visibleByDefault": true,
-                      "values": [
-                        {
-                          "value": "true",
-                          "label": "True"
+                        "name": "active",
+                        "dataType":{
+                          "dataType":"booleanType"
                         },
-                        {
-                          "value": "false",
-                          "label": "False"
-                        }
-                    ]
-                },
+                        "labelAlias": "User active",
+                        "visibleByDefault": true,
+                        "values": [
+                          {
+                            "value": "true",
+                            "label": "True"
+                          },
+                          {
+                            "value": "false",
+                            "label": "False"
+                          }
+                      ]
+                  },
                 {
                       "name": "barcode",
                       "dataType":{
@@ -291,6 +163,14 @@ INSERT INTO entity_type_definition (id, derived_table_name, definition)
                       },
                       "labelAlias": "User preferred first name",
                       "visibleByDefault": true
+                },
+                {
+                      "name": "primary_address",
+                      "dataType":{
+                        "dataType":"stringType"
+                      },
+                      "labelAlias": "User primary address",
+                      "visibleByDefault": false
                 },
                 {
                       "name": "updated_date",


### PR DESCRIPTION
## Purpose
[Hide address/department fields for User entity type](https://issues.folio.org/projects/MODFQMMGR/issues/MODFQMMGR-25)

## Approach
- Temporarily remove address and department fields from User entity type definition

## Testing
- [x] Tested by manually removing fields from user_details definition in corsair-frm environment. Fields were no longer visible in query builder.
