### PR TITLE
[MODFQMMGR-72] Remove instance_title_searchable field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ target/
 !.mvn/wrapper/maven-wrapper.jar
 !**/src/main/**/target/
 !**/src/test/**/target/
+.env
 
 ### STS ###
 .apt_generated

--- a/src/main/resources/db/changelog/changelog-master.xml
+++ b/src/main/resources/db/changelog/changelog-master.xml
@@ -6,5 +6,6 @@
 
   <include file="changes/v1.0.0/changelog-v1.0.0.xml" relativeToChangelogFile="true"/>
   <include file="changes/v1.0.1/changelog-v1.0.1.xml" relativeToChangelogFile="true"/>
+  <include file="changes/v1.0.2/changelog-v1.0.2.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.0.2/changelog-v1.0.2.xml
+++ b/src/main/resources/db/changelog/changes/v1.0.2/changelog-v1.0.2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+  <include file="remove_items_instance_title_searchable.xml" relativeToChangelogFile="true"/>
+  <include file="update_item_details_entity_type_definition.xml" relativeToChangelogFile="true"/>
+
+  <include file="remove_items_holdingsrecord_instance_title_searchable.xml" relativeToChangelogFile="true"/>
+  <include file="update_item_holdingsrecord_entity_type_definition.xml" relativeToChangelogFile="true"/>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.0.2/remove_items_holdingsrecord_instance_title_searchable.xml
+++ b/src/main/resources/db/changelog/changes/v1.0.2/remove_items_holdingsrecord_instance_title_searchable.xml
@@ -1,0 +1,48 @@
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+  <changeSet id="remove-items-holdingsrecord-instance-title-searchable" author="novercash@ebsco.com">
+    <!-- ensure other schemas/tables exist (primarily to prevent invalid references in integration tests) -->
+    <preConditions onFail="CONTINUE">
+      <viewExists viewName="src_inventory_item"/>
+      <viewExists viewName="src_inventory_holdings_record"/>
+      <viewExists viewName="src_inventory_instance"/>
+      <sqlCheck expectedResult="1">
+        SELECT COUNT(*) FROM pg_matviews WHERE schemaname = '${tenant_id}_mod_fqm_manager'AND matviewname = 'drv_inventory_item_status';
+      </sqlCheck>
+    </preConditions>
+    <dropView viewName="drv_item_details" />
+    <createView viewName="drv_item_holdingsrecord_instance">
+      SELECT src_inventory_item.id,
+        "left"(lower((instance_details.jsonb -> 'metadata'::text) ->> 'createdDate'::text), 600) AS instance_created_date,
+        hrim.instanceid AS instance_id,
+        jsonb_path_query_first(instance_details.jsonb, '$."contributors"[*]?(@."primary" == true)."name"'::jsonpath) #>> '{}'::text[] AS instance_primary_contributor,
+        instance_details.jsonb ->> 'title'::text AS instance_title,
+        "left"(lower((instance_details.jsonb -> 'metadata'::text) ->> 'updatedDate'::text), 600) AS instance_updated_date,
+        src_inventory_item.jsonb ->> 'barcode'::text AS item_barcode,
+        src_inventory_item.jsonb ->> 'copyNumber'::text AS item_copy_number,
+        (src_inventory_item.jsonb -> 'metadata'::text) ->> 'createdDate'::text AS item_created_date,
+        (src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'prefix'::text AS item_effective_call_number_prefix,
+        (src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'callNumber'::text AS item_effective_call_number_callnumber,
+        (src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'suffix'::text AS item_effective_call_number_suffix,
+        src_inventory_item.jsonb ->> 'copyNumber'::text AS item_effective_call_number_copynumber,
+        concat_ws(', '::text, NULLIF((src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'prefix'::text, ''::text), NULLIF((src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'callNumber'::text, ''::text), NULLIF((src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'suffix'::text, ''::text), NULLIF(src_inventory_item.jsonb ->> 'copyNumber'::text, ''::text)) AS item_effective_call_number,
+        (src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'typeId'::text AS item_effective_call_number_typeid,
+        src_inventory_item.effectivelocationid AS item_effective_location_id,
+        src_inventory_item.jsonb ->> 'hrid'::text AS item_hrid,
+        src_inventory_item.holdingsrecordid AS holdings_id,
+        src_inventory_item.jsonb ->> 'itemLevelCallNumber'::text AS item_level_call_number,
+        src_inventory_item.jsonb ->> 'itemLevelCallNumberTypeId'::text AS item_level_call_number_typeid,
+        src_inventory_item.materialtypeid AS item_material_type_id,
+        src_inventory_item.permanentlocationid AS item_permanent_location_id,
+        src_inventory_item.temporarylocationid AS item_temporary_location_id,
+        "left"(lower(${tenant_id}_mod_inventory_storage.f_unaccent((src_inventory_item.jsonb -> 'status'::text) ->> 'name'::text)), 600) AS item_status,
+        (src_inventory_item.jsonb -> 'metadata'::text) ->> 'updatedDate'::text AS item_updated_date
+      FROM src_inventory_item
+        JOIN src_inventory_holdings_record hrim ON src_inventory_item.holdingsrecordid = hrim.id
+        JOIN src_inventory_instance instance_details ON hrim.instanceid = instance_details.id;
+    </createView>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.0.2/remove_items_instance_title_searchable.xml
+++ b/src/main/resources/db/changelog/changes/v1.0.2/remove_items_instance_title_searchable.xml
@@ -1,0 +1,68 @@
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.20.xsd">
+  <changeSet id="remove-items-instance-title-searchable" author="novercash@ebsco.com">
+    <!-- ensure other schemas/tables exist (primarily to prevent invalid references in integration tests) -->
+    <preConditions onFail="CONTINUE">
+      <viewExists viewName="src_inventory_item"/>
+      <viewExists viewName="src_inventory_holdings_record"/>
+      <viewExists viewName="src_inventory_instance"/>
+      <viewExists viewName="src_inventory_location"/>
+      <viewExists viewName="src_inventory_call_number_type"/>
+      <viewExists viewName="src_inventory_loclibrary"/>
+      <viewExists viewName="src_inventory_material_type"/>
+      <sqlCheck expectedResult="1">
+        SELECT COUNT(*) FROM pg_matviews WHERE schemaname = '${tenant_id}_mod_fqm_manager'AND matviewname = 'drv_inventory_item_status';
+      </sqlCheck>
+    </preConditions>
+    <dropView viewName="drv_item_details" />
+    <createView viewName="drv_item_details">
+      SELECT src_inventory_item.id,
+        "left"(lower((instance_details.jsonb -> 'metadata'::text) ->> 'createdDate'::text), 600) AS instance_created_date,
+        hrim.instanceid AS instance_id,
+        jsonb_path_query_first(instance_details.jsonb, '$."contributors"[*]?(@."primary" == true)."name"'::jsonpath) #>> '{}'::text[] AS instance_primary_contributor,
+        instance_details.jsonb ->> 'title'::text AS instance_title,
+        "left"(lower((instance_details.jsonb -> 'metadata'::text) ->> 'updatedDate'::text), 600) AS instance_updated_date,
+        lower(src_inventory_item.jsonb ->> 'barcode'::text) AS item_barcode,
+        src_inventory_item.jsonb ->> 'copyNumber'::text AS item_copy_number,
+        (src_inventory_item.jsonb -> 'metadata'::text) ->> 'createdDate'::text AS item_created_date,
+        (src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'prefix'::text AS item_effective_call_number_prefix,
+        (src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'callNumber'::text AS item_effective_call_number_callnumber,
+        (src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'suffix'::text AS item_effective_call_number_suffix,
+        src_inventory_item.jsonb ->> 'copyNumber'::text AS item_effective_call_number_copynumber,
+        concat_ws(', '::text, NULLIF((src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'prefix'::text, ''::text), NULLIF((src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'callNumber'::text, ''::text), NULLIF((src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'suffix'::text, ''::text), NULLIF(src_inventory_item.jsonb ->> 'copyNumber'::text, ''::text)) AS item_effective_call_number,
+        call_number_type_ref_data.jsonb ->> 'name'::text AS item_effective_call_number_type_name,
+        (src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'typeId'::text AS item_effective_call_number_typeid,
+        loclib_ref_data.jsonb ->> 'code'::text AS item_effective_library_code,
+        loclib_ref_data.id AS item_effective_library_id,
+        loclib_ref_data.jsonb ->> 'name'::text AS item_effective_library_name,
+        src_inventory_item.effectivelocationid AS item_effective_location_id,
+        effective_location_ref_data.jsonb ->> 'name'::text AS item_effective_location_name,
+        src_inventory_item.jsonb ->> 'hrid'::text AS item_hrid,
+        src_inventory_item.holdingsrecordid AS holdings_id,
+        src_inventory_item.jsonb ->> 'itemLevelCallNumber'::text AS item_level_call_number,
+        call_item_number_type_ref_data.jsonb ->> 'name'::text AS item_level_call_number_type_name,
+        src_inventory_item.jsonb ->> 'itemLevelCallNumberTypeId'::text AS item_level_call_number_typeid,
+        material_type_ref_data.jsonb ->> 'name'::text AS item_material_type,
+        src_inventory_item.materialtypeid AS item_material_type_id,
+        src_inventory_item.permanentlocationid AS item_permanent_location_id,
+        permanent_location_ref_data.jsonb ->> 'name'::text AS item_permanent_location_name,
+        src_inventory_item.temporarylocationid AS item_temporary_location_id,
+        temporary_location_ref_data.jsonb ->> 'name'::text AS item_temporary_location_name,
+        "left"(lower(${tenant_id}_mod_inventory_storage.f_unaccent((src_inventory_item.jsonb -> 'status'::text) ->> 'name'::text)), 600) AS item_status,
+        (src_inventory_item.jsonb -> 'metadata'::text) ->> 'updatedDate'::text AS item_updated_date
+      FROM src_inventory_item
+        LEFT JOIN src_inventory_location effective_location_ref_data ON effective_location_ref_data.id = src_inventory_item.effectivelocationid
+        LEFT JOIN src_inventory_call_number_type call_number_type_ref_data ON call_number_type_ref_data.id::text = ((src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'typeId'::text)
+        LEFT JOIN src_inventory_call_number_type call_item_number_type_ref_data ON call_item_number_type_ref_data.id::text = (src_inventory_item.jsonb ->> 'itemLevelCallNumberTypeId'::text)
+        LEFT JOIN src_inventory_loclibrary loclib_ref_data ON loclib_ref_data.id = effective_location_ref_data.libraryid
+        LEFT JOIN src_inventory_location permanent_location_ref_data ON permanent_location_ref_data.id = src_inventory_item.permanentlocationid
+        LEFT JOIN src_inventory_material_type material_type_ref_data ON material_type_ref_data.id = src_inventory_item.materialtypeid
+        LEFT JOIN src_inventory_location temporary_location_ref_data ON temporary_location_ref_data.id = src_inventory_item.temporarylocationid
+        JOIN src_inventory_holdings_record hrim ON src_inventory_item.holdingsrecordid = hrim.id
+        JOIN src_inventory_instance instance_details ON hrim.instanceid = instance_details.id;
+    </createView>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.0.2/update_item_details_entity_type_definition.xml
+++ b/src/main/resources/db/changelog/changes/v1.0.2/update_item_details_entity_type_definition.xml
@@ -1,0 +1,322 @@
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+  <changeSet id="update-items-detail-entity-type-definition" author="novercash@ebsco.com">
+    <update tableName="entity_type_definition">
+      <column name="definition">
+        {
+          "id": "0cb79a4c-f7eb-4941-a104-745224ae0292",
+          "name": "drv_item_details",
+          "labelAlias": "Items",
+          "subEntityTypeIds": [
+            "097a6f96-edd0-11ed-a05b-0242ac120003",
+            "0cb79a4c-f7eb-4941-a104-745224ae0293"
+          ],
+          "private": false,
+          "columns": [
+            {
+              "name": "holdings_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "labelAlias": "Holdings ID",
+              "visibleByDefault": false
+            },
+            {
+              "name": "instance_created_date",
+              "dataType": {
+                "dataType": "dateType"
+              },
+              "labelAlias": "Instance created date",
+              "visibleByDefault": false
+            },
+            {
+              "name": "instance_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "labelAlias": "Instance ID",
+              "visibleByDefault": false
+            },
+            {
+              "name": "instance_primary_contributor",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "labelAlias": "Instance primary contributor",
+              "visibleByDefault": false
+            },
+            {
+              "name": "instance_title",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "labelAlias": "Instance title",
+              "visibleByDefault": true
+            },
+            {
+              "name": "instance_updated_date",
+              "dataType": {
+                "dataType": "dateType"
+              },
+              "labelAlias": "Instance updated date",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_barcode",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "labelAlias": "Item barcode",
+              "visibleByDefault": true
+            },
+            {
+              "name": "item_level_call_number",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "labelAlias": "Item call number",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_level_call_number_type_name",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "labelAlias": "Item call number type name",
+              "visibleByDefault": false,
+              "idColumnName": "item_level_call_number_typeid",
+              "source": {
+                "entityTypeId": "5c8315be-13f5-4df5-ae8b-086bae83484d",
+                "columnName": "call_number_type_name"
+              }
+            },
+            {
+              "name": "item_level_call_number_typeid",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "labelAlias": "Item call number type ID",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_copy_number",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "labelAlias": "Item copy number",
+              "visibleByDefault": true
+            },
+            {
+              "name": "item_created_date",
+              "dataType": {
+                "dataType": "dateType"
+              },
+              "labelAlias": "Item created date",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_effective_call_number",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "labelAlias": "Item effective call number",
+              "visibleByDefault": true
+            },
+            {
+              "name": "item_effective_call_number_type_name",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "labelAlias": "Item effective call number type name",
+              "visibleByDefault": false,
+              "idColumnName": "item_effective_call_number_typeid",
+              "source": {
+                "entityTypeId": "5c8315be-13f5-4df5-ae8b-086bae83484d",
+                "columnName": "call_number_type_name"
+              }
+            },
+            {
+              "name": "item_effective_call_number_typeid",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "labelAlias": "Item effective call number type ID",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_effective_library_code",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "labelAlias": "Item effective library code",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_effective_library_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "labelAlias": "Item effective library ID",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_effective_library_name",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "labelAlias": "Item effective library name",
+              "visibleByDefault": false,
+              "idColumnName": "item_effective_library_id",
+              "source": {
+                "entityTypeId": "cf9f5c11-e943-483c-913b-81d1e338accc",
+                "columnName": "loclibrary_name"
+              }
+            },
+            {
+              "name": "item_effective_location_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "labelAlias": "Item effective location ID",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_effective_location_name",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "labelAlias": "Item effective location name",
+              "visibleByDefault": true,
+              "idColumnName": "item_effective_location_id",
+              "source": {
+                "entityTypeId": "a9d6305e-fdb4-4fc4-8a73-4a5f76d8410b",
+                "columnName": "location_name"
+              }
+            },
+            {
+              "name": "item_hrid",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "labelAlias": "Item hrid",
+              "visibleByDefault": false
+            },
+            {
+              "name": "id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "labelAlias": "Item ID",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_material_type",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "labelAlias": "Item material type",
+              "visibleByDefault": false,
+              "idColumnName": "item_material_type_id",
+              "source": {
+                "entityTypeId": "917ea5c8-cafe-4fa6-a942-e2388a88c6f6",
+                "columnName": "material_type_name"
+              }
+            },
+            {
+              "name": "item_material_type_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "labelAlias": "Item material ID",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_permanent_location_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "labelAlias": "Item permanent ID",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_permanent_location_name",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "labelAlias": "Item permanent location name",
+              "visibleByDefault": false,
+              "idColumnName": "item_permanent_location_id",
+              "source": {
+                "entityTypeId": "a9d6305e-fdb4-4fc4-8a73-4a5f76d8410b",
+                "columnName": "location_name"
+              }
+            },
+            {
+              "name": "item_status",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "labelAlias": "Item status",
+              "visibleByDefault": false,
+              "source": {
+                "entityTypeId": "a1a37288-1afe-4fa5-ab59-a5bcf5d8ca2d",
+                "columnName": "item_status"
+              }
+            },
+            {
+              "name": "item_temporary_location_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "labelAlias": "Item temporary ID",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_temporary_location_name",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "labelAlias": "Item temporary location name",
+              "visibleByDefault": false,
+              "idColumnName": "item_temporary_location_id",
+              "source": {
+                "entityTypeId": "a9d6305e-fdb4-4fc4-8a73-4a5f76d8410b",
+                "columnName": "location_name"
+              }
+            },
+            {
+              "name": "item_updated_date",
+              "dataType": {
+                "dataType": "dateType"
+              },
+              "labelAlias": "Item updated date",
+              "visibleByDefault": false
+            }
+          ],
+          "defaultSort": [
+            {
+              "columnName": "item_effective_location_name",
+              "direction": "ASC"
+            },
+            {
+              "columnName": "instance_title",
+              "direction": "ASC"
+            },
+            {
+              "columnName": "instance_primary_contributor",
+              "direction": "ASC"
+            },
+            {
+              "columnName": "id",
+              "direction": "ASC"
+            }
+          ]
+        }        
+      </column>
+      <where>id = '0cb79a4c-f7eb-4941-a104-745224ae0292'</where>
+    </update>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.0.2/update_item_holdingsrecord_entity_type_definition.xml
+++ b/src/main/resources/db/changelog/changes/v1.0.2/update_item_holdingsrecord_entity_type_definition.xml
@@ -1,0 +1,201 @@
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+  <changeSet id="update-items-holdingsrecord-entity-type-definition" author="novercash@ebsco.com">
+    <update tableName="entity_type_definition">
+      <column name="definition">
+        {
+          "id": "0cb79a4c-f7eb-4941-a104-745224ae0293",
+          "name": "drv_item_holdingsrecord_instance",
+          "labelAlias": "Items, Holdings records, Instance",
+          "private": true,
+          "columns": [
+            {
+              "name": "holdings_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "labelAlias": "Holdings ID",
+              "visibleByDefault": false
+            },
+            {
+              "name": "instance_created_date",
+              "dataType": {
+                "dataType": "dateType"
+              },
+              "labelAlias": "Instance created date",
+              "visibleByDefault": false
+            },
+            {
+              "name": "instance_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "labelAlias": "Instance ID",
+              "visibleByDefault": false
+            },
+            {
+              "name": "instance_primary_contributor",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "labelAlias": "Instance primary contributor",
+              "visibleByDefault": false
+            },
+            {
+              "name": "instance_title",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "labelAlias": "Instance title",
+              "visibleByDefault": true
+            },
+            {
+              "name": "instance_title_searchable",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "labelAlias": "Instance title (Searchable)",
+              "visibleByDefault": true
+            },
+            {
+              "name": "instance_updated_date",
+              "dataType": {
+                "dataType": "dateType"
+              },
+              "labelAlias": "Instance updated date",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_barcode",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "labelAlias": "Item barcode",
+              "visibleByDefault": true
+            },
+            {
+              "name": "item_level_call_number",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "labelAlias": "Item call number",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_level_call_number_typeid",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "labelAlias": "Item call number type ID",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_copy_number",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "labelAlias": "Item copy number",
+              "visibleByDefault": true
+            },
+            {
+              "name": "item_created_date",
+              "dataType": {
+                "dataType": "dateType"
+              },
+              "labelAlias": "Item created date",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_effective_call_number",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "labelAlias": "Item effective call number",
+              "visibleByDefault": true
+            },
+            {
+              "name": "item_effective_call_number_typeid",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "labelAlias": "Item effective call number type ID",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_effective_location_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "labelAlias": "Item location ID",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_hrid",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "labelAlias": "Item hrid",
+              "visibleByDefault": false
+            },
+            {
+              "name": "id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "labelAlias": "Item ID",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_material_type_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "labelAlias": "Item material ID",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_permanent_location_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "labelAlias": "Item permanent ID",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_status",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "labelAlias": "Item status",
+              "visibleByDefault": false,
+              "source": {
+                "entityTypeId": "a1a37288-1afe-4fa5-ab59-a5bcf5d8ca2d",
+                "columnName": "item_status"
+              }
+            },
+            {
+              "name": "item_temporary_location_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "labelAlias": "Item temporary ID",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_updated_date",
+              "dataType": {
+                "dataType": "dateType"
+              },
+              "labelAlias": "Item updated date",
+              "visibleByDefault": false
+            }
+          ]
+        }        
+      </column>
+      <where>id = '0cb79a4c-f7eb-4941-a104-745224ae0293'</where>
+    </update>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.0.2/update_item_holdingsrecord_entity_type_definition.xml
+++ b/src/main/resources/db/changelog/changes/v1.0.2/update_item_holdingsrecord_entity_type_definition.xml
@@ -52,14 +52,6 @@
               "visibleByDefault": true
             },
             {
-              "name": "instance_title_searchable",
-              "dataType": {
-                "dataType": "stringType"
-              },
-              "labelAlias": "Instance title (Searchable)",
-              "visibleByDefault": true
-            },
-            {
               "name": "instance_updated_date",
               "dataType": {
                 "dataType": "dateType"


### PR DESCRIPTION
## Purpose
`instance_title_searchable` was causing more problems than it was worth, so we removed it.

## Approach
Add new Liquibase changelogs to recreate the view and update the associated entity_type_definition.

## Learning
- Turns out Postgres [will not allow you to remove columns when running a `CREATE OR REPLACE VIEW` query](https://stackoverflow.com/questions/65117930/postgresql-error-cannot-drop-columns-from-view), so we have to drop it first.  We can assume it's already there, though, since previous version's changes will be created before this changelog is executed.

## Bonus
- ignore `.env` files