### PR TITLE
MODFQMMGR-113: Rework array operators to avoid substring comparisons

### DIFF
--- a/src/main/resources/db/changelog/changes/v1.1.0/update-drv-user-details-definition.xml
+++ b/src/main/resources/db/changelog/changes/v1.1.0/update-drv-user-details-definition.xml
@@ -37,7 +37,8 @@
                   "dataType": "rangedUUIDType"
                 }
               },
-              "valueGetter": "( SELECT array_agg(add_id.value ->> 'addressTypeId'::text) FILTER (WHERE (add_id.value ->> 'addressTypeId'::text) IS NOT NULL) AS array_agg FROM jsonb_array_elements((src_users_users.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value))",
+              "valueGetter": "( SELECT array_agg(record.value ->> 'addressTypeId'::text) FILTER (WHERE (record.value ->> 'addressTypeId'::text) IS NOT NULL) AS array_agg FROM jsonb_array_elements((src_users_users.jsonb -> 'personal'::text) -> 'addresses'::text) record(value))",
+              "filterValueGetter": "( SELECT array_agg(lower(record.value ->> 'addressTypeId'::text)) FILTER (WHERE (record.value ->> 'addressTypeId'::text) IS NOT NULL) AS array_agg FROM jsonb_array_elements((src_users_users.jsonb -> 'personal'::text) -> 'addresses'::text) record(value))",
               "visibleByDefault": false
             },
             {
@@ -48,7 +49,8 @@
                   "dataType": "stringType"
                 }
               },
-              "valueGetter": "( SELECT array_agg(add_id.value ->> 'addressLine1'::text) FILTER (WHERE (add_id.value ->> 'addressLine1'::text) IS NOT NULL) AS array_agg FROM jsonb_array_elements((src_users_users.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value))",
+              "valueGetter": "( SELECT array_agg(record.value ->> 'addressLine1'::text) FILTER (WHERE (record.value ->> 'addressLine1'::text) IS NOT NULL) AS array_agg FROM jsonb_array_elements((src_users_users.jsonb -> 'personal'::text) -> 'addresses'::text) record(value))",
+              "filterValueGetter": "( SELECT array_agg(lower(record.value ->> 'addressLine1'::text)) FILTER (WHERE (record.value ->> 'addressLine1'::text) IS NOT NULL) AS array_agg FROM jsonb_array_elements((src_users_users.jsonb -> 'personal'::text) -> 'addresses'::text) record(value))",
               "visibleByDefault": false
             },
             {
@@ -59,7 +61,8 @@
                   "dataType": "stringType"
                 }
               },
-              "valueGetter": "( SELECT array_agg(add_id.value ->> 'addressLine2'::text) FILTER (WHERE (add_id.value ->> 'addressLine2'::text) IS NOT NULL) AS array_agg FROM jsonb_array_elements((src_users_users.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value))",
+              "valueGetter": "( SELECT array_agg(record.value ->> 'addressLine2'::text) FILTER (WHERE (record.value ->> 'addressLine2'::text) IS NOT NULL) AS array_agg FROM jsonb_array_elements((src_users_users.jsonb -> 'personal'::text) -> 'addresses'::text) record(value))",
+              "filterValueGetter": "( SELECT array_agg(lower(record.value ->> 'addressLine2'::text)) FILTER (WHERE (record.value ->> 'addressLine2'::text) IS NOT NULL) AS array_agg FROM jsonb_array_elements((src_users_users.jsonb -> 'personal'::text) -> 'addresses'::text) record(value))",
               "visibleByDefault": false
             },
             {
@@ -70,7 +73,8 @@
                   "dataType": "stringType"
                 }
               },
