### PR TITLE
MODFQMMGR-80: Build the SELECT clause from field accessors defined in the entity type

### DIFF
--- a/src/main/java/org/folio/fqm/utils/SqlFieldIdentificationUtils.java
+++ b/src/main/java/org/folio/fqm/utils/SqlFieldIdentificationUtils.java
@@ -1,12 +1,8 @@
 package org.folio.fqm.utils;
 
 import lombok.experimental.UtilityClass;
-import org.folio.querytool.domain.dto.ColumnValueGetter.TypeEnum;
 import org.folio.querytool.domain.dto.EntityTypeColumn;
 import org.jooq.Field;
-
-import java.util.Map;
-import java.util.function.UnaryOperator;
 
 import static org.jooq.impl.DSL.field;
 
@@ -15,16 +11,13 @@ import static org.jooq.impl.DSL.field;
  */
 @UtilityClass
 public class SqlFieldIdentificationUtils {
-  private static final Map<TypeEnum, UnaryOperator<String>> MAPPERS = Map.of(
-    TypeEnum.RMB_JSONB, param -> "jsonb ->> '" + param + "'"
-  );
 
   /**
    * Returns the version of a SQL field corresponding to an entity type column, intended to be displayed to users
    */
   public static Field<Object> getSqlResultsField(EntityTypeColumn entityTypeColumn) {
     if (entityTypeColumn.getValueGetter() != null) {
-      return getMappedField(entityTypeColumn);
+      return field(entityTypeColumn.getValueGetter());
     }
     // No value getter is defined for this column. Use column name as the SQL field name.
     return field(entityTypeColumn.getName());
@@ -33,24 +26,17 @@ public class SqlFieldIdentificationUtils {
   /**
    * Returns the version of a SQL field corresponding to an entity type column, intended to be used in the WHERE clause.
    *
-   * Note: If a both a value getter and a filter value getter is defined for this column, the value getter will be used.
+   * Note: If both a value getter and a filter value getter is defined for this column, the filter value getter will be used.
    */
   public static Field<Object> getSqlFilterField(EntityTypeColumn entityTypeColumn) {
-    if (entityTypeColumn.getValueGetter() != null) {
-      return getMappedField(entityTypeColumn);
-    }
     if (entityTypeColumn.getFilterValueGetter() != null) {
       return field(entityTypeColumn.getFilterValueGetter());
+    }
+    if (entityTypeColumn.getValueGetter() != null) {
+      return field(entityTypeColumn.getValueGetter());
     } else {
       // No value getter or filter is defined for this column. Use column name as the SQL field name.
       return field(entityTypeColumn.getName());
     }
-  }
-
-  private static Field<Object> getMappedField(EntityTypeColumn entityTypeColumn) {
-    var valueGetter = entityTypeColumn.getValueGetter();
-    UnaryOperator<String> mapperFunction = MAPPERS.get(valueGetter.getType());
-    String sqlFieldName = mapperFunction.apply(valueGetter.getParam());
-    return field(sqlFieldName);
   }
 }

--- a/src/main/resources/db/changelog/changes/v1.0.4/changelog-v1.0.4.xml
+++ b/src/main/resources/db/changelog/changes/v1.0.4/changelog-v1.0.4.xml
@@ -6,5 +6,27 @@
   <include file="remove_entity_type_label_aliases.sql" relativeToChangelogFile="true" />
   <include file="harvested-views.xml" relativeToChangelogFile="true"/>
   <include file="derived-tables.xml" relativeToChangelogFile="true"/>
-  <include file="entity-type-definitions.xml" relativeToChangelogFile="true"/>
+  <include file="update-drv-circulation-loan-status-definition.xml" relativeToChangelogFile="true"/>
+  <include file="update-drv-inventory-item-status-definition.xml" relativeToChangelogFile="true"/>
+  <include file="update-drv-item-callnumber-location-definition.xml" relativeToChangelogFile="true"/>
+  <include file="update-drv-item-details-definition.xml" relativeToChangelogFile="true"/>
+  <include file="update-drv-item-holdingsrecord-instance-definition.xml" relativeToChangelogFile="true"/>
+  <include file="update-drv-loan-details-definition.xml" relativeToChangelogFile="true"/>
+  <include file="update-drv-user-details-definition.xml" relativeToChangelogFile="true"/>
+  <include file="update-src-acquisitions-unit-definition.xml" relativeToChangelogFile="true"/>
+  <include file="update-src-circulation-loan-policy-definition.xml" relativeToChangelogFile="true"/>
+  <include file="update-src-inventory-call-number-type-definition.xml" relativeToChangelogFile="true"/>
+  <include file="update-src-inventory-location-definition.xml" relativeToChangelogFile="true"/>
+  <include file="update-src-inventory-loclibrary-definition.xml" relativeToChangelogFile="true"/>
+  <include file="update-src-inventory-material-type-definition.xml" relativeToChangelogFile="true"/>
+  <include file="update-src-inventory-service-point-definition.xml" relativeToChangelogFile="true"/>
+  <include file="update-src-organizations-definition.xml" relativeToChangelogFile="true"/>
+  <include file="update-src-users-addresstypes-definition.xml" relativeToChangelogFile="true"/>
+  <include file="update-src-users-departments-definition.xml" relativeToChangelogFile="true"/>
+  <include file="update-src-users-groups-definition.xml" relativeToChangelogFile="true"/>
+
+  <!-- Uncomment below scripts once PO line entity type is fixed !-->
+  <!-- <include file="entity-type-definitions.xml" relativeToChangelogFile="true"/> !-->
+  <!-- <include file="update-drv-purchase-order-line-details-definition.xml" relativeToChangelogFile="true"/> !-->
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.0.4/update-drv-circulation-loan-status-definition.xml
+++ b/src/main/resources/db/changelog/changes/v1.0.4/update-drv-circulation-loan-status-definition.xml
@@ -1,0 +1,29 @@
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+  <changeSet id="update-drv-circulation-loan-status-definition" author="bsharp@ebsco.com">
+    <update tableName="entity_type_definition">
+      <column name="definition">
+        {
+          "id": "146dfba5-cdc9-45f5-a8a1-3fdc454c9ae2",
+          "name": "drv_loan_status",
+          "root": false,
+          "fromClause": "drv_circulation_loan_status",
+          "columns": [
+            {
+              "name": "loan_status",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "drv_circulation_loan_status.loan_status",
+              "visibleByDefault": true
+            }
+          ],
+          "private": true
+        }
+      </column>
+      <where>id = '146dfba5-cdc9-45f5-a8a1-3fdc454c9ae2'</where>
+    </update>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.0.4/update-drv-inventory-item-status-definition.xml
+++ b/src/main/resources/db/changelog/changes/v1.0.4/update-drv-inventory-item-status-definition.xml
@@ -1,0 +1,29 @@
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+  <changeSet id="update-drv-inventory-item-status-definition" author="bsharp@ebsco.com">
+    <update tableName="entity_type_definition">
+      <column name="definition">
+        {
+          "id": "a1a37288-1afe-4fa5-ab59-a5bcf5d8ca2d",
+          "name": "drv_item_status",
+          "root": false,
+          "fromClause": "drv_inventory_item_status",
+          "columns": [
+            {
+              "name": "item_status",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "drv_inventory_item_status.item_status",
+              "visibleByDefault": true
+            }
+          ],
+          "private": true
+        }
+      </column>
+      <where>id = 'a1a37288-1afe-4fa5-ab59-a5bcf5d8ca2d'</where>
+    </update>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.0.4/update-drv-item-callnumber-location-definition.xml
+++ b/src/main/resources/db/changelog/changes/v1.0.4/update-drv-item-callnumber-location-definition.xml
@@ -1,0 +1,244 @@
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+  <changeSet id="update-item-details-callnumber-location-definition" author="bsharp@ebsco.com">
+    <update tableName="entity_type_definition">
+      <column name="definition">
+        {
+          "id": "097a6f96-edd0-11ed-a05b-0242ac120003",
+          "name": "drv_item_callnumber_location",
+          "private": true,
+          "fromClause": "src_inventory_item LEFT JOIN src_inventory_location effective_location_ref_data ON effective_location_ref_data.id = src_inventory_item.effectivelocationid LEFT JOIN src_inventory_call_number_type call_number_type_ref_data ON call_number_type_ref_data.id::text = ((src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'typeId'::text) LEFT JOIN src_inventory_call_number_type call_item_number_type_ref_data ON call_item_number_type_ref_data.id::text = (src_inventory_item.jsonb ->> 'itemLevelCallNumberTypeId'::text) LEFT JOIN src_inventory_loclibrary loclib_ref_data ON loclib_ref_data.id = effective_location_ref_data.libraryid LEFT JOIN src_inventory_location permanent_location_ref_data ON permanent_location_ref_data.id = src_inventory_item.permanentlocationid LEFT JOIN src_inventory_material_type material_type_ref_data ON material_type_ref_data.id = src_inventory_item.materialtypeid",
+          "columns": [
+            {
+              "name": "holdings_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_inventory_item.holdingsrecordid",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_barcode",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_inventory_item.jsonb ->> 'barcode'",
+              "visibleByDefault": true
+            },
+            {
+              "name": "item_level_call_number",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_inventory_item.jsonb ->> 'itemLevelCallNumber'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_level_call_number_type_name",
+              "source": {
+                "columnName": "call_number_type_name",
+                "entityTypeId": "5c8315be-13f5-4df5-ae8b-086bae83484d"
+              },
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "idColumnName": "item_level_call_number_typeid",
+              "valueGetter": "call_item_number_type_ref_data.jsonb ->> 'name'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_level_call_number_typeid",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_inventory_item.jsonb ->> 'itemLevelCallNumberTypeId'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_copy_number",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_inventory_item.jsonb ->> 'copyNumber'",
+              "visibleByDefault": true
+            },
+            {
+              "name": "item_created_date",
+              "dataType": {
+                "dataType": "dateType"
+              },
+              "valueGetter": "src_inventory_item.jsonb -> 'metadata' ->> 'createdDate'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_effective_call_number",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "concat_ws(', '::text, NULLIF((src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'prefix'::text, ''::text), NULLIF((src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'callNumber'::text, ''::text), NULLIF((src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'suffix'::text, ''::text), NULLIF(src_inventory_item.jsonb ->> 'copyNumber'::text, ''::text))",
+              "visibleByDefault": true
+            },
+            {
+              "name": "item_effective_call_number_type_name",
+              "source": {
+                "columnName": "call_number_type_name",
+                "entityTypeId": "5c8315be-13f5-4df5-ae8b-086bae83484d"
+              },
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "idColumnName": "item_effective_call_number_typeid",
+              "valueGetter": "call_number_type_ref_data.jsonb ->> 'name'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_effective_call_number_typeid",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_inventory_item.jsonb -> 'effectiveCallNumberComponents' ->> 'typeId'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_effective_library_code",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "loclib_ref_data.jsonb ->> 'code'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_effective_library_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "loclib_ref_data.id",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_effective_library_name",
+              "source": {
+                "columnName": "loclibrary_name",
+                "entityTypeId": "cf9f5c11-e943-483c-913b-81d1e338accc"
+              },
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "idColumnName": "item_effective_library_id",
+              "valueGetter": "loclib_ref_data.jsonb ->> 'name'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_effective_location_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_inventory_item.effectivelocationid",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_effective_location_name",
+              "source": {
+                "columnName": "location_name",
+                "entityTypeId": "a9d6305e-fdb4-4fc4-8a73-4a5f76d8410b"
+              },
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "idColumnName": "item_effective_location_id",
+              "valueGetter": "effective_location_ref_data.jsonb ->> 'name'",
+              "visibleByDefault": true
+            },
+            {
+              "name": "item_hrid",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_inventory_item.jsonb ->> 'hrid'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_inventory_item.id",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_material_type",
+              "source": {
+                "columnName": "material_type_name",
+                "entityTypeId": "917ea5c8-cafe-4fa6-a942-e2388a88c6f6"
+              },
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "idColumnName": "item_material_type_id",
+              "valueGetter": "material_type_ref_data.jsonb ->> 'name'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_material_type_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_inventory_item.materialtypeid",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_permanent_location_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_inventory_item.permanentlocationid",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_permanent_location_name",
+              "source": {
+                "columnName": "location_name",
+                "entityTypeId": "a9d6305e-fdb4-4fc4-8a73-4a5f76d8410b"
+              },
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "idColumnName": "item_permanent_location_id",
+              "valueGetter": "permanent_location_ref_data.jsonb ->> 'name'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_status",
+              "source": {
+                "columnName": "item_status",
+                "entityTypeId": "a1a37288-1afe-4fa5-ab59-a5bcf5d8ca2d"
+              },
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_inventory_item.jsonb -> 'status' ->> 'name'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_updated_date",
+              "dataType": {
+                "dataType": "dateType"
+              },
+              "valueGetter": "src_inventory_item.jsonb -> 'metadata' ->> 'updatedDate'",
+              "visibleByDefault": false
+            }
+          ],
+          "defaultSort": [
+            {
+              "direction": "ASC",
+              "columnName": "id"
+            }
+          ]
+        }
+      </column>
+      <where>id = '097a6f96-edd0-11ed-a05b-0242ac120003'</where>
+    </update>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.0.4/update-drv-item-details-definition.xml
+++ b/src/main/resources/db/changelog/changes/v1.0.4/update-drv-item-details-definition.xml
@@ -1,0 +1,321 @@
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+  <changeSet id="update-item-details-entity-type-definition" author="bsharp@ebsco.com">
+    <update tableName="entity_type_definition">
+      <column name="definition">
+        {
+          "id": "0cb79a4c-f7eb-4941-a104-745224ae0292",
+          "name": "drv_item_details",
+          "private": false,
+          "fromClause": "src_inventory_item LEFT JOIN src_inventory_location effective_location_ref_data ON effective_location_ref_data.id = src_inventory_item.effectivelocationid LEFT JOIN src_inventory_call_number_type call_number_type_ref_data ON call_number_type_ref_data.id::text = ((src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'typeId'::text) LEFT JOIN src_inventory_call_number_type call_item_number_type_ref_data ON call_item_number_type_ref_data.id::text = (src_inventory_item.jsonb ->> 'itemLevelCallNumberTypeId'::text) LEFT JOIN src_inventory_loclibrary loclib_ref_data ON loclib_ref_data.id = effective_location_ref_data.libraryid LEFT JOIN src_inventory_location permanent_location_ref_data ON permanent_location_ref_data.id = src_inventory_item.permanentlocationid LEFT JOIN src_inventory_material_type material_type_ref_data ON material_type_ref_data.id = src_inventory_item.materialtypeid LEFT JOIN src_inventory_location temporary_location_ref_data ON temporary_location_ref_data.id = src_inventory_item.temporarylocationid JOIN src_inventory_holdings_record hrim ON src_inventory_item.holdingsrecordid = hrim.id JOIN src_inventory_instance instance_details ON hrim.instanceid = instance_details.id",
+          "columns": [
+            {
+              "name": "holdings_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_inventory_item.holdingsrecordid",
+              "visibleByDefault": false
+            },
+            {
+              "name": "instance_created_date",
+              "dataType": {
+                "dataType": "dateType"
+              },
+              "valueGetter": "instance_details.jsonb -> 'metadata' ->> 'createdDate'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "instance_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "hrim.instanceid",
+              "visibleByDefault": false
+            },
+            {
+              "name": "instance_primary_contributor",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "jsonb_path_query_first(instance_details.jsonb, '$.\"contributors\"[*]?(@.\"primary\" == true).\"name\"'::jsonpath) #>> '{}'::text[]",
+              "visibleByDefault": false
+            },
+            {
+              "name": "instance_title",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "instance_details.jsonb ->> 'title'",
+              "visibleByDefault": true
+            },
+            {
+              "name": "instance_updated_date",
+              "dataType": {
+                "dataType": "dateType"
+              },
+              "valueGetter": "instance_details.jsonb -> 'metadata' ->> 'updatedDate'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_barcode",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_inventory_item.jsonb ->> 'barcode'",
+              "visibleByDefault": true
+            },
+            {
+              "name": "item_level_call_number",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_inventory_item.jsonb ->> 'itemLevelCallNumber'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_level_call_number_type_name",
+              "source": {
+                "columnName": "call_number_type_name",
+                "entityTypeId": "5c8315be-13f5-4df5-ae8b-086bae83484d"
+              },
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "idColumnName": "item_level_call_number_typeid",
+              "valueGetter": "call_item_number_type_ref_data.jsonb ->> 'name'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_level_call_number_typeid",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_inventory_item.jsonb ->> 'itemLevelCallNumberTypeId'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_copy_number",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_inventory_item.jsonb ->> 'copyNumber'",
+              "visibleByDefault": true
+            },
+            {
+              "name": "item_created_date",
+              "dataType": {
+                "dataType": "dateType"
+              },
+              "valueGetter": "src_inventory_item.jsonb -> 'metadata' ->> 'createdDate'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_effective_call_number",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "concat_ws(', '::text, NULLIF((src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'prefix'::text, ''::text), NULLIF((src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'callNumber'::text, ''::text), NULLIF((src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'suffix'::text, ''::text), NULLIF(src_inventory_item.jsonb ->> 'copyNumber'::text, ''::text))",
+              "visibleByDefault": true
+            },
+            {
+              "name": "item_effective_call_number_type_name",
+              "source": {
+                "columnName": "call_number_type_name",
+                "entityTypeId": "5c8315be-13f5-4df5-ae8b-086bae83484d"
+              },
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "idColumnName": "item_effective_call_number_typeid",
+              "valueGetter": "call_number_type_ref_data.jsonb ->> 'name'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_effective_call_number_typeid",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_inventory_item.jsonb -> 'effectiveCallNumberComponents' ->> 'typeId'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_effective_library_code",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "loclib_ref_data.jsonb ->> 'code'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_effective_library_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "loclib_ref_data.id",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_effective_library_name",
+              "source": {
+                "columnName": "loclibrary_name",
+                "entityTypeId": "cf9f5c11-e943-483c-913b-81d1e338accc"
+              },
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "idColumnName": "item_effective_library_id",
+              "valueGetter": "loclib_ref_data.jsonb ->> 'name'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_effective_location_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_inventory_item.effectivelocationid",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_effective_location_name",
+              "source": {
+                "columnName": "location_name",
+                "entityTypeId": "a9d6305e-fdb4-4fc4-8a73-4a5f76d8410b"
+              },
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "idColumnName": "item_effective_location_id",
+              "valueGetter": "effective_location_ref_data.jsonb ->> 'name'",
+              "visibleByDefault": true
+            },
+            {
+              "name": "item_hrid",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_inventory_item.jsonb ->> 'hrid'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_inventory_item.id",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_material_type",
+              "source": {
+                "columnName": "material_type_name",
+                "entityTypeId": "917ea5c8-cafe-4fa6-a942-e2388a88c6f6"
+              },
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "idColumnName": "item_material_type_id",
+              "valueGetter": "material_type_ref_data.jsonb ->> 'name'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_material_type_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_inventory_item.materialtypeid",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_permanent_location_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_inventory_item.permanentlocationid",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_permanent_location_name",
+              "source": {
+                "columnName": "location_name",
+                "entityTypeId": "a9d6305e-fdb4-4fc4-8a73-4a5f76d8410b"
+              },
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "idColumnName": "item_permanent_location_id",
+              "valueGetter": "permanent_location_ref_data.jsonb ->> 'name'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_status",
+              "source": {
+                "columnName": "item_status",
+                "entityTypeId": "a1a37288-1afe-4fa5-ab59-a5bcf5d8ca2d"
+              },
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_inventory_item.jsonb -> 'status' ->> 'name'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_temporary_location_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_inventory_item.temporarylocationid",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_temporary_location_name",
+              "source": {
+                "columnName": "location_name",
+                "entityTypeId": "a9d6305e-fdb4-4fc4-8a73-4a5f76d8410b"
+              },
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "idColumnName": "item_temporary_location_id",
+              "valueGetter": "temporary_location_ref_data.jsonb ->> 'name'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_updated_date",
+              "dataType": {
+                "dataType": "dateType"
+              },
+              "valueGetter": "src_inventory_item.jsonb -> 'metadata' ->> 'updatedDate'",
+              "visibleByDefault": false
+            }
+          ],
+          "defaultSort": [
+            {
+              "direction": "ASC",
+              "columnName": "item_effective_location_name"
+            },
+            {
+              "direction": "ASC",
+              "columnName": "instance_title"
+            },
+            {
+              "direction": "ASC",
+              "columnName": "instance_primary_contributor"
+            },
+            {
+              "direction": "ASC",
+              "columnName": "id"
+            }
+          ],
+          "subEntityTypeIds": [
+            "097a6f96-edd0-11ed-a05b-0242ac120003",
+            "0cb79a4c-f7eb-4941-a104-745224ae0293"
+          ]
+        }
+      </column>
+      <where>id = '0cb79a4c-f7eb-4941-a104-745224ae0292'</where>
+    </update>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.0.4/update-drv-item-holdingsrecord-instance-definition.xml
+++ b/src/main/resources/db/changelog/changes/v1.0.4/update-drv-item-holdingsrecord-instance-definition.xml
@@ -1,0 +1,198 @@
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+  <changeSet id="update-item-holdingsrecord-instance-entity-type-definition" author="bsharp@ebsco.com">
+    <update tableName="entity_type_definition">
+      <column name="definition">
+        {
+          "id": "0cb79a4c-f7eb-4941-a104-745224ae0293",
+          "name": "drv_item_holdingsrecord_instance",
+          "private": true,
+          "fromClause": "src_inventory_item JOIN src_inventory_holdings_record hrim ON src_inventory_item.holdingsrecordid = hrim.id JOIN src_inventory_instance instance_details ON hrim.instanceid = instance_details.id",
+          "columns": [
+            {
+              "name": "holdings_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_inventory_item.holdingsrecordid",
+              "visibleByDefault": false
+            },
+            {
+              "name": "instance_created_date",
+              "dataType": {
+                "dataType": "dateType"
+              },
+              "valueGetter": "instance_details.jsonb -> 'metadata' ->> 'createdDate'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "instance_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "hrim.instanceid",
+              "visibleByDefault": false
+            },
+            {
+              "name": "instance_primary_contributor",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "jsonb_path_query_first(instance_details.jsonb, '$.\"contributors\"[*]?(@.\"primary\" == true).\"name\"'::jsonpath) #>> '{}'::text[]",
+              "visibleByDefault": false
+            },
+            {
+              "name": "instance_title",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "instance_details.jsonb ->> 'title'",
+              "visibleByDefault": true
+            },
+            {
+              "name": "instance_updated_date",
+              "dataType": {
+                "dataType": "dateType"
+              },
+              "valueGetter": "instance_details.jsonb -> 'metadata' ->> 'updatedDate'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_barcode",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_inventory_item.jsonb ->> 'barcode'",
+              "visibleByDefault": true
+            },
+            {
+              "name": "item_level_call_number",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_inventory_item.jsonb ->> 'itemLevelCallNumber'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_level_call_number_typeid",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_inventory_item.jsonb ->> 'itemLevelCallNumberTypeId'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_copy_number",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_inventory_item.jsonb ->> 'copyNumber'",
+              "visibleByDefault": true
+            },
+            {
+              "name": "item_created_date",
+              "dataType": {
+                "dataType": "dateType"
+              },
+              "valueGetter": "src_inventory_item.jsonb -> 'metadata' ->> 'createdDate'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_effective_call_number",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "concat_ws(', '::text, NULLIF((src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'prefix'::text, ''::text), NULLIF((src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'callNumber'::text, ''::text), NULLIF((src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'suffix'::text, ''::text), NULLIF(src_inventory_item.jsonb ->> 'copyNumber'::text, ''::text))",
+              "visibleByDefault": true
+            },
+            {
+              "name": "item_effective_call_number_typeid",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_inventory_item.jsonb -> 'effectiveCallNumberComponents' ->> 'typeId'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_effective_location_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_inventory_item.effectivelocationid",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_hrid",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_inventory_item.jsonb ->> 'hrid'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_inventory_item.id",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_material_type_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_inventory_item.materialtypeid",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_permanent_location_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_inventory_item.permanentlocationid",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_status",
+              "source": {
+                "columnName": "item_status",
+                "entityTypeId": "a1a37288-1afe-4fa5-ab59-a5bcf5d8ca2d"
+              },
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_inventory_item.jsonb -> 'status' ->> 'name'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_temporary_location_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_inventory_item.temporarylocationid",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_updated_date",
+              "dataType": {
+                "dataType": "dateType"
+              },
+              "valueGetter": "src_inventory_item.jsonb -> 'metadata' ->> 'updatedDate'",
+              "visibleByDefault": false
+            }
+          ],
+          "defaultSort": [
+            {
+              "direction": "ASC",
+              "columnName": "id"
+            }
+          ]
+        }
+      </column>
+      <where>id = '0cb79a4c-f7eb-4941-a104-745224ae0293'</where>
+    </update>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.0.4/update-drv-loan-details-definition.xml
+++ b/src/main/resources/db/changelog/changes/v1.0.4/update-drv-loan-details-definition.xml
@@ -1,0 +1,317 @@
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+  <changeSet id="update-loan-details-entity-type-definition" author="bsharp@ebsco.com">
+    <update tableName="entity_type_definition">
+      <column name="definition">
+        {
+          "id": "4e09d89a-44ed-418e-a9cc-820dfb27bf3a",
+          "name":"drv_loan_details",
+          "private" : false,
+          "fromClause": "src_circulation_loan LEFT JOIN src_circulation_loan_policy loan_policy_ref_data ON loan_policy_ref_data.id = ((src_circulation_loan.jsonb ->> 'loanPolicyId'::text)::uuid) LEFT JOIN src_inventory_service_point cospi ON cospi.id = \"left\"(lower(src_circulation_loan.jsonb ->> 'checkoutServicePointId'::text), 600)::uuid LEFT JOIN src_inventory_service_point cispi ON cispi.id = \"left\"(lower(src_circulation_loan.jsonb ->> 'checkinServicePointId'::text), 600)::uuid JOIN src_inventory_item item_details ON item_details.id = \"left\"(lower(f_unaccent(src_circulation_loan.jsonb ->> 'itemId'::text)), 600)::uuid LEFT JOIN src_inventory_material_type material_type_ref_data ON material_type_ref_data.id = item_details.materialtypeid JOIN src_users_users user_details ON user_details.id = \"left\"(lower(f_unaccent(src_circulation_loan.jsonb ->> 'userId'::text)), 600)::uuid LEFT JOIN src_users_groups patron_id_ref_data ON patron_id_ref_data.id::text = (user_details.jsonb ->> 'patronGroup'::text) JOIN src_inventory_holdings_record hrim ON item_details.holdingsrecordid = hrim.id JOIN src_inventory_instance instance_details ON hrim.instanceid = instance_details.id",
+          "columns": [
+            {
+              "name": "holdings_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "item_details.holdingsrecordid",
+              "visibleByDefault": false
+            },
+            {
+              "name": "instance_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "hrim.instanceid",
+              "visibleByDefault": false
+            },
+            {
+              "name": "instance_primary_contributor",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "jsonb_path_query_first(instance_details.jsonb, '$.\"contributors\"[*]?(@.\"primary\" == true).\"name\"'::jsonpath) #>> '{}'::text[]",
+              "visibleByDefault": false
+            },
+            {
+              "name": "instance_title",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "instance_details.jsonb ->> 'title'",
+              "visibleByDefault": true
+            },
+            {
+              "name": "item_barcode",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "item_details.jsonb ->> 'barcode'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_call_number",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "item_details.jsonb -> 'effectiveCallNumberComponents' ->> 'callNumber'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "item_details.id",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_material_type",
+              "source": {
+                "columnName": "material_type_name",
+                "entityTypeId": "917ea5c8-cafe-4fa6-a942-e2388a88c6f6"
+              },
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "idColumnName": "item_material_type_id",
+              "valueGetter": "material_type_ref_data.jsonb ->> 'name'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_material_type_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "item_details.materialtypeid",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_status",
+              "source": {
+                "columnName": "item_status",
+                "entityTypeId": "a1a37288-1afe-4fa5-ab59-a5bcf5d8ca2d"
+              },
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "item_details.jsonb -> 'status' ->> 'name'",
+              "visibleByDefault": true
+            },
+            {
+              "name": "loan_checkin_servicepoint_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "cispi.id",
+              "visibleByDefault": false
+            },
+            {
+              "name": "loan_checkin_servicepoint_name",
+              "source": {
+                "columnName": "service_point_name",
+                "entityTypeId": "89cdeac4-9582-4388-800b-9ccffd8d7691"
+              },
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "idColumnName": "loan_checkin_servicepoint_id",
+              "valueGetter": "cispi.jsonb ->> 'name'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "loan_checkout_date",
+              "dataType": {
+                "dataType": "dateType"
+              },
+              "valueGetter": "src_circulation_loan.jsonb ->> 'loanDate'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "loan_checkout_servicepoint_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "cospi.id",
+              "visibleByDefault": false
+            },
+            {
+              "name": "loan_checkout_servicepoint_name",
+              "source": {
+                "columnName": "service_point_name",
+                "entityTypeId": "89cdeac4-9582-4388-800b-9ccffd8d7691"
+              },
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "idColumnName": "loan_checkout_servicepoint_id",
+              "valueGetter": "cospi.jsonb ->> 'name'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "loan_due_date",
+              "dataType": {
+                "dataType": "dateType"
+              },
+              "valueGetter": "src_circulation_loan.jsonb ->> 'dueDate'",
+              "visibleByDefault": true
+            },
+            {
+              "name": "id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_circulation_loan.id",
+              "visibleByDefault": false
+            },
+            {
+              "name": "loan_policy_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "loan_policy_ref_data.id",
+              "visibleByDefault": false
+            },
+            {
+              "name": "loan_policy_name",
+              "source": {
+                "columnName": "policy_name",
+                "entityTypeId": "5e7de445-bcc6-4008-8032-8d9602b854d7"
+              },
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "idColumnName": "loan_policy_id",
+              "valueGetter": "loan_policy_ref_data.jsonb ->> 'name'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "loan_return_date",
+              "dataType": {
+                "dataType": "dateType"
+              },
+              "valueGetter": "src_circulation_loan.jsonb ->> 'returnDate'",
+              "visibleByDefault": false
+            },
+            {
+            "name": "loan_status",
+              "source": {
+                "columnName": "loan_status",
+                "entityTypeId": "146dfba5-cdc9-45f5-a8a1-3fdc454c9ae2"
+              },
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_circulation_loan.jsonb -> 'status' ->> 'name'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "user_active",
+              "values": [
+                {
+                  "label": "True",
+                  "value": "true"
+                },
+                {
+                  "label": "False",
+                  "value": "false"
+                }
+              ],
+              "dataType": {
+                "dataType": "booleanType"
+              },
+              "valueGetter": "user_details.jsonb ->> 'active'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "user_barcode",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "user_details.jsonb ->> 'barcode'",
+              "visibleByDefault": true
+            },
+            {
+              "name": "user_expiration_date",
+              "dataType": {
+                "dataType": "dateType"
+              },
+              "valueGetter": "user_details.jsonb ->> 'expirationDate'",
+              "visibleByDefault": true
+            },
+            {
+              "name": "user_first_name",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "user_details.jsonb -> 'personal' ->> 'firstName'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "user_full_name",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "concat(user_details.jsonb -> 'personal' ->> 'lastName', ', ', user_details.jsonb -> 'personal' ->> 'firstName')",
+              "visibleByDefault": true
+            },
+            {
+              "name": "user_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "user_details.id",
+              "visibleByDefault": false
+            },
+            {
+              "name": "user_last_name",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "user_details.jsonb -> 'personal' ->> 'lastName'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "user_patron_group",
+              "source": {
+                "columnName": "group",
+                "entityTypeId": "e611264d-377e-4d87-a93f-f1ca327d3db0"
+              },
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "idColumnName": "user_patron_group_id",
+              "valueGetter": "patron_id_ref_data.jsonb ->> 'group'",
+              "visibleByDefault": true
+            },
+            {
+              "name": "user_patron_group_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "patron_id_ref_data.id",
+              "visibleByDefault": false
+            }
+          ],
+          "defaultSort": [
+            {
+              "direction": "ASC",
+              "columnName": "user_full_name"
+            },
+            {
+              "direction": "ASC",
+              "columnName": "loan_due_date"
+            },
+            {
+              "direction": "ASC",
+              "columnName": "id"
+            }
+          ]
+        }
+      </column>
+      <where>id = '4e09d89a-44ed-418e-a9cc-820dfb27bf3a'</where>
+    </update>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.0.4/update-drv-purchase-order-line-details-definition.xml
+++ b/src/main/resources/db/changelog/changes/v1.0.4/update-drv-purchase-order-line-details-definition.xml
@@ -1,0 +1,335 @@
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+  <changeSet id="update-purchase-order-line-details-entity-type-definition" author="bsharp@ebsco.com">
+    <update tableName="entity_type_definition">
+      <column name="definition">
+        {
+          "id": "90403847-8c47-4f58-b117-9a807b052808",
+          "name": "drv_purchase_order_line_details",
+          "private": false,
+          "fromClause": "src_purchase_order_line JOIN src_purchase_order purchase_order ON purchase_order.id = ((src_purchase_order_line.jsonb ->> 'purchaseOrderId'::text)::uuid) LEFT JOIN src_users_users user_details ON user_details.id = (((purchase_order.jsonb -> 'metadata'::text) ->> 'createdByUserId'::text)::uuid) LEFT JOIN src_users_users user_details_for_order_updated_by ON user_details_for_order_updated_by.id = (((purchase_order.jsonb -> 'metadata'::text) ->> 'updatedByUserId'::text)::uuid) LEFT JOIN src_users_users user_details_for_pol_created_by ON user_details_for_pol_created_by.id = (((src_purchase_order_line.jsonb -> 'metadata'::text) ->> 'createdByUserId'::text)::uuid) LEFT JOIN src_users_users user_details_for_pol_updated_by ON user_details_for_pol_updated_by.id = (((src_purchase_order_line.jsonb -> 'metadata'::text) ->> 'updatedByUserId'::text)::uuid) LEFT JOIN src_organizations organization_details ON organization_details.id = ((purchase_order.jsonb ->> 'vendor'::text)::uuid) LEFT JOIN src_users_users user_details_of_assignee ON user_details_of_assignee.id = ((purchase_order.jsonb ->> 'assignedTo'::text)::uuid) LEFT JOIN LATERAL jsonb_array_elements(src_purchase_order_line.jsonb -> 'fundDistribution'::text) json_array_elements(value) ON true",
+          "columns": [
+            {
+              "name": "acqunit_ids",
+              "dataType": {
+                "dataType": "arrayType",
+                "itemDataType": {
+                  "dataType": "rangedUUIDType"
+                }
+              },
+              "valueGetter": "( SELECT array_to_string(array_agg(acq_id.value), ','::text) AS array_agg FROM jsonb_array_elements_text(purchase_order.jsonb -> 'acqUnitIds'::text) acq_id(value))",
+              "visibleByDefault": false
+            },
+            {
+                "name": "acqunit_names",
+                "dataType": {
+                  "dataType": "arrayType",
+                  "itemDataType": {
+                    "dataType": "stringType"
+                  }
+                },
+                "valueGetter": "( SELECT array_agg(acq_unit.jsonb ->> 'name'::text) AS array_agg FROM jsonb_array_elements_text(purchase_order.jsonb -> 'acqUnitIds'::text) acq_id(value) JOIN src_acquisitions_unit acq_unit ON acq_id.value = acq_unit.id::text)",
+                "visibleByDefault": false,
+                "idColumnName": "acqunit_ids",
+                "source": {
+                  "entityTypeId": "cc51f042-03e2-43d1-b1d6-11aa6a39bc78",
+                  "columnName": "acquisitions_name"
+                }
+            },
+            {
+              "name": "fund_distribution_code",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "COALESCE(json_array_elements.value ->> 'code', NULL::text)",
+              "visibleByDefault": false
+            },
+            {
+              "name": "fund_distribution_encumbrance",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "COALESCE(json_array_elements.value ->> 'encumbrance', NULL::text)",
+              "visibleByDefault": true
+            },
+            {
+              "name": "fund_distribution_type",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "COALESCE(json_array_elements.value ->> 'distributionType', NULL::text)",
+              "visibleByDefault": false
+            },
+            {
+              "name": "fund_distribution_value",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "COALESCE(json_array_elements.value ->> 'value', NULL::text)",
+              "visibleByDefault": false
+            },
+            {
+              "name": "fund_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "COALESCE(json_array_elements.value ->> 'fundId', NULL::text)",
+              "visibleByDefault": false
+            },
+            {
+              "name": "po_number",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "purchase_order.jsonb ->> 'poNumber'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "purchase_order_approved",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "purchase_order.jsonb ->> 'approved'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "purchase_order_assigned_to",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "concat_ws(', '::text, NULLIF((user_details_of_assignee.jsonb -> 'personal'::text) ->> 'lastName', ''::text), NULLIF((user_details_of_assignee.jsonb -> 'personal'::text) ->> 'firstName', ''::text))",
+              "visibleByDefault": true
+            },
+            {
+              "name": "purchase_order_assigned_to_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "purchase_order.jsonb ->> 'assignedTo'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "purchase_order_created_by",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "concat_ws(', '::text, NULLIF((user_details.jsonb -> 'personal'::text) ->> 'lastName', ''::text), NULLIF((user_details.jsonb -> 'personal'::text) ->> 'firstName', ''::text))",
+              "visibleByDefault": false
+            },
+            {
+              "name": "purchase_order_created_by_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "purchase_order.jsonb -> 'metadata' ->> 'createdByUserId'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "purchase_order_created_date",
+              "dataType": {
+                "dataType": "dateType"
+              },
+              "valueGetter": "purchase_order.jsonb -> 'metadata' ->> 'createdDate'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "purchase_order_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_purchase_order_line.jsonb ->> 'purchaseOrderId'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "purchase_order_line_created_by",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "concat_ws(', '::text, NULLIF((user_details_for_pol_created_by.jsonb -> 'personal'::text) ->> 'lastName', ''::text), NULLIF((user_details_for_pol_created_by.jsonb -> 'personal'::text) ->> 'firstName', ''::text))",
+              "visibleByDefault": true
+            },
+            {
+              "name": "purchase_order_line_created_by_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_purchase_order_line.jsonb -> 'metadata' ->> 'createdByUserId'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "purchase_order_line_created_date",
+              "dataType": {
+                "dataType": "dateType"
+              },
+              "valueGetter": "src_purchase_order_line.jsonb -> 'metadata' ->> 'createdDate'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "purchase_order_line_description",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_purchase_order_line.jsonb ->> 'description'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "purchase_order_line_estimated_price",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_purchase_order_line.jsonb -> 'cost' ->> 'poLineEstimatedPrice'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "purchase_order_line_exchange_rate",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_purchase_order_line.jsonb -> 'cost' ->> 'exchangeRate'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_purchase_order_line.id",
+              "visibleByDefault": true
+            },
+            {
+              "name": "purchase_order_line_number",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_purchase_order_line.jsonb ->> 'poLineNumber'",
+              "visibleByDefault": true
+            },
+            {
+              "name": "purchase_order_line_payment_status",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_purchase_order_line.jsonb ->> 'paymentStatus'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "purchase_order_line_receipt_status",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_purchase_order_line.jsonb ->> 'receiptStatus'",
+              "visibleByDefault": true
+            },
+            {
+              "name": "purchase_order_line_updated_by",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "concat_ws(', '::text, NULLIF((user_details_for_pol_updated_by.jsonb -> 'personal'::text) ->> 'lastName', ''::text), NULLIF((user_details_for_pol_updated_by.jsonb -> 'personal'::text) ->> 'firstName', ''::text))",
+              "visibleByDefault": false
+            },
+            {
+              "name": "purchase_order_line_updater_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_purchase_order_line.jsonb -> 'metadata' ->> 'updatedByUserId'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "purchase_order_line_updated_date",
+              "dataType": {
+                "dataType": "dateType"
+              },
+              "valueGetter": "src_purchase_order_line.jsonb -> 'metadata' ->> 'updatedDate'",
+              "visibleByDefault": true
+            },
+            {
+              "name": "purchase_order_notes",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "jsonb_array_elements(purchase_order.jsonb -> 'notes'::text)::text",
+              "visibleByDefault": false
+            },
+            {
+              "name": "purchase_order_type",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "purchase_order.jsonb ->> 'orderType'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "purchase_order_updated_by",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "concat_ws(', '::text, NULLIF((user_details_for_order_updated_by.jsonb -> 'personal'::text) ->> 'lastName', ''::text), NULLIF((user_details_for_order_updated_by.jsonb -> 'personal'::text) ->> 'firstName', ''::text))",
+              "visibleByDefault": false
+            },
+            {
+              "name": "purchase_order_updated_by_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "purchase_order.jsonb -> 'metadata' ->> 'updatedByUserId'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "purchase_order_updated_date",
+              "dataType": {
+                "dataType": "dateType"
+              },
+              "valueGetter": "purchase_order.jsonb -> 'metadata' ->> 'updatedDate'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "vendor_code",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "organization_details.jsonb ->> 'code'",
+              "visibleByDefault": false,
+              "idColumnName": "vendor_id",
+              "source": {
+                "entityTypeId": "489234a9-8703-48cd-85e3-7f84011bafa3",
+                "columnName": "vendor_code"
+              }
+            },
+            {
+              "name": "vendor_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "purchase_order.jsonb ->> 'vendor'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "vendor_name",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "organization_details.jsonb ->> 'name'",
+              "visibleByDefault": false,
+              "idColumnName": "vendor_id",
+              "source": {
+                "entityTypeId": "489234a9-8703-48cd-85e3-7f84011bafa3",
+                "columnName": "vendor_name"
+              }
+            }
+          ],
+          "defaultSort": [
+            {
+              "columnName": "id",
+              "direction": "ASC"
+            }
+          ]
+        }
+      </column>
+      <where>id = '90403847-8c47-4f58-b117-9a807b052808'</where>
+    </update>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.0.4/update-drv-user-details-definition.xml
+++ b/src/main/resources/db/changelog/changes/v1.0.4/update-drv-user-details-definition.xml
@@ -1,0 +1,223 @@
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+  <changeSet id="update-user-details-entity-type-definition" author="bsharp@ebsco.com">
+    <update tableName="entity_type_definition">
+      <column name="definition">
+        {
+          "id": "0069cf6f-2833-46db-8a51-8934769b8289",
+          "name":"drv_user_details",
+          "private" : false,
+          "fromClause": "src_users_users LEFT JOIN src_users_groups ON src_users_groups.id = ((src_users_users.jsonb ->> 'patronGroup'::text)::uuid)",
+          "columns": [
+            {
+              "name": "user_active",
+              "dataType":{
+                "dataType":"booleanType"
+              },
+              "valueGetter": "src_users_users.jsonb ->> 'active'",
+              "visibleByDefault": true,
+              "values": [
+                {
+                  "value": "true",
+                  "label": "True"
+                },
+                {
+                  "value": "false",
+                  "label": "False"
+                }
+              ]
+            },
+            {
+              "name": "user_barcode",
+              "dataType":{
+                "dataType":"stringType"
+              },
+              "valueGetter": "src_users_users.jsonb ->> 'barcode'",
+              "visibleByDefault": true
+            },
+            {
+              "name": "user_created_date",
+              "dataType":{
+                "dataType":"dateType"
+              },
+              "valueGetter": "src_users_users.jsonb -> 'metadata' ->> 'createdDate'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "user_date_of_birth",
+              "dataType":{
+                "dataType":"dateType"
+              },
+              "valueGetter": "src_users_users.jsonb -> 'personal' ->> 'dateOfBirth'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "user_email",
+              "dataType":{
+                "dataType":"stringType"
+              },
+              "valueGetter": "src_users_users.jsonb -> 'personal' ->> 'email'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "user_enrollment_date",
+              "dataType":{
+                "dataType":"dateType"
+              },
+              "valueGetter": "src_users_users.jsonb ->> 'enrollmentDate'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "user_expiration_date",
+              "dataType":{
+                "dataType":"dateType"
+              },
+              "valueGetter": "src_users_users.jsonb ->> 'expirationDate'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "user_external_system_id",
+              "dataType":{
+                "dataType":"stringType"
+              },
+              "valueGetter": "src_users_users.jsonb ->> 'externalSystemId'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "user_first_name",
+              "dataType":{
+                "dataType":"stringType"
+              },
+              "valueGetter": "src_users_users.jsonb -> 'personal' ->> 'firstName'",
+              "visibleByDefault": true
+            },
+            {
+              "name": "id",
+              "dataType":{
+                "dataType":"rangedUUIDType"
+              },
+              "valueGetter": "src_users_users.id",
+              "visibleByDefault": true
+            },
+            {
+              "name": "user_last_name",
+              "dataType":{
+                "dataType":"stringType"
+              },
+              "valueGetter": "src_users_users.jsonb -> 'personal' ->> 'lastName'",
+              "visibleByDefault": true
+            },
+            {
+              "name": "user_middle_name",
+              "dataType":{
+                "dataType":"stringType"
+              },
+              "valueGetter": "src_users_users.jsonb -> 'personal' ->> 'middleName'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "user_mobile_phone",
+              "dataType":{
+                "dataType":"stringType"
+              },
+              "valueGetter": "src_users_users.jsonb -> 'personal' ->> 'mobilePhone'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "user_patron_group",
+              "dataType":{
+                "dataType":"stringType"
+              },
+              "valueGetter": "src_users_groups.jsonb ->> 'group'",
+              "visibleByDefault": false,
+              "idColumnName": "user_patron_group_id",
+              "source": {
+                "entityTypeId": "e611264d-377e-4d87-a93f-f1ca327d3db0",
+                "columnName": "group"
+              }
+            },
+            {
+              "name": "user_patron_group_id",
+              "dataType":{
+                "dataType":"rangedUUIDType"
+              },
+              "valueGetter": "src_users_groups.id",
+              "visibleByDefault": false
+            },
+            {
+              "name": "user_phone",
+              "dataType":{
+                "dataType":"stringType"
+              },
+              "valueGetter": "src_users_users.jsonb -> 'personal' ->> 'phone'",
+              "visibleByDefault": true
+            },
+            {
+              "name": "user_preferred_contact_type",
+              "dataType":{
+                "dataType":"stringType"
+              },
+              "valueGetter": "CASE (src_users_users.jsonb -> 'personal'::text) ->> 'preferredContactTypeId'::text WHEN '001'::text THEN 'Mail (Primary Address)'::text WHEN '002'::text THEN 'Email'::text WHEN '003'::text THEN 'Text Message'::text ELSE 'unknown'::text END",
+              "visibleByDefault": false,
+              "values": [
+                {
+                  "value": "Email",
+                  "label": "Email"
+                },
+                {
+                  "value": "Mail (Primary Address)",
+                  "label": "Mail (Primary Address)"
+                },
+                {
+                  "value": "Text Message",
+                  "label": "Text Message"
+                }
+              ]
+            },
+            {
+              "name": "user_preferred_first_name",
+              "dataType":{
+                "dataType":"stringType"
+              },
+              "valueGetter": "src_users_users.jsonb -> 'personal' ->> 'preferredFirstName'",
+              "visibleByDefault": true
+            },
+            {
+              "name": "user_primary_address",
+              "dataType":{
+                "dataType":"stringType"
+              },
+              "valueGetter": "concat_ws(', '::text, NULLIF(( SELECT subquery.addressline1 FROM ( SELECT add_id.value ->> 'addressLine1'::text AS addressline1, row_number() OVER (ORDER BY (add_id.value ->> 'primaryAddress'::text)) AS row_num FROM jsonb_array_elements((src_users_users.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value)) subquery WHERE subquery.row_num = 1), ''::text), NULLIF(( SELECT subquery.addressline2 FROM ( SELECT add_id.value ->> 'addressLine2'::text AS addressline2, row_number() OVER (ORDER BY (add_id.value ->> 'primaryAddress'::text)) AS row_num FROM jsonb_array_elements((src_users_users.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value)) subquery WHERE subquery.row_num = 1), ''::text), NULLIF(( SELECT subquery.city FROM ( SELECT add_id.value ->> 'city'::text AS city, row_number() OVER (ORDER BY (add_id.value ->> 'primaryAddress'::text)) AS row_num FROM jsonb_array_elements((src_users_users.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value)) subquery WHERE subquery.row_num = 1), ''::text), NULLIF(( SELECT subquery.region FROM ( SELECT add_id.value ->> 'region'::text AS region, row_number() OVER (ORDER BY (add_id.value ->> 'primaryAddress'::text)) AS row_num FROM jsonb_array_elements((src_users_users.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value)) subquery WHERE subquery.row_num = 1), ''::text), NULLIF(( SELECT subquery.postalcode FROM ( SELECT add_id.value ->> 'postalCode'::text AS postalcode, row_number() OVER (ORDER BY (add_id.value ->> 'primaryAddress'::text)) AS row_num FROM jsonb_array_elements((src_users_users.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value)) subquery WHERE subquery.row_num = 1), ''::text), NULLIF(( SELECT subquery.countryid FROM ( SELECT add_id.value ->> 'countryId'::text AS countryid, row_number() OVER (ORDER BY (add_id.value ->> 'primaryAddress'::text)) AS row_num FROM jsonb_array_elements((src_users_users.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value)) subquery WHERE subquery.row_num = 1), ''::text))",
+              "visibleByDefault": false
+            },
+            {
+              "name": "user_updated_date",
+              "dataType":{
+                "dataType":"dateType"
+              },
+              "valueGetter": "src_users_users.jsonb -> 'metadata' ->> 'updatedDate'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "username",
+              "dataType":{
+                "dataType":"stringType"
+              },
+              "valueGetter": "src_users_users.jsonb ->> 'username'",
+              "visibleByDefault": true
+            }
+          ],
+          "defaultSort": [
+            {
+              "columnName": "id",
+              "direction": "ASC"
+            }
+          ]
+        }
+      </column>
+      <where>id = '0069cf6f-2833-46db-8a51-8934769b8289'</where>
+    </update>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.0.4/update-src-acquisitions-unit-definition.xml
+++ b/src/main/resources/db/changelog/changes/v1.0.4/update-src-acquisitions-unit-definition.xml
@@ -1,0 +1,37 @@
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+  <changeSet id="update-src-acquisitions-unit-definition" author="bsharp@ebsco.com">
+    <update tableName="entity_type_definition">
+      <column name="definition">
+        {
+          "id": "cc51f042-03e2-43d1-b1d6-11aa6a39bc78",
+          "name": "src_acquisitions_unit",
+          "root": true,
+          "fromClause": "src_acquisitions_unit",
+          "columns": [
+            {
+              "name": "id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_acquisitions_unit.id",
+              "visibleByDefault": true
+            },
+            {
+              "name": "acquisitions_name",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_acquisitions_unit.jsonb ->> 'name'",
+              "visibleByDefault": true
+            }
+          ],
+          "private": true
+        }
+      </column>
+      <where>id = 'cc51f042-03e2-43d1-b1d6-11aa6a39bc78'</where>
+    </update>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.0.4/update-src-circulation-loan-policy-definition.xml
+++ b/src/main/resources/db/changelog/changes/v1.0.4/update-src-circulation-loan-policy-definition.xml
@@ -1,0 +1,37 @@
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+  <changeSet id="update-src-circulation-loan-policy-definition" author="bsharp@ebsco.com">
+    <update tableName="entity_type_definition">
+      <column name="definition">
+        {
+          "id": "5e7de445-bcc6-4008-8032-8d9602b854d7",
+          "name": "src_circulation_loan_policy",
+          "root": true,
+          "fromClause": "src_circulation_loan_policy",
+          "columns": [
+            {
+              "name": "id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_circulation_loan_policy.id",
+              "visibleByDefault": true
+            },
+            {
+              "name": "policy_name",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_circulation_loan_policy.jsonb ->> 'name'",
+              "visibleByDefault": true
+            }
+          ],
+          "private": true
+        }
+      </column>
+      <where>id = '5e7de445-bcc6-4008-8032-8d9602b854d7'</where>
+    </update>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.0.4/update-src-inventory-call-number-type-definition.xml
+++ b/src/main/resources/db/changelog/changes/v1.0.4/update-src-inventory-call-number-type-definition.xml
@@ -1,0 +1,37 @@
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+  <changeSet id="update-src-inventory-call-number-type-definition" author="bsharp@ebsco.com">
+    <update tableName="entity_type_definition">
+      <column name="definition">
+        {
+          "id": "5c8315be-13f5-4df5-ae8b-086bae83484d",
+          "name": "src_inventory_call_number_type",
+          "root": true,
+          "fromClause": "src_inventory_call_number_type",
+          "columns": [
+            {
+              "name": "id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_inventory_call_number_type.id",
+              "visibleByDefault": true
+            },
+            {
+              "name": "call_number_type_name",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_inventory_call_number_type.jsonb ->> 'name'",
+              "visibleByDefault": true
+            }
+          ],
+          "private": true
+        }
+      </column>
+      <where>id = '5c8315be-13f5-4df5-ae8b-086bae83484d'</where>
+    </update>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.0.4/update-src-inventory-location-definition.xml
+++ b/src/main/resources/db/changelog/changes/v1.0.4/update-src-inventory-location-definition.xml
@@ -1,0 +1,45 @@
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+  <changeSet id="update-src-inventory-location-definition" author="bsharp@ebsco.com">
+    <update tableName="entity_type_definition">
+      <column name="definition">
+        {
+          "id": "a9d6305e-fdb4-4fc4-8a73-4a5f76d8410b",
+          "name": "src_inventory_location",
+          "root": true,
+          "fromClause": "src_inventory_location",
+          "columns": [
+            {
+              "name": "id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_inventory_location.id",
+              "visibleByDefault": true
+            },
+            {
+              "name": "location_name",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_inventory_location.jsonb ->> 'name'",
+              "visibleByDefault": true
+            },
+            {
+              "name": "location_code",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_inventory_location.jsonb ->> 'code'",
+              "visibleByDefault": true
+            }
+          ],
+          "private": true
+        }
+      </column>
+      <where>id = 'a9d6305e-fdb4-4fc4-8a73-4a5f76d8410b'</where>
+    </update>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.0.4/update-src-inventory-loclibrary-definition.xml
+++ b/src/main/resources/db/changelog/changes/v1.0.4/update-src-inventory-loclibrary-definition.xml
@@ -1,0 +1,45 @@
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+  <changeSet id="update-src-inventory-loclibrary-definition" author="bsharp@ebsco.com">
+    <update tableName="entity_type_definition">
+      <column name="definition">
+        {
+          "id": "cf9f5c11-e943-483c-913b-81d1e338accc",
+          "name": "src_inventory_loclibrary",
+          "root": true,
+          "fromClause": "src_inventory_loclibrary",
+          "columns": [
+            {
+              "name": "id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_inventory_loclibrary.id",
+              "visibleByDefault": true
+            },
+            {
+              "name": "loclibrary_name",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_inventory_loclibrary.jsonb ->> 'name'",
+              "visibleByDefault": true
+            },
+            {
+              "name": "loclibrary_code",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_inventory_loclibrary.jsonb ->> 'code'",
+              "visibleByDefault": true
+            }
+          ],
+          "private": true
+        }
+      </column>
+      <where>id = 'cf9f5c11-e943-483c-913b-81d1e338accc'</where>
+    </update>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.0.4/update-src-inventory-material-type-definition.xml
+++ b/src/main/resources/db/changelog/changes/v1.0.4/update-src-inventory-material-type-definition.xml
@@ -1,0 +1,37 @@
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+  <changeSet id="update-src-inventory-material-type-definition" author="bsharp@ebsco.com">
+    <update tableName="entity_type_definition">
+      <column name="definition">
+        {
+          "id": "917ea5c8-cafe-4fa6-a942-e2388a88c6f6",
+          "name": "src_inventory_material_type",
+          "root": true,
+          "fromClause": "src_inventory_material_type",
+          "columns": [
+            {
+              "name": "id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_inventory_material_type.id",
+              "visibleByDefault": true
+            },
+            {
+              "name": "material_type_name",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_inventory_material_type.jsonb ->> 'name'",
+              "visibleByDefault": true
+            }
+          ],
+          "private": true
+        }
+      </column>
+      <where>id = '917ea5c8-cafe-4fa6-a942-e2388a88c6f6'</where>
+    </update>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.0.4/update-src-inventory-service-point-definition.xml
+++ b/src/main/resources/db/changelog/changes/v1.0.4/update-src-inventory-service-point-definition.xml
@@ -1,0 +1,45 @@
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+  <changeSet id="update-src-inventory-service-point-definition" author="bsharp@ebsco.com">
+    <update tableName="entity_type_definition">
+      <column name="definition">
+        {
+          "id": "89cdeac4-9582-4388-800b-9ccffd8d7691",
+          "name": "src_inventory_service_point",
+          "root": true,
+          "fromClause": "src_inventory_service_point",
+          "columns": [
+            {
+              "name": "id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_inventory_service_point.id",
+              "visibleByDefault": true
+            },
+            {
+              "name": "service_point_name",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_inventory_service_point.jsonb ->> 'name'",
+              "visibleByDefault": true
+            },
+            {
+              "name": "service_point_code",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_inventory_service_point.jsonb ->> 'code'",
+              "visibleByDefault": true
+            }
+          ],
+          "private": true
+        }
+      </column>
+      <where>id = '89cdeac4-9582-4388-800b-9ccffd8d7691'</where>
+    </update>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.0.4/update-src-organizations-definition.xml
+++ b/src/main/resources/db/changelog/changes/v1.0.4/update-src-organizations-definition.xml
@@ -1,0 +1,45 @@
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+  <changeSet id="update-src-organizations-definition" author="bsharp@ebsco.com">
+    <update tableName="entity_type_definition">
+      <column name="definition">
+        {
+          "id": "489234a9-8703-48cd-85e3-7f84011bafa3",
+          "name": "src_organizations",
+          "root": true,
+          "fromClause": "src_organizations",
+          "columns": [
+            {
+              "name": "id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_organizations.id",
+              "visibleByDefault": true
+            },
+            {
+              "name": "vendor_name",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_organizations.jsonb ->> 'name'",
+              "visibleByDefault": true
+            },
+            {
+              "name": "vendor_code",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_organizations.jsonb ->> 'code'",
+              "visibleByDefault": true
+            }
+          ],
+          "private": true
+        }
+      </column>
+      <where>id = '489234a9-8703-48cd-85e3-7f84011bafa3'</where>
+    </update>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.0.4/update-src-users-addresstypes-definition.xml
+++ b/src/main/resources/db/changelog/changes/v1.0.4/update-src-users-addresstypes-definition.xml
@@ -1,0 +1,37 @@
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+  <changeSet id="update-src-users-addresstypes-definition" author="bsharp@ebsco.com">
+    <update tableName="entity_type_definition">
+      <column name="definition">
+        {
+          "id": "e627a89b-682b-41fe-b532-f4262020a451",
+          "name": "src_users_addresstype",
+          "root": true,
+          "fromClause": "src_users_addresstype",
+          "columns": [
+            {
+              "name": "id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_users_addresstype.id",
+              "visibleByDefault": true
+            },
+            {
+              "name": "addressType",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_users_addresstype.jsonb ->> 'addressType'",
+              "visibleByDefault": true
+            }
+          ],
+          "private": true
+        }
+      </column>
+      <where>id = 'e627a89b-682b-41fe-b532-f4262020a451'</where>
+    </update>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.0.4/update-src-users-departments-definition.xml
+++ b/src/main/resources/db/changelog/changes/v1.0.4/update-src-users-departments-definition.xml
@@ -1,0 +1,37 @@
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+  <changeSet id="update-src-users-departments-definition" author="bsharp@ebsco.com">
+    <update tableName="entity_type_definition">
+      <column name="definition">
+        {
+          "id": "c8364551-7e51-475d-8473-88951181452d",
+          "name": "src_users_departments",
+          "root": true,
+          "fromClause": "src_users_departments",
+          "columns": [
+            {
+              "name": "id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_users_departments.id",
+              "visibleByDefault": true
+            },
+            {
+              "name": "department",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_users_departments.jsonb ->> 'name'",
+              "visibleByDefault": true
+            }
+          ],
+          "private": true
+        }
+      </column>
+      <where>id = 'c8364551-7e51-475d-8473-88951181452d'</where>
+    </update>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.0.4/update-src-users-groups-definition.xml
+++ b/src/main/resources/db/changelog/changes/v1.0.4/update-src-users-groups-definition.xml
@@ -1,0 +1,37 @@
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+  <changeSet id="update-src-users-groups-definition" author="bsharp@ebsco.com">
+    <update tableName="entity_type_definition">
+      <column name="definition">
+        {
+          "id": "e611264d-377e-4d87-a93f-f1ca327d3db0",
+          "name": "src_users_groups",
+          "root": true,
+          "fromClause": "src_users_groups",
+          "columns": [
+            {
+              "name": "id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_users_groups.id",
+              "visibleByDefault": true
+            },
+            {
+              "name": "group",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_users_groups.jsonb ->> 'group'",
+              "visibleByDefault": true
+            }
+          ],
+          "private": true
+        }
+      </column>
+      <where>id = 'e611264d-377e-4d87-a93f-f1ca327d3db0'</where>
+    </update>
+  </changeSet>
+</databaseChangeLog>

--- a/src/test/java/org/folio/fqm/ModFqmManagerIT.java
+++ b/src/test/java/org/folio/fqm/ModFqmManagerIT.java
@@ -124,6 +124,7 @@ class ModFqmManagerIT {
       .get("/entity-types")
       .then()
       .statusCode(200)
-      .body("$.size()", is(4));
+      // TODO: below value should be updated to 4 once POL entity type is fixed
+      .body("$.size()", is(3));
   }
 }

--- a/src/test/java/org/folio/fqm/repository/ResultSetRepositoryArrayTestDataProvider.java
+++ b/src/test/java/org/folio/fqm/repository/ResultSetRepositoryArrayTestDataProvider.java
@@ -40,7 +40,9 @@ public class ResultSetRepositoryArrayTestDataProvider implements MockDataProvide
     .columns(List.of(
       new EntityTypeColumn().name(ID_FIELD_NAME),
       new EntityTypeColumn().name("testField").dataType(new EntityDataType().dataType("arrayType"))
-    ));
+    ))
+    .name("TEST_ARRAY_ENTITY_TYPE")
+    .fromClause("TEST_ARRAY_ENTITY_TYPE");
 
   private static final String DERIVED_TABLE_NAME_QUERY_REGEX = "SELECT DERIVED_TABLE_NAME FROM ENTITY_TYPE_DEFINITION WHERE ID = .*";
   private static final String LIST_CONTENTS_BY_IDS_WITH_ARRAY_REGEX = "SELECT .* FROM .* WHERE ID IN .*";

