### PR TITLE
Rework item views to use instance metadata indexes

### DIFF
--- a/src/main/resources/db/changelog/changelog-master.xml
+++ b/src/main/resources/db/changelog/changelog-master.xml
@@ -5,5 +5,6 @@
                    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
 
   <include file="changes/v1.0.0/changelog-v1.0.0.xml" relativeToChangelogFile="true"/>
+  <include file="changes/v1.0.1/changelog-v1.0.1.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.0.1/changelog-v1.0.1.xml
+++ b/src/main/resources/db/changelog/changes/v1.0.1/changelog-v1.0.1.xml
@@ -5,5 +5,7 @@
                    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
 
   <include file="drv_item_callnumber_location_create.xml" relativeToChangelogFile="true"/>
+  <include file="drv_item_holdingsrecord_instance_create.xml" relativeToChangelogFile="true"/>
+  <include file="drv_item_details_create.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.0.1/drv_item_details_create.xml
+++ b/src/main/resources/db/changelog/changes/v1.0.1/drv_item_details_create.xml
@@ -1,0 +1,69 @@
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+  <changeSet id="create-view-item-details" author="bsharp@ebsco.com">
+    <preConditions onFail="CONTINUE">
+      <viewExists viewName="src_inventory_item"/>
+      <viewExists viewName="src_inventory_holdings_record"/>
+      <viewExists viewName="src_inventory_instance"/>
+      <viewExists viewName="src_inventory_location"/>
+      <viewExists viewName="src_inventory_call_number_type"/>
+      <viewExists viewName="src_inventory_loclibrary"/>
+      <viewExists viewName="src_inventory_material_type"/>
+      <sqlCheck expectedResult="1">
+        SELECT COUNT(*) FROM pg_matviews WHERE schemaname = '${tenant_id}_mod_fqm_manager'AND matviewname = 'drv_inventory_item_status';
+      </sqlCheck>
+    </preConditions>
+    <createView
+      replaceIfExists="true"
+      viewName="drv_item_details">
+      SELECT src_inventory_item.id,
+        "left"(lower((instance_details.jsonb -> 'metadata'::text) ->> 'createdDate'::text), 600) AS instance_created_date,
+        hrim.instanceid AS instance_id,
+        jsonb_path_query_first(instance_details.jsonb, '$."contributors"[*]?(@."primary" == true)."name"'::jsonpath) #>> '{}'::text[] AS instance_primary_contributor,
+        instance_details.jsonb ->> 'title'::text AS instance_title,
+        "left"(lower(${tenant_id}_mod_inventory_storage.f_unaccent(instance_details.jsonb ->> 'title'::text)), 600) AS instance_title_searchable,
+        "left"(lower((instance_details.jsonb -> 'metadata'::text) ->> 'updatedDate'::text), 600) AS instance_updated_date,
+        lower(src_inventory_item.jsonb ->> 'barcode'::text) AS item_barcode,
+        src_inventory_item.jsonb ->> 'copyNumber'::text AS item_copy_number,
+        (src_inventory_item.jsonb -> 'metadata'::text) ->> 'createdDate'::text AS item_created_date,
+        (src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'prefix'::text AS item_effective_call_number_prefix,
+        (src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'callNumber'::text AS item_effective_call_number_callnumber,
+        (src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'suffix'::text AS item_effective_call_number_suffix,
+        src_inventory_item.jsonb ->> 'copyNumber'::text AS item_effective_call_number_copynumber,
+        concat_ws(', '::text, NULLIF((src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'prefix'::text, ''::text), NULLIF((src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'callNumber'::text, ''::text), NULLIF((src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'suffix'::text, ''::text), NULLIF(src_inventory_item.jsonb ->> 'copyNumber'::text, ''::text)) AS item_effective_call_number,
+        call_number_type_ref_data.jsonb ->> 'name'::text AS item_effective_call_number_type_name,
+        (src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'typeId'::text AS item_effective_call_number_typeid,
+        loclib_ref_data.jsonb ->> 'code'::text AS item_effective_library_code,
+        loclib_ref_data.id AS item_effective_library_id,
+        loclib_ref_data.jsonb ->> 'name'::text AS item_effective_library_name,
+        src_inventory_item.effectivelocationid AS item_effective_location_id,
+        effective_location_ref_data.jsonb ->> 'name'::text AS item_effective_location_name,
+        src_inventory_item.jsonb ->> 'hrid'::text AS item_hrid,
+        src_inventory_item.holdingsrecordid AS holdings_id,
+        src_inventory_item.jsonb ->> 'itemLevelCallNumber'::text AS item_level_call_number,
+        call_item_number_type_ref_data.jsonb ->> 'name'::text AS item_level_call_number_type_name,
+        src_inventory_item.jsonb ->> 'itemLevelCallNumberTypeId'::text AS item_level_call_number_typeid,
+        material_type_ref_data.jsonb ->> 'name'::text AS item_material_type,
+        src_inventory_item.materialtypeid AS item_material_type_id,
+        src_inventory_item.permanentlocationid AS item_permanent_location_id,
+        permanent_location_ref_data.jsonb ->> 'name'::text AS item_permanent_location_name,
+        src_inventory_item.temporarylocationid AS item_temporary_location_id,
+        temporary_location_ref_data.jsonb ->> 'name'::text AS item_temporary_location_name,
+        "left"(lower(${tenant_id}_mod_inventory_storage.f_unaccent((src_inventory_item.jsonb -> 'status'::text) ->> 'name'::text)), 600) AS item_status,
+        (src_inventory_item.jsonb -> 'metadata'::text) ->> 'updatedDate'::text AS item_updated_date
+      FROM src_inventory_item
+        LEFT JOIN src_inventory_location effective_location_ref_data ON effective_location_ref_data.id = src_inventory_item.effectivelocationid
+        LEFT JOIN src_inventory_call_number_type call_number_type_ref_data ON call_number_type_ref_data.id::text = ((src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'typeId'::text)
+        LEFT JOIN src_inventory_call_number_type call_item_number_type_ref_data ON call_item_number_type_ref_data.id::text = (src_inventory_item.jsonb ->> 'itemLevelCallNumberTypeId'::text)
+        LEFT JOIN src_inventory_loclibrary loclib_ref_data ON loclib_ref_data.id = effective_location_ref_data.libraryid
+        LEFT JOIN src_inventory_location permanent_location_ref_data ON permanent_location_ref_data.id = src_inventory_item.permanentlocationid
+        LEFT JOIN src_inventory_material_type material_type_ref_data ON material_type_ref_data.id = src_inventory_item.materialtypeid
+        LEFT JOIN src_inventory_location temporary_location_ref_data ON temporary_location_ref_data.id = src_inventory_item.temporarylocationid
+        JOIN src_inventory_holdings_record hrim ON src_inventory_item.holdingsrecordid = hrim.id
+        JOIN src_inventory_instance instance_details ON hrim.instanceid = instance_details.id;
+    </createView>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.0.1/drv_item_holdingsrecord_instance_create.xml
+++ b/src/main/resources/db/changelog/changes/v1.0.1/drv_item_holdingsrecord_instance_create.xml
@@ -1,0 +1,49 @@
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+  <changeSet id="create-view-item-holdingsrecord-instance" author="bsharp@ebsco.com">
+    <preConditions onFail="CONTINUE">
+      <viewExists viewName="src_inventory_item"/>
+      <viewExists viewName="src_inventory_holdings_record"/>
+      <viewExists viewName="src_inventory_instance"/>
+      <sqlCheck expectedResult="1">
+        SELECT COUNT(*) FROM pg_matviews WHERE schemaname = '${tenant_id}_mod_fqm_manager'AND matviewname = 'drv_inventory_item_status';
+      </sqlCheck>
+    </preConditions>
+    <createView
+      replaceIfExists="true"
+      viewName="drv_item_holdingsrecord_instance">
+      SELECT src_inventory_item.id,
+        "left"(lower((instance_details.jsonb -> 'metadata'::text) ->> 'createdDate'::text), 600) AS instance_created_date,
+        hrim.instanceid AS instance_id,
+        jsonb_path_query_first(instance_details.jsonb, '$."contributors"[*]?(@."primary" == true)."name"'::jsonpath) #>> '{}'::text[] AS instance_primary_contributor,
+        instance_details.jsonb ->> 'title'::text AS instance_title,
+        "left"(lower(${tenant_id}_mod_inventory_storage.f_unaccent(instance_details.jsonb ->> 'title'::text)), 600) AS instance_title_searchable,
+        "left"(lower((instance_details.jsonb -> 'metadata'::text) ->> 'updatedDate'::text), 600) AS instance_updated_date,
+        src_inventory_item.jsonb ->> 'barcode'::text AS item_barcode,
+        src_inventory_item.jsonb ->> 'copyNumber'::text AS item_copy_number,
+        (src_inventory_item.jsonb -> 'metadata'::text) ->> 'createdDate'::text AS item_created_date,
+        (src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'prefix'::text AS item_effective_call_number_prefix,
+        (src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'callNumber'::text AS item_effective_call_number_callnumber,
+        (src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'suffix'::text AS item_effective_call_number_suffix,
+        src_inventory_item.jsonb ->> 'copyNumber'::text AS item_effective_call_number_copynumber,
+        concat_ws(', '::text, NULLIF((src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'prefix'::text, ''::text), NULLIF((src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'callNumber'::text, ''::text), NULLIF((src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'suffix'::text, ''::text), NULLIF(src_inventory_item.jsonb ->> 'copyNumber'::text, ''::text)) AS item_effective_call_number,
+        (src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'typeId'::text AS item_effective_call_number_typeid,
+        src_inventory_item.effectivelocationid AS item_effective_location_id,
+        src_inventory_item.jsonb ->> 'hrid'::text AS item_hrid,
+        src_inventory_item.holdingsrecordid AS holdings_id,
+        src_inventory_item.jsonb ->> 'itemLevelCallNumber'::text AS item_level_call_number,
+        src_inventory_item.jsonb ->> 'itemLevelCallNumberTypeId'::text AS item_level_call_number_typeid,
+        src_inventory_item.materialtypeid AS item_material_type_id,
+        src_inventory_item.permanentlocationid AS item_permanent_location_id,
+        src_inventory_item.temporarylocationid AS item_temporary_location_id,
+        "left"(lower(${tenant_id}_mod_inventory_storage.f_unaccent((src_inventory_item.jsonb -> 'status'::text) ->> 'name'::text)), 600) AS item_status,
+        (src_inventory_item.jsonb -> 'metadata'::text) ->> 'updatedDate'::text AS item_updated_date
+      FROM src_inventory_item
+        JOIN src_inventory_holdings_record hrim ON src_inventory_item.holdingsrecordid = hrim.id
+        JOIN src_inventory_instance instance_details ON hrim.instanceid = instance_details.id;
+    </createView>
+  </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
## Purpose
[MODFQMMGR-51](https://issues.folio.org/browse/MODFQMMGR-51): queries using instance_updated_date and instance_created_date take a very long time 

## Approach
Rework item views to use instance metadata indexes for faster querying

