### PR TITLE
MODFQMMGR-20 and MODFQMMGR-3 - Fix interface names

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -17,7 +17,7 @@
       ]
     },
     {
-      "id": "entity_types",
+      "id": "entity-types",
       "version": "1.0",
       "handlers": [
         {

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -3,11 +3,6 @@
   "name": "The module descriptor for mod-fqm-manager.",
   "provides": [
     {
-      "id": "mod-fqm-manager",
-      "version": "1.0",
-      "handlers": []
-    },
-    {
       "id": "_tenant",
       "version": "1.2",
       "interfaceType": "system",
@@ -43,7 +38,7 @@
       ]
     },
     {
-      "id": "query",
+      "id": "fqm-query",
       "version": "1.0",
       "handlers": [
         {


### PR DESCRIPTION
This commit renames the module interface name, along with the entity-types interface, to comply with established naming conventions