### PR TITLE
Fix timer permissions

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -37,6 +37,11 @@
           "methods": ["GET"],
           "pathPattern": "/entity-types/{entity-type-id}/columns/{column-name}/values",
           "permissionsRequired": ["fqm.entityTypes.item.columnValues.get"]
+        },
+        {
+          "methods": ["POST"],
+          "pathPattern": "/entity-types/materialized-views/refresh",
+          "permissionsRequired": ["fqm.materializedViews.post"]
         }
       ]
     },
@@ -78,11 +83,6 @@
           "methods": ["DELETE"],
           "pathPattern": "/query/{query-id}",
           "permissionsRequired": ["fqm.query.async.delete"]
-        },
-        {
-          "methods": ["POST"],
-          "pathPattern": "/materialized-views/refresh",
-          "permissionsRequired": ["fqm.materializedViews.post"]
         }
       ]
     },
@@ -95,13 +95,19 @@
           "methods": ["POST"],
           "pathPattern": "/query/purge",
           "unit": "hour",
-          "delay": "1"
+          "delay": "1",
+          "modulePermissions": [
+            "fqm.query.purge"
+          ]
         },
         {
           "methods": ["POST"],
-          "pathPattern": "/materialized-views/refresh",
+          "pathPattern": "/entity-types/materialized-views/refresh",
           "unit": "hour",
-          "delay": "24"
+          "delay": "24",
+          "modulePermissions": [
+            "fqm.materializedViews.post"
+          ]
         }
       ]
     }

--- a/src/main/resources/swagger.api/mod-fqm-manager.yaml
+++ b/src/main/resources/swagger.api/mod-fqm-manager.yaml
@@ -44,7 +44,7 @@ paths:
           $ref: '#/components/responses/badRequestResponse'
         '500':
           $ref: '#/components/responses/internalServerErrorResponse'
-  /materialized-views/refresh:
+  /entity-types/materialized-views/refresh:
     post:
       operationId: refreshMaterializedViews
       tags:

--- a/src/test/java/org/folio/fqm/controller/MaterializedViewRefreshControllerTest.java
+++ b/src/test/java/org/folio/fqm/controller/MaterializedViewRefreshControllerTest.java
@@ -31,7 +31,7 @@ class MaterializedViewRefreshControllerTest {
   @Test
   void refreshMaterializedViewsTest() throws Exception {
     String tenantId = "tenant_01";
-    RequestBuilder requestBuilder = MockMvcRequestBuilders.post("/materialized-views/refresh")
+    RequestBuilder requestBuilder = MockMvcRequestBuilders.post("/entity-types/materialized-views/refresh")
       .header(XOkapiHeaders.TENANT, tenantId)
       .contentType(APPLICATION_JSON);
     when(executionContext.getTenantId()).thenReturn(tenantId);


### PR DESCRIPTION
## Purpose
- Add module permissions to timers in module descriptor
- Change /materialized-views/refresh endpoint to /entity-types/materialized-views/refresh
