### PR TITLE
MODFQMMGR-116 Add support for value functions on fields

### DIFF
--- a/src/main/java/org/folio/fqm/service/FqlToSqlConverterService.java
+++ b/src/main/java/org/folio/fqm/service/FqlToSqlConverterService.java
@@ -35,9 +35,9 @@ import static org.jooq.impl.DSL.val;
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 public class FqlToSqlConverterService {
 
-  // The compiler is unable to determine handle a type parameter on ConditionHandler
-  // (depending on how it's constrained, it either fails to compile this initialization or uses of the variable)
-  // IDEs seem to be able to handle ConditionHandler
+  // Suppress warnings here because the compiler is unable to determine a type parameter on ConditionHandler
+  // (depending on how it's constrained, it either fails to compile this initialization or the uses of this variable).
+  // IDEs seem to be able to handle ConditionHandler, though
   @SuppressWarnings("rawtypes")
   private static final Map<Class<? extends FqlCondition<?>>, ConditionHandler> sqlConverters = Map.ofEntries(
     buildMapping(EqualsCondition.class, FqlToSqlConverterService::handleEquals),


### PR DESCRIPTION
This makes it so we can configure a "valueFunction" property on a column
within an entity type, allowing us to customize how query conditions on
a column work. This way, if a filter value getter on a field changes its
behavior (e.g., removing accents), we can make the condition's value
exhibit that same behavior, to make it more intuitive to work with.

An example of this is Loan.instance_title: the filter value getter on
that field converts it to lower-case, truncates it to 600 characters,
and removes all accents. This makes it so a user could copy/paste a
title with accents from query results directly into an `instance_title
== <the title>` query and not get the expected result. With this commit,
we can do the same `lower(truncate(unaccent()))` processing on both the
field (using the filter value getter) and on the condition's static
value (using the value function) and get more consistent results.