### PR TITLE
MODFQMMGR-106: Remove transactions and fix query result count

### DIFF
--- a/src/main/java/org/folio/fqm/service/QueryExecutionCallbacks.java
+++ b/src/main/java/org/folio/fqm/service/QueryExecutionCallbacks.java
@@ -9,7 +9,6 @@ import org.folio.fqm.model.IdsWithCancelCallback;
 import org.folio.fqm.repository.QueryRepository;
 import org.folio.fqm.repository.QueryResultsRepository;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -23,7 +22,6 @@ public class QueryExecutionCallbacks {
   private final QueryRepository queryRepository;
   private final QueryResultsRepository queryResultsRepository;
 
-  @Transactional
   public void handleDataBatch(UUID queryId, IdsWithCancelCallback idsWithCancelCallback) {
     Query query = queryRepository.getQuery(queryId, true)
       .orElseThrow(() -> new QueryNotFoundException(queryId));
@@ -37,7 +35,6 @@ public class QueryExecutionCallbacks {
     queryResultsRepository.saveQueryResults(queryId, resultIds);
   }
 
-  @Transactional
   public void handleSuccess(Query query, int totalCount) {
     Query savedQuery = queryRepository.getQuery(query.queryId(), true)
       .orElseThrow(() -> new QueryNotFoundException(query.queryId()));
@@ -50,7 +47,6 @@ public class QueryExecutionCallbacks {
     queryRepository.updateQuery(query.queryId(), QueryStatus.SUCCESS, OffsetDateTime.now(), null);
   }
 
-  @Transactional
   public void handleFailure(Query query, Throwable throwable) {
     log.error("Query Execution failed for queryId {}, entityTypeId {}. Failure reason: {}", query.queryId(),
       query.entityTypeId(), throwable.getMessage());

--- a/src/main/java/org/folio/fqm/service/QueryExecutionService.java
+++ b/src/main/java/org/folio/fqm/service/QueryExecutionService.java
@@ -1,7 +1,5 @@
 package org.folio.fqm.service;
 
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.folio.fqm.domain.Query;
@@ -23,7 +21,6 @@ public class QueryExecutionService {
   @Async
   // Long-running method. Running this method within a transaction boundary will hog db connection for
   // long time. Hence, do not run this method in a transaction.
-  @Transactional(propagation = Propagation.NOT_SUPPORTED)
   public void executeQueryAsync(Query query) {
     try {
       log.info("Executing query {}", query.queryId());

--- a/src/main/java/org/folio/fqm/service/QueryManagementService.java
+++ b/src/main/java/org/folio/fqm/service/QueryManagementService.java
@@ -60,7 +60,6 @@ public class QueryManagementService {
    * @param submitQuery Query to execute
    * @return ID of the query
    */
-  @Transactional
   public QueryIdentifier runFqlQueryAsync(SubmitQuery submitQuery) {
     Query query = Query.newQuery(submitQuery.getEntityTypeId(),
       submitQuery.getFqlQuery(),


### PR DESCRIPTION
## Purpose
[MODFQMMGR-106](https://issues.folio.org/browse/MODFQMMGR-106): Query result count is not incrementally updated

This is a PR to fix the bug where query result counts are no longer being updated during query execution. As part of this ticket, we're also removing transactional annotations on most methods. This will allow query result counts to be updated again, without causing a dip in performance.

## Testing
- [x] All unit tests passed
- [x] Query result counts are updated incrementally during query execution
