### PR TITLE
MODFQMMGR-102 Rearrange the columns in the query_results PK

### DIFF
--- a/src/main/resources/db/changelog/changes/v1.1.0/changelog-v1.1.0.xml
+++ b/src/main/resources/db/changelog/changes/v1.1.0/changelog-v1.1.0.xml
@@ -14,4 +14,12 @@
   <include file="update-src-organizations-definition.xml" relativeToChangelogFile="true"/>
   <include file="update-drv-purchase-order-line-details-definition.xml" relativeToChangelogFile="true"/>
 
+  <changeSet id="MODFQMMGR-107" author="mweaver@ebsco.com">
+    <comment>Swap the columns in the query_results primary key, to improve performance</comment>
+    <sql>
+      ALTER TABLE query_results DROP CONSTRAINT IF EXISTS query_results_pkey;
+      ALTER TABLE query_results ADD PRIMARY KEY (query_id, result_id);
+    </sql>
+  </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
This improves the performance for nearly all queries that we do with that table by changing it to (query_id, result_id), since in pretty much every query, we provide a query ID and no result IDs