### PR TITLE
MODFQMMGR-109: Add filterValueGetters for Users entity type

### DIFF
--- a/src/main/resources/db/changelog/changes/v1.1.0/update-drv-user-details-definition.xml
+++ b/src/main/resources/db/changelog/changes/v1.1.0/update-drv-user-details-definition.xml
@@ -2,14 +2,14 @@
                    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
-  <changeSet id="update-user-details-entity-type-definition" author="bsharp@ebsco.com">
+  <changeSet id="update-user-details-entity-type-definition" runOnChange="true" author="bsharp@ebsco.com">
     <update tableName="entity_type_definition">
       <column name="definition">
         {
           "id": "0069cf6f-2833-46db-8a51-8934769b8289",
           "name":"drv_user_details",
           "private" : false,
-          "fromClause": "src_users_users LEFT JOIN src_users_groups ON src_users_groups.id = ((src_users_users.jsonb ->> 'patronGroup'::text)::uuid)",
+          "fromClause": "src_users_users LEFT JOIN src_users_groups ON src_users_groups.id = src_users_users.patrongroup",
           "columns": [
             {
               "name": "user_active",
@@ -17,6 +17,7 @@
                 "dataType":"booleanType"
               },
               "valueGetter": "src_users_users.jsonb ->> 'active'",
+              "filterValueGetter": "lower(${tenant_id}_mod_users.f_unaccent(src_users_users.jsonb ->> 'active'::text))",
               "visibleByDefault": true,
               "values": [
                 {
@@ -88,6 +89,7 @@
                 "dataType":"stringType"
               },
               "valueGetter": "src_users_users.jsonb ->> 'barcode'",
+              "filterValueGetter": "lower(${tenant_id}_mod_users.f_unaccent(src_users_users.jsonb ->> 'barcode'::text))",
               "visibleByDefault": true
             },
             {
@@ -165,6 +167,7 @@
                 "dataType":"stringType"
               },
               "valueGetter": "src_users_users.jsonb -> 'personal' ->> 'email'",
+              "filterValueGetter": "lower(${tenant_id}_mod_users.f_unaccent((src_users_users.jsonb -> 'personal'::text) ->> 'email'::text))",
               "visibleByDefault": false
             },
             {
@@ -181,6 +184,7 @@
                 "dataType":"dateType"
               },
               "valueGetter": "src_users_users.jsonb ->> 'expirationDate'",
+              "filterValueGetter": "\"left\"(src_users_users.jsonb ->> 'expirationDate'::text, 600)",
               "visibleByDefault": false
             },
             {
@@ -189,6 +193,7 @@
                 "dataType":"stringType"
               },
               "valueGetter": "src_users_users.jsonb ->> 'externalSystemId'",
+              "filterValueGetter": "lower(${tenant_id}_mod_users.f_unaccent(src_users_users.jsonb ->> 'externalSystemId'::text))",
               "visibleByDefault": false
             },
             {
@@ -197,6 +202,7 @@
                 "dataType":"stringType"
               },
               "valueGetter": "src_users_users.jsonb -> 'personal' ->> 'firstName'",
+              "filterValueGetter": "\"left\"(lower(${tenant_id}_mod_users.f_unaccent((src_users_users.jsonb -> 'personal'::text) ->> 'firstName'::text)), 600)",
               "visibleByDefault": true
             },
             {
@@ -213,6 +219,7 @@
                 "dataType":"stringType"
               },
               "valueGetter": "src_users_users.jsonb -> 'personal' ->> 'lastName'",
+              "filterValueGetter": "\"left\"(lower(${tenant_id}_mod_users.f_unaccent((src_users_users.jsonb -> 'personal'::text) ->> 'lastName'::text)), 600)",
               "visibleByDefault": true
             },
             {
@@ -237,6 +244,7 @@
                 "dataType":"stringType"
               },
               "valueGetter": "src_users_groups.jsonb ->> 'group'",
+              "filterValueGetter": "lower(${tenant_id}_mod_users.f_unaccent(src_users_groups.jsonb ->> 'group'::text))",
               "visibleByDefault": false,
               "idColumnName": "user_patron_group_id",
               "source": {
@@ -300,6 +308,7 @@
                 "dataType":"stringType"
               },
               "valueGetter": "src_users_users.jsonb -> 'personal' ->> 'preferredFirstName'",
+              "filterValueGetter": "${tenant_id}_mod_users.f_unaccent((src_users_users.jsonb -> 'personal'::text) ->> 'preferredFirstName'::text)",
               "visibleByDefault": true
             },
             {
@@ -336,6 +345,7 @@
                 "dataType":"stringType"
               },
               "valueGetter": "src_users_users.jsonb ->> 'username'",
+              "filterValueGetter": "lower(${tenant_id}_mod_users.f_unaccent(src_users_users.jsonb ->> 'username'::text))",
               "visibleByDefault": true
             }
           ],


### PR DESCRIPTION
## Purpose
Add filterValueGetters for Users entity type

## Testing
- [x] All fields with new filterValueGetters can be queried successfully
- [x] filterValueGetters result in index scans where appropriate