-              "valueGetter": "( SELECT array_agg(a.jsonb ->> 'addressType'::text) FILTER (WHERE (a.jsonb ->> 'addressType'::text) IS NOT NULL) AS array_agg FROM jsonb_array_elements((src_users_users.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value) JOIN src_users_addresstype a ON (add_id.value ->> 'addressTypeId'::text) = a.id::text)",
+              "valueGetter": "( SELECT array_agg(a.jsonb ->> 'addressType'::text) FILTER (WHERE (a.jsonb ->> 'addressType'::text) IS NOT NULL) AS array_agg FROM jsonb_array_elements((src_users_users.jsonb -> 'personal'::text) -> 'addresses'::text) record(value) JOIN src_users_addresstype a ON (record.value ->> 'addressTypeId'::text) = a.id::text)",
+              "filterValueGetter": "( SELECT array_agg(lower(a.jsonb ->> 'addressType'::text)) FILTER (WHERE (a.jsonb ->> 'addressType'::text) IS NOT NULL) AS array_agg FROM jsonb_array_elements((src_users_users.jsonb -> 'personal'::text) -> 'addresses'::text) record(value) JOIN src_users_addresstype a ON (record.value ->> 'addressTypeId'::text) = a.id::text)",
               "visibleByDefault": false,
               "idColumnName": "user_address_ids",
               "source": {
@@ -94,7 +98,8 @@
                   "dataType": "stringType"
                 }
               },
-              "valueGetter": "( SELECT array_agg(add_id.value ->> 'city'::text) FILTER (WHERE (add_id.value ->> 'city'::text) IS NOT NULL) AS array_agg FROM jsonb_array_elements((src_users_users.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value))",
+              "valueGetter": "( SELECT array_agg(record.value ->> 'city'::text) FILTER (WHERE (record.value ->> 'city'::text) IS NOT NULL) AS array_agg FROM jsonb_array_elements((src_users_users.jsonb -> 'personal'::text) -> 'addresses'::text) record(value))",
+              "filterValueGetter": "( SELECT array_agg(lower(record.value ->> 'city'::text)) FILTER (WHERE (record.value ->> 'city'::text) IS NOT NULL) AS array_agg FROM jsonb_array_elements((src_users_users.jsonb -> 'personal'::text) -> 'addresses'::text) record(value))",
               "visibleByDefault": false
             },
             {
@@ -105,7 +110,8 @@
                   "dataType": "stringType"
                 }
               },
-              "valueGetter": "( SELECT array_agg(add_id.value ->> 'countryId'::text) FILTER (WHERE (add_id.value ->> 'countryId'::text) IS NOT NULL) AS array_agg FROM jsonb_array_elements((src_users_users.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value))",
+              "valueGetter": "( SELECT array_agg(record.value ->> 'countryId'::text) FILTER (WHERE (record.value ->> 'countryId'::text) IS NOT NULL) AS array_agg FROM jsonb_array_elements((src_users_users.jsonb -> 'personal'::text) -> 'addresses'::text) record(value))",
+              "filterValueGetter": "( SELECT array_agg(lower(record.value ->> 'countryId'::text)) FILTER (WHERE (record.value ->> 'countryId'::text) IS NOT NULL) AS array_agg FROM jsonb_array_elements((src_users_users.jsonb -> 'personal'::text) -> 'addresses'::text) record(value))",
               "visibleByDefault": false
             },
             {
@@ -132,7 +138,8 @@
                   "dataType": "rangedUUIDType"
                 }
               },
-              "valueGetter": "( SELECT array_agg(add_id.value::text) FILTER (WHERE (add_id.value::text) IS NOT NULL) AS array_agg FROM jsonb_array_elements_text(src_users_users.jsonb -> 'departments'::text) add_id(value))",
+              "valueGetter": "( SELECT array_agg(record.value::text) FILTER (WHERE (record.value::text) IS NOT NULL) AS array_agg FROM jsonb_array_elements_text(src_users_users.jsonb -> 'departments'::text) record(value))",
+              "filterValueGetter": "( SELECT array_agg(lower(record.value::text)) FILTER (WHERE (record.value::text) IS NOT NULL) AS array_agg FROM jsonb_array_elements_text(src_users_users.jsonb -> 'departments'::text) record(value))",
               "visibleByDefault": false
             },
             {
@@ -148,7 +155,8 @@
                 "entityTypeId": "c8364551-7e51-475d-8473-88951181452d",
                 "columnName": "department"
               },
