### PR TITLE
MODFQMMGR-28: Fix api-lint errors

### DIFF
--- a/src/main/resources/swagger.api/schemas/error.json
+++ b/src/main/resources/swagger.api/schemas/error.json
@@ -15,7 +15,6 @@
       "description": "Error message code"
     },
     "parameters": {
-      "type": "object",
       "description": "Error message parameters",
       "$ref": "parameters.json"
     }

--- a/src/main/resources/swagger.api/schemas/errors.json
+++ b/src/main/resources/swagger.api/schemas/errors.json
@@ -7,7 +7,6 @@
       "id": "errors",
       "type": "array",
       "items": {
-        "type": "object",
         "$ref": "error.json"
       }
     },

--- a/src/main/resources/swagger.api/schemas/parameters.json
+++ b/src/main/resources/swagger.api/schemas/parameters.json
@@ -2,8 +2,6 @@
   "description": "List of key/value parameters of an error",
   "type": "array",
   "items": {
-    "type": "object",
     "$ref": "parameter.json"
-  },
-  "additionalProperties": false
+  }
 }


### PR DESCRIPTION
## Purpose
[MODFQMMGR-28: Fix api-lint errors](https://issues.folio.org/browse/MODFQMMGR-28)

## Testing
- [x] mod-fqm-manager can be built with no lint errors
