### PR TITLE
Add unique indexes and hardcoded statuses to new materialized views

### DIFF
--- a/src/main/resources/db/changelog/changes/v1.1.0/changelog-v1.1.0.xml
+++ b/src/main/resources/db/changelog/changes/v1.1.0/changelog-v1.1.0.xml
@@ -15,15 +15,15 @@
   <include file="update-src-organizations-definition.xml" relativeToChangelogFile="true"/>
   <include file="update-drv-purchase-order-line-details-definition.xml" relativeToChangelogFile="true"/>
   <include file="update-drv-user-details-definition.xml" relativeToChangelogFile="true"/>
-  <include file="sql/add-pol-payment-status-definition.sql" relativeToChangelogFile="true"/>
-  <include file="sql/add-pol-receipt-status-definition.sql" relativeToChangelogFile="true"/>
 
-  <changeSet id="create-mat-views-pol-payment-receipt-status" author="bsharp@ebsco.com">
+  <changeSet id="create-mat-views-pol-payment-receipt-status" author="bsharp@ebsco.com" runOnChange="true">
     <preConditions onFail="CONTINUE">
       <tableExists tableName = "po_line" schemaName="${tenant_id}_mod_orders_storage"/>
     </preConditions>
     <sqlFile path="sql/create-mat-view-pol-payment-status.sql" relativeToChangelogFile="true"/>
     <sqlFile path="sql/create-mat-view-pol-receipt-status.sql" relativeToChangelogFile="true"/>
+    <sqlFile path="sql/add-pol-payment-status-definition.sql" relativeToChangelogFile="true"/>
+    <sqlFile path="sql/add-pol-receipt-status-definition.sql" relativeToChangelogFile="true"/>
   </changeSet>
 
 

--- a/src/main/resources/db/changelog/changes/v1.1.0/sql/create-mat-view-pol-payment-status.sql
+++ b/src/main/resources/db/changelog/changes/v1.1.0/sql/create-mat-view-pol-payment-status.sql
@@ -1,5 +1,19 @@
-CREATE MATERIALIZED VIEW IF NOT EXISTS drv_pol_payment_status AS
-SELECT DISTINCT jsonb ->> 'paymentStatus' AS payment_status
-FROM ${tenant_id}_mod_orders_storage.po_line;
+DROP MATERIALIZED VIEW IF EXISTS drv_pol_payment_status;
 
-REFRESH MATERIALIZED VIEW drv_pol_payment_status;
+CREATE MATERIALIZED VIEW drv_pol_payment_status AS
+SELECT payment_status FROM
+	(SELECT DISTINCT jsonb ->> 'paymentStatus' AS payment_status FROM ${tenant_id}_mod_orders_storage.po_line) existing_statuses
+UNION
+	(SELECT payment_status FROM
+	 	(VALUES
+			('Awaiting Payment'),
+			('Cancelled'),
+			('Fully Paid'),
+			('Partially Paid'),
+			('Payment Not Required'),
+			('Pending')
+		) AS hardcoded_statuses(payment_status)
+	);
+
+CREATE UNIQUE INDEX fqm_pol_payment_status
+ON ${tenant_id}_mod_fqm_manager.drv_pol_payment_status(payment_status);

--- a/src/main/resources/db/changelog/changes/v1.1.0/sql/create-mat-view-pol-receipt-status.sql
+++ b/src/main/resources/db/changelog/changes/v1.1.0/sql/create-mat-view-pol-receipt-status.sql
@@ -1,5 +1,19 @@
-CREATE MATERIALIZED VIEW IF NOT EXISTS drv_pol_receipt_status AS
-SELECT DISTINCT jsonb ->> 'receiptStatus' AS receipt_status
-FROM ${tenant_id}_mod_orders_storage.po_line;
+DROP MATERIALIZED VIEW IF EXISTS drv_pol_receipt_status;
 
-REFRESH MATERIALIZED VIEW drv_pol_receipt_status;
+CREATE MATERIALIZED VIEW drv_pol_receipt_status AS
+SELECT receipt_status FROM
+	(SELECT DISTINCT jsonb ->> 'receiptStatus' AS receipt_status FROM ${tenant_id}_mod_orders_storage.po_line) existing_statuses
+UNION
+	(SELECT receipt_status FROM
+	 	(VALUES
+			('Awaiting Receipt'),
+			('Cancelled'),
+			('Fully Received'),
+			('Partially Received'),
+			('Pending'),
+			('Receipt Not Required')
+		) AS hardcoded_statuses(receipt_status)
+	) ;
+
+CREATE UNIQUE INDEX fqm_pol_receipt_status
+ON ${tenant_id}_mod_fqm_manager.drv_pol_receipt_status(receipt_status);


### PR DESCRIPTION
## Purpose
Add unique indexes so that new materialized views can be refreshed. Also include hardcoded statuses in new views, so that they show up in the query builder even if the tenant doesn't have any records with the status.