--- a/src/test/java/org/folio/fqm/repository/ResultSetRepositoryTestDataProvider.java
+++ b/src/test/java/org/folio/fqm/repository/ResultSetRepositoryTestDataProvider.java
@@ -43,10 +43,12 @@ public class ResultSetRepositoryTestDataProvider implements MockDataProvider {
 
   private static final EntityType ENTITY_TYPE = new EntityType()
     .columns(List.of(
-      new EntityTypeColumn().name(ID_FIELD_NAME),
-      new EntityTypeColumn().name("key1").dataType(new EntityDataType().dataType("stringType")),
-      new EntityTypeColumn().name("key2").dataType(new EntityDataType().dataType("stringType"))
-    ));
+      new EntityTypeColumn().name(ID_FIELD_NAME).valueGetter(ID_FIELD_NAME),
+      new EntityTypeColumn().name("key1").dataType(new EntityDataType().dataType("stringType")).valueGetter("key1"),
+      new EntityTypeColumn().name("key2").dataType(new EntityDataType().dataType("stringType")).valueGetter("key2")
+    ))
+    .name("TEST_ENTITY_TYPE")
+    .fromClause("TEST_ENTITY_TYPE");
   private static final String DERIVED_TABLE_NAME_QUERY_REGEX = "SELECT DERIVED_TABLE_NAME FROM ENTITY_TYPE_DEFINITION WHERE ID = .*";
   private static final String LIST_CONTENTS_BY_ID_SELECTOR_REGEX = "SELECT .* FROM .* JOIN \\(SELECT CONTENT_ID, SORT_SEQ FROM .* ORDER BY SORT_SEQ";
   private static final String LIST_CONTENTS_BY_IDS_REGEX = "SELECT .* FROM .* WHERE ID IN .*";