-              "valueGetter": "( SELECT array_agg(a.jsonb ->> 'name'::text) FILTER (WHERE (a.jsonb ->> 'name'::text) IS NOT NULL) AS array_agg FROM jsonb_array_elements_text((src_users_users.jsonb -> 'departments'::text)) add_id(value) JOIN src_users_departments a ON (add_id.value::text) = a.id::text)",
+              "valueGetter": "( SELECT array_agg(a.jsonb ->> 'name'::text) FILTER (WHERE (a.jsonb ->> 'name'::text) IS NOT NULL) AS array_agg FROM jsonb_array_elements_text((src_users_users.jsonb -> 'departments'::text)) record(value) JOIN src_users_departments a ON (record.value::text) = a.id::text)",
+              "filterValueGetter": "( SELECT array_agg(lower(a.jsonb ->> 'name'::text)) FILTER (WHERE (a.jsonb ->> 'name'::text) IS NOT NULL) AS array_agg FROM jsonb_array_elements_text((src_users_users.jsonb -> 'departments'::text)) record(value) JOIN src_users_departments a ON (record.value::text) = a.id::text)",
               "visibleByDefault": false
             },
             {
@@ -260,7 +268,8 @@
                   "dataType": "stringType"
                 }
               },
-              "valueGetter": "( SELECT array_agg(add_id.value ->> 'postalCode'::text) FILTER (WHERE (add_id.value ->> 'postalCode'::text) IS NOT NULL) AS array_agg FROM jsonb_array_elements((src_users_users.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value))",
+              "valueGetter": "( SELECT array_agg(record.value ->> 'postalCode'::text) FILTER (WHERE (record.value ->> 'postalCode'::text) IS NOT NULL) AS array_agg FROM jsonb_array_elements((src_users_users.jsonb -> 'personal'::text) -> 'addresses'::text) record(value))",
+              "filterValueGetter": "( SELECT array_agg(lower(record.value ->> 'postalCode'::text)) FILTER (WHERE (record.value ->> 'postalCode'::text) IS NOT NULL) AS array_agg FROM jsonb_array_elements((src_users_users.jsonb -> 'personal'::text) -> 'addresses'::text) record(value))",
               "visibleByDefault": false
             },
             {
@@ -298,7 +307,7 @@
               "dataType":{
                 "dataType":"stringType"
               },
-              "valueGetter": "concat_ws(', '::text, NULLIF(( SELECT subquery.addressline1 FROM ( SELECT add_id.value ->> 'addressLine1'::text AS addressline1, row_number() OVER (ORDER BY (add_id.value ->> 'primaryAddress'::text)) AS row_num FROM jsonb_array_elements((src_users_users.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value)) subquery WHERE subquery.row_num = 1), ''::text), NULLIF(( SELECT subquery.addressline2 FROM ( SELECT add_id.value ->> 'addressLine2'::text AS addressline2, row_number() OVER (ORDER BY (add_id.value ->> 'primaryAddress'::text)) AS row_num FROM jsonb_array_elements((src_users_users.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value)) subquery WHERE subquery.row_num = 1), ''::text), NULLIF(( SELECT subquery.city FROM ( SELECT add_id.value ->> 'city'::text AS city, row_number() OVER (ORDER BY (add_id.value ->> 'primaryAddress'::text)) AS row_num FROM jsonb_array_elements((src_users_users.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value)) subquery WHERE subquery.row_num = 1), ''::text), NULLIF(( SELECT subquery.region FROM ( SELECT add_id.value ->> 'region'::text AS region, row_number() OVER (ORDER BY (add_id.value ->> 'primaryAddress'::text)) AS row_num FROM jsonb_array_elements((src_users_users.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value)) subquery WHERE subquery.row_num = 1), ''::text), NULLIF(( SELECT subquery.postalcode FROM ( SELECT add_id.value ->> 'postalCode'::text AS postalcode, row_number() OVER (ORDER BY (add_id.value ->> 'primaryAddress'::text)) AS row_num FROM jsonb_array_elements((src_users_users.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value)) subquery WHERE subquery.row_num = 1), ''::text), NULLIF(( SELECT subquery.countryid FROM ( SELECT add_id.value ->> 'countryId'::text AS countryid, row_number() OVER (ORDER BY (add_id.value ->> 'primaryAddress'::text)) AS row_num FROM jsonb_array_elements((src_users_users.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value)) subquery WHERE subquery.row_num = 1), ''::text))",
+              "valueGetter": "concat_ws(', '::text, NULLIF(( SELECT subquery.addressline1 FROM ( SELECT record.value ->> 'addressLine1'::text AS addressline1, row_number() OVER (ORDER BY (record.value ->> 'primaryAddress'::text)) AS row_num FROM jsonb_array_elements((src_users_users.jsonb -> 'personal'::text) -> 'addresses'::text) record(value)) subquery WHERE subquery.row_num = 1), ''::text), NULLIF(( SELECT subquery.addressline2 FROM ( SELECT record.value ->> 'addressLine2'::text AS addressline2, row_number() OVER (ORDER BY (record.value ->> 'primaryAddress'::text)) AS row_num FROM jsonb_array_elements((src_users_users.jsonb -> 'personal'::text) -> 'addresses'::text) record(value)) subquery WHERE subquery.row_num = 1), ''::text), NULLIF(( SELECT subquery.city FROM ( SELECT record.value ->> 'city'::text AS city, row_number() OVER (ORDER BY (record.value ->> 'primaryAddress'::text)) AS row_num FROM jsonb_array_elements((src_users_users.jsonb -> 'personal'::text) -> 'addresses'::text) record(value)) subquery WHERE subquery.row_num = 1), ''::text), NULLIF(( SELECT subquery.region FROM ( SELECT record.value ->> 'region'::text AS region, row_number() OVER (ORDER BY (record.value ->> 'primaryAddress'::text)) AS row_num FROM jsonb_array_elements((src_users_users.jsonb -> 'personal'::text) -> 'addresses'::text) record(value)) subquery WHERE subquery.row_num = 1), ''::text), NULLIF(( SELECT subquery.postalcode FROM ( SELECT record.value ->> 'postalCode'::text AS postalcode, row_number() OVER (ORDER BY (record.value ->> 'primaryAddress'::text)) AS row_num FROM jsonb_array_elements((src_users_users.jsonb -> 'personal'::text) -> 'addresses'::text) record(value)) subquery WHERE subquery.row_num = 1), ''::text), NULLIF(( SELECT subquery.countryid FROM ( SELECT record.value ->> 'countryId'::text AS countryid, row_number() OVER (ORDER BY (record.value ->> 'primaryAddress'::text)) AS row_num FROM jsonb_array_elements((src_users_users.jsonb -> 'personal'::text) -> 'addresses'::text) record(value)) subquery WHERE subquery.row_num = 1), ''::text))",
               "visibleByDefault": false
             },
             {
@@ -309,7 +318,8 @@
                   "dataType": "stringType"
                 }
               },
