### PR TITLE
Downgrade loan-types interface version requirement

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -172,7 +172,7 @@
     },
     {
       "id": "loan-types",
-      "version": "2.3"
+      "version": "2.2"
     },
     {
       "id": "material-types",


### PR DESCRIPTION
## Purpose
Our environment doesn't like loan-types 2.3, so downgrading to 2.2
