### PR TITLE
MODFQMMGR-73 - ***Coming this Winter*** - The Purge: Query Me This

### DIFF
--- a/src/main/java/org/folio/fqm/repository/QueryRepository.java
+++ b/src/main/java/org/folio/fqm/repository/QueryRepository.java
@@ -73,10 +73,10 @@ public class QueryRepository {
       .fetchOneInto(Query.class));
   }
 
-  public List<UUID> getQueryIdsCompletedBefore(Duration duration) {
+  public List<UUID> getQueryIdsStartedBefore(Duration duration) {
     return jooqContext.select(field(QUERY_ID))
       .from(table(QUERY_DETAILS_TABLE))
-      .where(field("end_date").
+      .where(field("start_date").
         lessOrEqual(OffsetDateTime.now().minus(duration)))
       .fetchInto(UUID.class);
   }

--- a/src/main/java/org/folio/fqm/service/QueryManagementService.java
+++ b/src/main/java/org/folio/fqm/service/QueryManagementService.java
@@ -133,7 +133,7 @@ public class QueryManagementService {
    */
   @Transactional
   public PurgedQueries deleteOldQueries() {
-    List<UUID> queryIds = queryRepository.getQueryIdsCompletedBefore(queryRetentionDuration);
+    List<UUID> queryIds = queryRepository.getQueryIdsStartedBefore(queryRetentionDuration);
     log.info("Deleting the queries with queryIds {}", queryIds);
     deleteQueryAndResults(queryIds);
     return new PurgedQueries().deletedQueryIds(queryIds);

--- a/src/test/java/org/folio/fqm/service/QueryManagementServiceTest.java
+++ b/src/test/java/org/folio/fqm/service/QueryManagementServiceTest.java
@@ -381,7 +381,7 @@ class QueryManagementServiceTest {
   void shouldPurgeQueries() {
     List<UUID> queryIds = List.of(UUID.randomUUID(), UUID.randomUUID());
     PurgedQueries expectedPurgedQueries = new PurgedQueries().deletedQueryIds(queryIds);
-    when(queryRepository.getQueryIdsCompletedBefore(Mockito.any())).thenReturn(queryIds);
+    when(queryRepository.getQueryIdsStartedBefore(Mockito.any())).thenReturn(queryIds);
     PurgedQueries actualPurgedQueries = queryManagementService.deleteOldQueries();
     verify(queryResultsRepository, times(1)).deleteQueryResults(queryIds);
     verify(queryRepository, times(1)).deleteQueries(queryIds);


### PR DESCRIPTION
This commit modifies the query purge process, to make it use the query start date instead of the end date. If the server shuts down while a query is still running, the end date doesn't get set, so those queries weren't getting purged. Using the start date avoids that issue. This means that queries may get purged a little sooner (e.g., if a query takes 20 minutes to run, we'd potentially purge it 20 minutes sooner), but the threshold is long enough (3 hours and can be overridden at runtime) that this should be okay