--- a/src/test/java/org/folio/fqm/utils/IdStreamerTestDataProvider.java
+++ b/src/test/java/org/folio/fqm/utils/IdStreamerTestDataProvider.java
@@ -27,11 +27,13 @@ public class IdStreamerTestDataProvider implements MockDataProvider {
     .id(UUID.randomUUID().toString())
     .columns(
       List.of(
-        new EntityTypeColumn().name(EntityTypeRepository.ID_FIELD_NAME),
+        new EntityTypeColumn().name(EntityTypeRepository.ID_FIELD_NAME).valueGetter(EntityTypeRepository.ID_FIELD_NAME),
         new EntityTypeColumn().name("field1").dataType(new EntityDataType().dataType("stringType"))
       )
     )
-    .defaultSort(List.of(new EntityTypeDefaultSort().columnName(EntityTypeRepository.ID_FIELD_NAME)));
+    .defaultSort(List.of(new EntityTypeDefaultSort().columnName(EntityTypeRepository.ID_FIELD_NAME)))
+    .name("TEST_ENTITY_TYPE")
+    .fromClause("TEST_ENTITY_TYPE");
 
   private static final String DERIVED_TABLE_NAME_QUERY_REGEX = "SELECT DERIVED_TABLE_NAME FROM ENTITY_TYPE_DEFINITION WHERE ID = .*";
   private static final String ENTITY_TYPE_DEFINITION_REGEX = "SELECT DEFINITION FROM ENTITY_TYPE_DEFINITION WHERE ID = .*";

--- a/src/test/java/org/folio/fqm/utils/SqlFieldIdentificationUtilsTest.java
+++ b/src/test/java/org/folio/fqm/utils/SqlFieldIdentificationUtilsTest.java
@@ -3,23 +3,18 @@ package org.folio.fqm.utils;
 import static org.jooq.impl.DSL.field;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.folio.querytool.domain.dto.ColumnValueGetter;
 import org.folio.querytool.domain.dto.EntityTypeColumn;
 import org.junit.jupiter.api.Test;
 
 class SqlFieldIdentificationUtilsTest {
 
   @Test
-  void testRmbJsonbResultsColumn() {
-    ColumnValueGetter columnValueGetter = new ColumnValueGetter()
-      .type(ColumnValueGetter.TypeEnum.RMB_JSONB)
-      .param("name");
-
+  void testSqlResultsFilterWithValueGetter() {
     EntityTypeColumn entityTypeColumn = new EntityTypeColumn()
       .name("derived_column_name_01")
-      .valueGetter(columnValueGetter);
+      .valueGetter("valueGetter");
     var actualField = SqlFieldIdentificationUtils.getSqlResultsField(entityTypeColumn);
-    var expectedField = field("jsonb ->> 'name'");
+    var expectedField = field(entityTypeColumn.getValueGetter());
     assertEquals(expectedField, actualField);
   }
 
@@ -33,22 +28,7 @@ class SqlFieldIdentificationUtilsTest {
   }
 
   @Test
-  void testRmbJsonbFilterColumn() {
-    ColumnValueGetter columnValueGetter = new ColumnValueGetter()
-      .type(ColumnValueGetter.TypeEnum.RMB_JSONB)
-      .param("name");
-
-    EntityTypeColumn entityTypeColumn = new EntityTypeColumn()
-      .name("derived_column_name_01")
-      .filterValueGetter("this is a filter which is being overridden by the value getter")
-      .valueGetter(columnValueGetter);
-    var actualField = SqlFieldIdentificationUtils.getSqlFilterField(entityTypeColumn);
-    var expectedField = field("jsonb ->> 'name'");
-    assertEquals(expectedField, actualField);
-  }
-
-  @Test
-  void testSqlFilterFieldWhenValueGetterMissing() {
+  void testSqlFilterFieldWhenValueGetterAndFilterValueGetterMissing() {
     EntityTypeColumn entityTypeColumn = new EntityTypeColumn()
       .name("derived_column_name_01");
     var actualField = SqlFieldIdentificationUtils.getSqlFilterField(entityTypeColumn);
@@ -57,9 +37,20 @@ class SqlFieldIdentificationUtilsTest {
   }
 
   @Test
-  void testSqlFilterField() {
+  void testSqlFilterFieldWithValueGetter() {
     EntityTypeColumn entityTypeColumn = new EntityTypeColumn()
       .name("derived_column_name_01")
+      .valueGetter("valueGetter");
+    var actualField = SqlFieldIdentificationUtils.getSqlFilterField(entityTypeColumn);
+    var expectedField = field(entityTypeColumn.getValueGetter());
+    assertEquals(expectedField, actualField);
+  }
+
+  @Test
+  void testSqlFilterFieldWithValueGetterAndFilterValueGetter() {
+    EntityTypeColumn entityTypeColumn = new EntityTypeColumn()
+      .name("derived_column_name_01")
+      .valueGetter("valueGetter")
       .filterValueGetter("this is a filter. We want it to be used instead of the real column name");
     var actualField = SqlFieldIdentificationUtils.getSqlFilterField(entityTypeColumn);
     var expectedField = field(entityTypeColumn.getFilterValueGetter());


### PR DESCRIPTION
## Purpose
Build the SELECT clause from field accessors defined in the entity type. Update entity type definitions to be used with new technique.

## Testing
- [x] All unit tests passed
- [x] Tenant onboarded with no errors
- [x] Query can be run successfully and results retrieved for each entity type
- [x] UserFriendlyQueryService in mod-lists still works for each entity type
- [x] GET /entity-types/{entityTypeId}/columns/{columnName}/values still works for derived fields using materialized views

## Notes
- This ticket does not add filterValueGetters, so only valueGetters will be used initially
- For getting the filter field, filterValueGetter now takes precedence over valueGetter if both are present
- Commented out the script to create the POL entity type since it doesn't work properly right now
- Now that idValueGetter logic is implemented, we actually don't need the idView field in the entity type definitions. This field can be removed from the definition.