### PR TITLE
MODFQMMGR-28: Fix remaining api-lint errors

### DIFF
--- a/src/main/resources/swagger.api/mod-fqm-manager.yaml
+++ b/src/main/resources/swagger.api/mod-fqm-manager.yaml
@@ -91,14 +91,20 @@ components:
       description: Validation errors
       content:
         application/json:
-          example: examples/validationErrorResponse.sample
+          example:
+            errors:
+              - message: Request is invalid
+                code: invalid.request
           schema:
             $ref: "#/components/schemas/errorResponse"
     internalServerErrorResponse:
       description: When unhandled exception occurred during code execution, e.g. NullPointerException
       content:
         application/json:
-          example: examples/unknownError.sample
+          example:
+            errors:
+              - message: Unexpected error
+                code: unexpected.error
           schema:
             $ref: "#/components/schemas/errorResponse"
 


### PR DESCRIPTION
## Purpose
[MODFQMMGR-28: Fix remaining api-lint errors](https://issues.folio.org/browse/MODFQMMGR-28)

## Testing
- [x] Module can be built with no api-lint errors or warnings (checked with -w flag)
