### PR TITLE
MODFQMMGR-26: Handle missing values in derived fields

### DIFF
--- a/src/main/resources/db/changelog/changes/v1.0.0/sql/derived-tables/create-view-item-details.sql
+++ b/src/main/resources/db/changelog/changes/v1.0.0/sql/derived-tables/create-view-item-details.sql
@@ -9,7 +9,11 @@ CREATE OR REPLACE VIEW drv_item_details
     src_inventory_item.jsonb ->> 'barcode'::text AS item_barcode,
     src_inventory_item.jsonb ->> 'copyNumber'::text AS item_copy_number,
     (src_inventory_item.jsonb -> 'metadata'::text) ->> 'createdDate'::text AS item_created_date,
-    concat((src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'prefix'::text ,', ', (src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'callNumber'::text ,', ',src_inventory_item.jsonb ->> 'copyNumber'::text) AS item_effective_call_number,
+    concat_ws(', ',
+    		NULLIF((src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'prefix'::text, ''),
+    		NULLIF((src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'callNumber'::text, ''),
+    		NULLIF(src_inventory_item.jsonb ->> 'copyNumber'::text, '')
+    ) AS item_effective_call_number,
     call_number_type_ref_data.jsonb ->> 'name'::text AS item_effective_call_number_type_name,
     (src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'typeId'::text AS item_effective_call_number_typeid,
     loclib_ref_data.jsonb ->> 'code'::text AS item_effective_library_code,

--- a/src/main/resources/db/changelog/changes/v1.0.0/sql/derived-tables/create-view-user-details.sql
+++ b/src/main/resources/db/changelog/changes/v1.0.0/sql/derived-tables/create-view-user-details.sql
@@ -29,52 +29,61 @@ SELECT
           WHEN '005' THEN 'mobile'
           ELSE 'unknown'
         END AS preferred_contact_type,
-               CASE
-                    WHEN (( SELECT array_agg(add_id.value ->> 'primaryAddress'::text) FILTER (WHERE (add_id.value ->> 'primaryAddress'::text) IS NOT NULL) AS array_agg
-                       FROM jsonb_array_elements((userdetails.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value))) @> ARRAY['true'::text] THEN (((((((((array_to_string(( SELECT array_agg(subquery.city) AS array_agg
-                       FROM ( SELECT add_id.value ->> 'city'::text AS city,
-                                row_number() OVER (ORDER BY (add_id.value ->> 'primaryAddress'::text)) AS row_num
-                               FROM jsonb_array_elements((userdetails.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value)) subquery
-                      WHERE subquery.row_num = 1), ','::text) || ', '::text) || array_to_string(( SELECT array_agg(subquery.region) AS array_agg
-                       FROM ( SELECT add_id.value ->> 'region'::text AS region,
-                                row_number() OVER (ORDER BY (add_id.value ->> 'primaryAddress'::text)) AS row_num
-                               FROM jsonb_array_elements((userdetails.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value)) subquery
-                      WHERE subquery.row_num = 1), ','::text)) || ', '::text) || array_to_string(( SELECT array_agg(subquery.countryid) AS array_agg
-                       FROM ( SELECT add_id.value ->> 'countryId'::text AS countryid,
-                                row_number() OVER (ORDER BY (add_id.value ->> 'primaryAddress'::text)) AS row_num
-                               FROM jsonb_array_elements((userdetails.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value)) subquery
-                      WHERE subquery.row_num = 1), ','::text)) || ', '::text) || array_to_string(( SELECT array_agg(subquery.postalcode) AS array_agg
-                       FROM ( SELECT add_id.value ->> 'postalCode'::text AS postalcode,
-                                row_number() OVER (ORDER BY (add_id.value ->> 'primaryAddress'::text)) AS row_num
-                               FROM jsonb_array_elements((userdetails.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value)) subquery
-                      WHERE subquery.row_num = 1), ','::text)) || ', '::text) || array_to_string(( SELECT array_agg(subquery.addressline1) AS array_agg
-                       FROM ( SELECT add_id.value ->> 'addressLine1'::text AS addressline1,
-                                row_number() OVER (ORDER BY (add_id.value ->> 'primaryAddress'::text)) AS row_num
-                               FROM jsonb_array_elements((userdetails.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value)) subquery
-                      WHERE subquery.row_num = 1), ','::text)) || ' '::text) || array_to_string(( SELECT array_agg(subquery.addressline2) AS array_agg
-                       FROM ( SELECT add_id.value ->> 'addressLine2'::text AS addressline2,
-                                row_number() OVER (ORDER BY (add_id.value ->> 'primaryAddress'::text)) AS row_num
-                               FROM jsonb_array_elements((userdetails.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value)) subquery
-                      WHERE subquery.row_num = 1), ','::text)
-                    ELSE NULL::text
-                END AS primary_address,
-            ( SELECT array_agg(add_id.value ->> 'city'::text) FILTER (WHERE (add_id.value ->> 'city'::text) IS NOT NULL) AS array_agg
-                   FROM jsonb_array_elements((userdetails.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value)) AS cities,
-            ( SELECT array_agg(add_id.value ->> 'region'::text) FILTER (WHERE (add_id.value ->> 'region'::text) IS NOT NULL) AS array_agg
-                   FROM jsonb_array_elements((userdetails.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value)) AS regions,
-            ( SELECT array_agg(add_id.value ->> 'countryId'::text) FILTER (WHERE (add_id.value ->> 'countryId'::text) IS NOT NULL) AS array_agg
-                   FROM jsonb_array_elements((userdetails.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value)) AS country_ids,
-            ( SELECT array_agg(add_id.value ->> 'postalCode'::text) FILTER (WHERE (add_id.value ->> 'postalCode'::text) IS NOT NULL) AS array_agg
-                   FROM jsonb_array_elements((userdetails.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value)) AS postal_codes,
-            ( SELECT array_agg(add_id.value ->> 'addressLine1'::text) FILTER (WHERE (add_id.value ->> 'addressLine1'::text) IS NOT NULL) AS array_agg
-                   FROM jsonb_array_elements((userdetails.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value)) AS address_line1,
-            ( SELECT array_agg(add_id.value ->> 'addressLine2'::text) FILTER (WHERE (add_id.value ->> 'addressLine2'::text) IS NOT NULL) AS array_agg
-                   FROM jsonb_array_elements((userdetails.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value)) AS address_line2,
-            ( SELECT array_agg(add_id.value ->> 'addressTypeId'::text) FILTER (WHERE (add_id.value ->> 'addressTypeId'::text) IS NOT NULL) AS array_agg
-                   FROM jsonb_array_elements((userdetails.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value)) AS address_ids,
-            ( SELECT array_agg(a.jsonb ->> 'addressType'::text) FILTER (WHERE (a.jsonb ->> 'addressType'::text) IS NOT NULL) AS array_agg
-                   FROM jsonb_array_elements((userdetails.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value)
-                     JOIN src_users_addresstype a ON (add_id.value ->> 'addressTypeId'::text) = a.id::text) AS address_type_names,
+        concat_ws(', ',
+        		  NULLIF((SELECT subquery.city
+        				  FROM (
+        						SELECT add_id.value ->> 'city'::text AS city,
+        						row_number() OVER (ORDER BY (add_id.value ->> 'primaryAddress'::text)) AS row_num
+        						FROM jsonb_array_elements((userdetails.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value)) subquery
+        				  WHERE subquery.row_num = 1), ''),
+        		  NULLIF((SELECT subquery.region
+        				  FROM (
+        						SELECT add_id.value ->> 'region'::text AS region,
+        						row_number() OVER (ORDER BY (add_id.value ->> 'primaryAddress'::text)) AS row_num
+        						FROM jsonb_array_elements((userdetails.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value)) subquery
+        				  WHERE subquery.row_num = 1), ''),
+        		  NULLIF((SELECT subquery.countryId
+        				  FROM (
+        						SELECT add_id.value ->> 'countryId'::text AS countryId,
+        						row_number() OVER (ORDER BY (add_id.value ->> 'primaryAddress'::text)) AS row_num
+        						FROM jsonb_array_elements((userdetails.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value)) subquery
+        				  WHERE subquery.row_num = 1), ''),
+        		  NULLIF((SELECT subquery.postalCode
+        				  FROM (
+        						SELECT add_id.value ->> 'postalCode'::text AS postalCode,
+        						row_number() OVER (ORDER BY (add_id.value ->> 'primaryAddress'::text)) AS row_num
+        						FROM jsonb_array_elements((userdetails.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value)) subquery
+        				  WHERE subquery.row_num = 1), ''),
+        		  NULLIF((SELECT subquery.addressLine1
+        				  FROM (
+        						SELECT add_id.value ->> 'addressLine1'::text AS addressLine1,
+        						row_number() OVER (ORDER BY (add_id.value ->> 'primaryAddress'::text)) AS row_num
+        						FROM jsonb_array_elements((userdetails.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value)) subquery
+        				  WHERE subquery.row_num = 1), ''),
+        		  NULLIF((SELECT subquery.addressLine2
+        				  FROM (
+        						SELECT add_id.value ->> 'addressLine2'::text AS addressLine2,
+        						row_number() OVER (ORDER BY (add_id.value ->> 'primaryAddress'::text)) AS row_num
+        						FROM jsonb_array_elements((userdetails.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value)) subquery
+        				  WHERE subquery.row_num = 1), '')
+        ) AS primary_address,
+        ( SELECT array_agg(add_id.value ->> 'city'::text) FILTER (WHERE (add_id.value ->> 'city'::text) IS NOT NULL) AS array_agg
+               FROM jsonb_array_elements((userdetails.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value)) AS cities,
+        ( SELECT array_agg(add_id.value ->> 'region'::text) FILTER (WHERE (add_id.value ->> 'region'::text) IS NOT NULL) AS array_agg
+               FROM jsonb_array_elements((userdetails.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value)) AS regions,
+        ( SELECT array_agg(add_id.value ->> 'countryId'::text) FILTER (WHERE (add_id.value ->> 'countryId'::text) IS NOT NULL) AS array_agg
+               FROM jsonb_array_elements((userdetails.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value)) AS country_ids,
+        ( SELECT array_agg(add_id.value ->> 'postalCode'::text) FILTER (WHERE (add_id.value ->> 'postalCode'::text) IS NOT NULL) AS array_agg
+               FROM jsonb_array_elements((userdetails.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value)) AS postal_codes,
+        ( SELECT array_agg(add_id.value ->> 'addressLine1'::text) FILTER (WHERE (add_id.value ->> 'addressLine1'::text) IS NOT NULL) AS array_agg
+               FROM jsonb_array_elements((userdetails.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value)) AS address_line1,
+        ( SELECT array_agg(add_id.value ->> 'addressLine2'::text) FILTER (WHERE (add_id.value ->> 'addressLine2'::text) IS NOT NULL) AS array_agg
+               FROM jsonb_array_elements((userdetails.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value)) AS address_line2,
+        ( SELECT array_agg(add_id.value ->> 'addressTypeId'::text) FILTER (WHERE (add_id.value ->> 'addressTypeId'::text) IS NOT NULL) AS array_agg
+               FROM jsonb_array_elements((userdetails.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value)) AS address_ids,
+        ( SELECT array_agg(a.jsonb ->> 'addressType'::text) FILTER (WHERE (a.jsonb ->> 'addressType'::text) IS NOT NULL) AS array_agg
+               FROM jsonb_array_elements((userdetails.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value)
+                 JOIN src_users_addresstype a ON (add_id.value ->> 'addressTypeId'::text) = a.id::text) AS address_type_names,
         array_agg(temp_departments.id::text) FILTER (where temp_departments.id is not null) as department_ids,
         array_agg(temp_departments.jsonb ->> 'name') FILTER (where temp_departments.jsonb ->> 'name' is not null) as department_names
 FROM src_users_users userdetails


### PR DESCRIPTION
## Purpose
[Handle missing values in compound derived fields](https://issues.folio.org/browse/MODFQMMGR-26)

## Testing
- [x] Missing fields for primary_address and item_effective_call_number are handled correctly with no extra commas:
<img width="793" alt="Screenshot 2023-09-27 at 11 03 45 AM" src="https://github.com/folio-org/mod-fqm-manager/assets/97990858/f91c0cf7-dc6c-45f8-a549-e47e28cc0cff">


