### PR TITLE
Add dependencies to module descriptor

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -162,7 +162,64 @@
       "visible": true
     }
   ],
-  "requires": [],
+  "requires": [
+    {
+      "id": "item-storage",
+      "version": "10.0"
+    },
+    {
+      "id": "holdings-storage",
+      "version": "6.0"
+    },
+    {
+      "id": "instance-storage",
+      "version": "10.0"
+    },
+    {
+      "id": "loan-types",
+      "version": "2.3"
+    },
+    {
+      "id": "material-types",
+      "version": "2.2"
+    },
+    {
+      "id": "shelf-locations",
+      "version": "1.1"
+    },
+    {
+      "id": "location-units",
+      "version": "2.0"
+    },
+    {
+      "id": "locations",
+      "version": "3.0"
+    },
+    {
+      "id": "call-number-types",
+      "version": "1.0"
+    },
+    {
+      "id": "holdings-types",
+      "version": "1.0"
+    },
+    {
+      "id": "service-points",
+      "version": "3.3"
+    },
+    {
+      "id": "users",
+      "version": "16.0"
+    },
+    {
+      "id": "loan-storage",
+      "version": "7.1"
+    },
+    {
+      "id": "loan-policy-storage",
+      "version": "2.3"
+    }
+  ],
   "launchDescriptor": {
     "dockerImage": "@artifactId@:@version@",
     "dockerPull": false,


### PR DESCRIPTION
## Purpose
Add dependencies to module descriptor so that mod-fqm-manager can be deployed in snapshot