-              "valueGetter": "( SELECT array_agg(add_id.value ->> 'region'::text) FILTER (WHERE (add_id.value ->> 'region'::text) IS NOT NULL) AS array_agg FROM jsonb_array_elements((src_users_users.jsonb -> 'personal'::text) -> 'addresses'::text) add_id(value))",
+              "valueGetter": "( SELECT array_agg(record.value ->> 'region'::text) FILTER (WHERE (record.value ->> 'region'::text) IS NOT NULL) AS array_agg FROM jsonb_array_elements((src_users_users.jsonb -> 'personal'::text) -> 'addresses'::text) record(value))",
+              "filterValueGetter": "( SELECT array_agg(lower(record.value ->> 'region'::text)) FILTER (WHERE (record.value ->> 'region'::text) IS NOT NULL) AS array_agg FROM jsonb_array_elements((src_users_users.jsonb -> 'personal'::text) -> 'addresses'::text) record(value))",
               "visibleByDefault": false
             },
             {

--- a/src/test/java/org/folio/fqm/service/FqlToSqlConverterServiceTest.java
+++ b/src/test/java/org/folio/fqm/service/FqlToSqlConverterServiceTest.java
@@ -8,6 +8,7 @@ import org.folio.querytool.domain.dto.EntityDataType;
 import org.folio.querytool.domain.dto.EntityType;
 import org.folio.querytool.domain.dto.EntityTypeColumn;
 import org.jooq.Condition;
+import org.jooq.impl.DSL;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -220,27 +221,27 @@ class FqlToSqlConverterServiceTest {
       Arguments.of(
         "contains string",
         """
-          {"arrayField": {"$contains": "some value"}}""",
-        field("arrayField").containsIgnoreCase("some value")
+          {"arrayField": {"$contains": "Some vALUE"}}""",
+        DSL.cast(field("arrayField"), String[].class).contains(new String[]{"some value"})
       ),
       Arguments.of(
         "contains numeric",
         """
           {"arrayField": {"$contains": 10}}""",
-        field("arrayField").contains(10)
+        DSL.cast(field("arrayField"), String[].class).contains(new String[]{"10"})
       ),
 
       Arguments.of(
         "not contains string",
         """
-          {"arrayField": {"$not_contains": "some value"}}""",
-        field("arrayField").notContainsIgnoreCase("some value").or(field("arrayField").isNull())
+          {"arrayField": {"$not_contains": "Some vALUE"}}""",
+        DSL.cast(field("arrayField"), String[].class).notContains(new String[]{"some value"})
       ),
       Arguments.of(
         "not contains numeric",
         """
           {"arrayField": {"$not_contains": 10}}""",
-        field("arrayField").notContains(10).or(field("arrayField").isNull())
+        DSL.cast(field("arrayField"), String[].class).notContains(new String[]{"10"})
       ),
 
       Arguments.of(
@@ -285,7 +286,7 @@ class FqlToSqlConverterServiceTest {
       Arguments.of(
         "condition on a field with a filter value getter",
         """
-           {"fieldWithFilterValueGetter": {"$eq": "Test value"}}""",
+          {"fieldWithFilterValueGetter": {"$eq": "Test value"}}""",
         field("thisIsAFilterValueGetter").eq("Test value".toLowerCase())
       )
     );

--- a/translations/mod-fqm-manager/en.json
+++ b/translations/mod-fqm-manager/en.json
@@ -168,7 +168,7 @@
   "entityType.drv_user_details.user_created_date": "User created date",
   "entityType.drv_user_details.user_date_of_birth": "User date of birth",
   "entityType.drv_user_details.user_department_ids": "User department IDs",
-  "entityType.drv_loan_details.user_department_names": "User department names",
+  "entityType.drv_user_details.user_department_names": "User department names",
   "entityType.drv_user_details.user_email": "User email",
   "entityType.drv_user_details.user_enrollment_date": "User enrollment date",
   "entityType.drv_user_details.user_expiration_date": "User expiration date",


### PR DESCRIPTION
## Purpose
[MODFQMMGR-113: Rework array operators to avoid substring comparisons](https://issues.folio.org/projects/MODFQMMGR/issues/MODFQMMGR-113)

# Notes
- This ticket supports $contains and $not_contains operators. Other operators have been discussed for use with arrays ($in, $nin), but these operators are not in the scope of this ticket
- This does not fix the POL fund distribution array column, this will be handled in another ticket

## Testing
- [x] All unit tests passed
- [x] All array fields (minus POL fund distribution) can be queried with $contains and $not_contains operators. These operators use array-contains logic and do not search for/match substrings.
