### PR TITLE
MODFQMMGR-137: Change how we identify unique records for lists

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   <properties>
     <!-- runtime dependencies -->
     <folio-spring-base.version>7.1.2</folio-spring-base.version>
-    <folio-query-tool-metadata.version>1.1.0</folio-query-tool-metadata.version>
+    <folio-query-tool-metadata.version>1.2.0-SNAPSHOT</folio-query-tool-metadata.version>
     <mapstruct.version>1.5.2.Final</mapstruct.version>
     <lib-fqm-query-processor.version>1.2.0-SNAPSHOT</lib-fqm-query-processor.version>
     <coffee-boots.version>4.0.0</coffee-boots.version>

--- a/src/main/java/org/folio/fqm/model/IdsWithCancelCallback.java
+++ b/src/main/java/org/folio/fqm/model/IdsWithCancelCallback.java
@@ -1,9 +1,8 @@
 package org.folio.fqm.model;
 
 import java.util.List;
-import java.util.UUID;
 
-public record IdsWithCancelCallback(List<UUID> ids, Runnable cancelFunction) {
+public record IdsWithCancelCallback(List<String[]> ids, Runnable cancelFunction) {
 
   public void cancel() {
     cancelFunction.run();

--- a/src/main/java/org/folio/fqm/resource/FqlQueryController.java
+++ b/src/main/java/org/folio/fqm/resource/FqlQueryController.java
@@ -41,14 +41,14 @@ public class FqlQueryController implements FqlQueryApi {
   }
 
   @Override
-  public ResponseEntity<List<UUID>> getSortedIds(UUID queryId, Integer offset, Integer limit){
+  public ResponseEntity<List<List<String>>> getSortedIds(UUID queryId, Integer offset, Integer limit){
     return ResponseEntity.ok(queryManagementService.getSortedIds(queryId, offset, limit));
   }
 
 
   @Override
   public ResponseEntity<ResultsetPage> runFqlQuery(String query, UUID entityTypeId, List<String> fields,
-                                                   UUID afterId, Integer limit) {
+                                                   List<String> afterId, Integer limit) {
     return ResponseEntity.ok(queryManagementService.runFqlQuery(query, entityTypeId, fields, afterId, limit));
   }
 

--- a/src/main/java/org/folio/fqm/service/FqlToSqlConverterService.java
+++ b/src/main/java/org/folio/fqm/service/FqlToSqlConverterService.java
@@ -138,9 +138,9 @@ public class FqlToSqlConverterService {
   private static EntityTypeColumn getColumn(FieldCondition<?> fieldCondition, EntityType entityType) {
     return entityType.getColumns()
       .stream()
-      .filter(col -> col.getName().equals(fieldCondition.fieldName()))
+      .filter(col -> col.getName().equals(fieldCondition.field().getColumnName()))
       .findFirst()
-      .orElseThrow(() -> new ColumnNotFoundException(entityType.getName(), fieldCondition.fieldName()));
+      .orElseThrow(() -> new ColumnNotFoundException(entityType.getName(), fieldCondition.field().getColumnName()));
   }
 
   private static boolean isDateCondition(FieldCondition<?> fieldCondition, EntityType entityType) {
@@ -264,7 +264,7 @@ public class FqlToSqlConverterService {
   }
 
   private static Field<Object> field(FieldCondition<?> condition, EntityType entityType) {
-    String columnName = condition.fieldName();
+    String columnName = condition.field().getColumnName();
     return entityType.getColumns()
       .stream()
       .filter(col -> columnName.equals(col.getName()))
@@ -276,10 +276,10 @@ public class FqlToSqlConverterService {
   private static String getColumnDataType(EntityType entityType, FieldCondition<?> fieldCondition) {
     return entityType.getColumns()
       .stream()
-      .filter(col -> fieldCondition.fieldName().equals(col.getName()))
+      .filter(col -> fieldCondition.field().getColumnName().equals(col.getName()))
       .map(col -> col.getDataType().getDataType())
       .findFirst()
-      .orElseThrow(() -> new ColumnNotFoundException(entityType.getName(), fieldCondition.fieldName()));
+      .orElseThrow(() -> new ColumnNotFoundException(entityType.getName(), fieldCondition.field().getColumnName()));
   }
 
   // Suppress the unchecked cast warning on the Class<T> cast below. We need the correct type there in order to get

--- a/src/main/java/org/folio/fqm/service/QueryExecutionCallbacks.java
+++ b/src/main/java/org/folio/fqm/service/QueryExecutionCallbacks.java
@@ -30,7 +30,7 @@ public class QueryExecutionCallbacks {
       idsWithCancelCallback.cancel();
       return;
     }
-    List<UUID> resultIds = idsWithCancelCallback.ids();
+    List<String[]> resultIds = idsWithCancelCallback.ids();
     log.info("Saving query results for queryId: {}. Count: {}", queryId, resultIds.size());
     queryResultsRepository.saveQueryResults(queryId, resultIds);
   }

--- a/src/main/java/org/folio/fqm/service/QueryProcessorService.java
+++ b/src/main/java/org/folio/fqm/service/QueryProcessorService.java
@@ -62,7 +62,6 @@ public class QueryProcessorService {
   /**
    * Process the FQL query and return the results.
    *
-   * @param tenantId     Tenant ID
    * @param entityTypeId Entity type ID
    * @param fqlQuery     FQL query
    * @param fields       fields to return in query results
@@ -72,7 +71,7 @@ public class QueryProcessorService {
    * @param limit        Count of records to be returned.
    * @return Results matching the query
    */
-  public List<Map<String, Object>> processQuery(UUID entityTypeId, String fqlQuery, List<String> fields, UUID afterId, Integer limit) {
+  public List<Map<String, Object>> processQuery(UUID entityTypeId, String fqlQuery, List<String> fields, List<String> afterId, Integer limit) {
     Fql fql = fqlService.getFql(fqlQuery);
     return resultSetRepository.getResultSet(entityTypeId, fql, fields, afterId, limit);
   }

--- a/src/main/java/org/folio/fqm/service/QueryResultsSorterService.java
+++ b/src/main/java/org/folio/fqm/service/QueryResultsSorterService.java
@@ -55,8 +55,8 @@ public class QueryResultsSorterService {
     }
   }
 
-  public List<UUID> getSortedIds(UUID queryId,
-                                 int offset, int limit) {
+  public List<List<String>> getSortedIds(UUID queryId,
+                                         int offset, int limit) {
     log.debug("Getting sorted ids for query {}, offset {}, limit {}", queryId, offset, limit);
     // Sort ids based on the sort criteria defined in the entity type definition
     // Note: This does not sort right now, due to performance concerns. Instead, it just pulls straight from query_results

--- a/src/main/java/org/folio/fqm/utils/IdColumnUtils.java
+++ b/src/main/java/org/folio/fqm/utils/IdColumnUtils.java
@@ -1,0 +1,67 @@
+package org.folio.fqm.utils;
+
+import lombok.experimental.UtilityClass;
+import org.folio.querytool.domain.dto.EntityType;
+import org.folio.querytool.domain.dto.EntityTypeColumn;
+import org.jooq.Field;
+import org.jooq.impl.DSL;
+
+import java.util.List;
+
+import static org.jooq.impl.DSL.field;
+
+/**
+ * Class responsible for retrieving information related to the ID columns of an entity type.
+ */
+@UtilityClass
+public class IdColumnUtils {
+
+  public static final Field<String[]> RESULT_ID_FIELD = field("result_id", String[].class);
+
+  /**
+   * Returns a list of strings corresponding to the names of the id columns of an entity type.
+   *
+   * @param entityType Entity type to extract id column information from
+   * @return List of id column names for the entity type
+   */
+  public static List<String> getIdColumnNames(EntityType entityType) {
+    return entityType
+      .getColumns()
+      .stream()
+      .filter(column -> Boolean.TRUE.equals(column.getIsIdColumn()))
+      .map(EntityTypeColumn::getName)
+      .toList();
+  }
+
+  /**
+   * Returns a list of strings corresponding to the valueGetters for the id columns of an entity type.
+   *
+   * @param entityType Entity type to extract id column information from
+   * @return List of value getters for the id columns of the entity type
+   */
+  public static List<String> getIdColumnValueGetters(EntityType entityType) {
+    return entityType
+      .getColumns()
+      .stream()
+      .filter(column -> Boolean.TRUE.equals(column.getIsIdColumn()))
+      .map(EntityTypeColumn::getValueGetter)
+      .toList();
+  }
+
+  /**
+   * Returns a JOOQ field corresponding to the array of valueGetters for the id columns of an entity type.
+   *
+   * @param entityType Entity type to extract id column information from
+   * @return JOOQ field corresponding to the valueGetters for the id columns of the entity type
+   */
+  public static Field<String[]> getResultIdValueGetter(EntityType entityType) {
+    List<Field<Object>> idColumnValueGetters = getIdColumnValueGetters(entityType)
+      .stream()
+      .map(DSL::field)
+      .toList();
+    return DSL.cast(
+      DSL.array(idColumnValueGetters.toArray(new Field[0])),
+      String[].class
+    );
+  }
+}

--- a/src/main/resources/db/changelog/changes/v1.1.0/changelog-v1.1.0.xml
+++ b/src/main/resources/db/changelog/changes/v1.1.0/changelog-v1.1.0.xml
@@ -19,6 +19,17 @@
   <include file="update-drv-purchase-order-line-details-definition.xml" relativeToChangelogFile="true"/>
   <include file="update-drv-user-details-definition.xml" relativeToChangelogFile="true"/>
   <include file="update-custom-field-entity-type-definition.xml" relativeToChangelogFile="true"/>
+  <include file="update-drv-item-callnumber-location-definition.xml" relativeToChangelogFile="true"/>
+  <include file="update-drv-item-holdingsrecord-instance-definition.xml" relativeToChangelogFile="true"/>
+  <include file="update-src-circulation-loan-policy-definition.xml" relativeToChangelogFile="true"/>
+  <include file="update-src-inventory-call-number-type-definition.xml" relativeToChangelogFile="true"/>
+  <include file="update-src-inventory-location-definition.xml" relativeToChangelogFile="true"/>
+  <include file="update-src-inventory-loclibrary-definition.xml" relativeToChangelogFile="true"/>
+  <include file="update-src-inventory-material-type-definition.xml" relativeToChangelogFile="true"/>
+  <include file="update-src-inventory-service-point-definition.xml" relativeToChangelogFile="true"/>
+  <include file="update-src-users-addresstypes-definition.xml" relativeToChangelogFile="true"/>
+  <include file="update-src-users-departments-definition.xml" relativeToChangelogFile="true"/>
+  <include file="update-src-users-groups-definition.xml" relativeToChangelogFile="true"/>
 
   <changeSet id="create-mat-views-pol-payment-receipt-status" author="bsharp@ebsco.com" runOnChange="true">
     <preConditions onFail="CONTINUE">
@@ -38,5 +49,7 @@
       ALTER TABLE query_results ADD PRIMARY KEY (query_id, result_id);
     </sql>
   </changeSet>
+
+  <include file="update-query-results-table.xml" relativeToChangelogFile="true"/>
 
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.1.0/update-drv-item-callnumber-location-definition.xml
+++ b/src/main/resources/db/changelog/changes/v1.1.0/update-drv-item-callnumber-location-definition.xml
@@ -1,0 +1,245 @@
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+  <changeSet id="update-item-details-callnumber-location-definition" author="bsharp@ebsco.com" runOnChange="true">
+    <update tableName="entity_type_definition">
+      <column name="definition">
+        {
+          "id": "097a6f96-edd0-11ed-a05b-0242ac120003",
+          "name": "drv_item_callnumber_location",
+          "private": true,
+          "fromClause": "src_inventory_item LEFT JOIN src_inventory_location effective_location_ref_data ON effective_location_ref_data.id = src_inventory_item.effectivelocationid LEFT JOIN src_inventory_call_number_type call_number_type_ref_data ON call_number_type_ref_data.id::text = ((src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'typeId'::text) LEFT JOIN src_inventory_call_number_type call_item_number_type_ref_data ON call_item_number_type_ref_data.id::text = (src_inventory_item.jsonb ->> 'itemLevelCallNumberTypeId'::text) LEFT JOIN src_inventory_loclibrary loclib_ref_data ON loclib_ref_data.id = effective_location_ref_data.libraryid LEFT JOIN src_inventory_location permanent_location_ref_data ON permanent_location_ref_data.id = src_inventory_item.permanentlocationid LEFT JOIN src_inventory_material_type material_type_ref_data ON material_type_ref_data.id = src_inventory_item.materialtypeid",
+          "columns": [
+            {
+              "name": "holdings_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_inventory_item.holdingsrecordid",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_barcode",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_inventory_item.jsonb ->> 'barcode'",
+              "visibleByDefault": true
+            },
+            {
+              "name": "item_level_call_number",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_inventory_item.jsonb ->> 'itemLevelCallNumber'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_level_call_number_type_name",
+              "source": {
+                "columnName": "call_number_type_name",
+                "entityTypeId": "5c8315be-13f5-4df5-ae8b-086bae83484d"
+              },
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "idColumnName": "item_level_call_number_typeid",
+              "valueGetter": "call_item_number_type_ref_data.jsonb ->> 'name'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_level_call_number_typeid",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_inventory_item.jsonb ->> 'itemLevelCallNumberTypeId'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_copy_number",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_inventory_item.jsonb ->> 'copyNumber'",
+              "visibleByDefault": true
+            },
+            {
+              "name": "item_created_date",
+              "dataType": {
+                "dataType": "dateType"
+              },
+              "valueGetter": "src_inventory_item.jsonb -> 'metadata' ->> 'createdDate'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_effective_call_number",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "concat_ws(', '::text, NULLIF((src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'prefix'::text, ''::text), NULLIF((src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'callNumber'::text, ''::text), NULLIF((src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'suffix'::text, ''::text), NULLIF(src_inventory_item.jsonb ->> 'copyNumber'::text, ''::text))",
+              "visibleByDefault": true
+            },
+            {
+              "name": "item_effective_call_number_type_name",
+              "source": {
+                "columnName": "call_number_type_name",
+                "entityTypeId": "5c8315be-13f5-4df5-ae8b-086bae83484d"
+              },
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "idColumnName": "item_effective_call_number_typeid",
+              "valueGetter": "call_number_type_ref_data.jsonb ->> 'name'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_effective_call_number_typeid",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_inventory_item.jsonb -> 'effectiveCallNumberComponents' ->> 'typeId'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_effective_library_code",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "loclib_ref_data.jsonb ->> 'code'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_effective_library_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "loclib_ref_data.id",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_effective_library_name",
+              "source": {
+                "columnName": "loclibrary_name",
+                "entityTypeId": "cf9f5c11-e943-483c-913b-81d1e338accc"
+              },
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "idColumnName": "item_effective_library_id",
+              "valueGetter": "loclib_ref_data.jsonb ->> 'name'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_effective_location_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_inventory_item.effectivelocationid",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_effective_location_name",
+              "source": {
+                "columnName": "location_name",
+                "entityTypeId": "a9d6305e-fdb4-4fc4-8a73-4a5f76d8410b"
+              },
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "idColumnName": "item_effective_location_id",
+              "valueGetter": "effective_location_ref_data.jsonb ->> 'name'",
+              "visibleByDefault": true
+            },
+            {
+              "name": "item_hrid",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_inventory_item.jsonb ->> 'hrid'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_inventory_item.id",
+              "isIdColumn": true,
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_material_type",
+              "source": {
+                "columnName": "material_type_name",
+                "entityTypeId": "917ea5c8-cafe-4fa6-a942-e2388a88c6f6"
+              },
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "idColumnName": "item_material_type_id",
+              "valueGetter": "material_type_ref_data.jsonb ->> 'name'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_material_type_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_inventory_item.materialtypeid",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_permanent_location_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_inventory_item.permanentlocationid",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_permanent_location_name",
+              "source": {
+                "columnName": "location_name",
+                "entityTypeId": "a9d6305e-fdb4-4fc4-8a73-4a5f76d8410b"
+              },
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "idColumnName": "item_permanent_location_id",
+              "valueGetter": "permanent_location_ref_data.jsonb ->> 'name'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_status",
+              "source": {
+                "columnName": "item_status",
+                "entityTypeId": "a1a37288-1afe-4fa5-ab59-a5bcf5d8ca2d"
+              },
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_inventory_item.jsonb -> 'status' ->> 'name'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_updated_date",
+              "dataType": {
+                "dataType": "dateType"
+              },
+              "valueGetter": "src_inventory_item.jsonb -> 'metadata' ->> 'updatedDate'",
+              "visibleByDefault": false
+            }
+          ],
+          "defaultSort": [
+            {
+              "direction": "ASC",
+              "columnName": "id"
+            }
+          ]
+        }
+      </column>
+      <where>id = '097a6f96-edd0-11ed-a05b-0242ac120003'</where>
+    </update>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.1.0/update-drv-item-details-definition.xml
+++ b/src/main/resources/db/changelog/changes/v1.1.0/update-drv-item-details-definition.xml
@@ -235,6 +235,7 @@
                 "dataType": "rangedUUIDType"
               },
               "valueGetter": "src_inventory_item.id",
+              "isIdColumn": true,
               "visibleByDefault": false
             },
             {

--- a/src/main/resources/db/changelog/changes/v1.1.0/update-drv-item-holdingsrecord-instance-definition.xml
+++ b/src/main/resources/db/changelog/changes/v1.1.0/update-drv-item-holdingsrecord-instance-definition.xml
@@ -1,0 +1,199 @@
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+  <changeSet id="update-item-holdingsrecord-instance-entity-type-definition" author="bsharp@ebsco.com" runOnChange="true">
+    <update tableName="entity_type_definition">
+      <column name="definition">
+        {
+          "id": "0cb79a4c-f7eb-4941-a104-745224ae0293",
+          "name": "drv_item_holdingsrecord_instance",
+          "private": true,
+          "fromClause": "src_inventory_item JOIN src_inventory_holdings_record hrim ON src_inventory_item.holdingsrecordid = hrim.id JOIN src_inventory_instance instance_details ON hrim.instanceid = instance_details.id",
+          "columns": [
+            {
+              "name": "holdings_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_inventory_item.holdingsrecordid",
+              "visibleByDefault": false
+            },
+            {
+              "name": "instance_created_date",
+              "dataType": {
+                "dataType": "dateType"
+              },
+              "valueGetter": "instance_details.jsonb -> 'metadata' ->> 'createdDate'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "instance_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "hrim.instanceid",
+              "visibleByDefault": false
+            },
+            {
+              "name": "instance_primary_contributor",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "jsonb_path_query_first(instance_details.jsonb, '$.\"contributors\"[*]?(@.\"primary\" == true).\"name\"'::jsonpath) #>> '{}'::text[]",
+              "visibleByDefault": false
+            },
+            {
+              "name": "instance_title",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "instance_details.jsonb ->> 'title'",
+              "visibleByDefault": true
+            },
+            {
+              "name": "instance_updated_date",
+              "dataType": {
+                "dataType": "dateType"
+              },
+              "valueGetter": "instance_details.jsonb -> 'metadata' ->> 'updatedDate'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_barcode",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_inventory_item.jsonb ->> 'barcode'",
+              "visibleByDefault": true
+            },
+            {
+              "name": "item_level_call_number",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_inventory_item.jsonb ->> 'itemLevelCallNumber'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_level_call_number_typeid",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_inventory_item.jsonb ->> 'itemLevelCallNumberTypeId'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_copy_number",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_inventory_item.jsonb ->> 'copyNumber'",
+              "visibleByDefault": true
+            },
+            {
+              "name": "item_created_date",
+              "dataType": {
+                "dataType": "dateType"
+              },
+              "valueGetter": "src_inventory_item.jsonb -> 'metadata' ->> 'createdDate'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_effective_call_number",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "concat_ws(', '::text, NULLIF((src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'prefix'::text, ''::text), NULLIF((src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'callNumber'::text, ''::text), NULLIF((src_inventory_item.jsonb -> 'effectiveCallNumberComponents'::text) ->> 'suffix'::text, ''::text), NULLIF(src_inventory_item.jsonb ->> 'copyNumber'::text, ''::text))",
+              "visibleByDefault": true
+            },
+            {
+              "name": "item_effective_call_number_typeid",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_inventory_item.jsonb -> 'effectiveCallNumberComponents' ->> 'typeId'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_effective_location_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_inventory_item.effectivelocationid",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_hrid",
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_inventory_item.jsonb ->> 'hrid'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_inventory_item.id",
+              "isIdColumn": true,
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_material_type_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_inventory_item.materialtypeid",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_permanent_location_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_inventory_item.permanentlocationid",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_status",
+              "source": {
+                "columnName": "item_status",
+                "entityTypeId": "a1a37288-1afe-4fa5-ab59-a5bcf5d8ca2d"
+              },
+              "dataType": {
+                "dataType": "stringType"
+              },
+              "valueGetter": "src_inventory_item.jsonb -> 'status' ->> 'name'",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_temporary_location_id",
+              "dataType": {
+                "dataType": "rangedUUIDType"
+              },
+              "valueGetter": "src_inventory_item.temporarylocationid",
+              "visibleByDefault": false
+            },
+            {
+              "name": "item_updated_date",
+              "dataType": {
+                "dataType": "dateType"
+              },
+              "valueGetter": "src_inventory_item.jsonb -> 'metadata' ->> 'updatedDate'",
+              "visibleByDefault": false
+            }
+          ],
+          "defaultSort": [
+            {
+              "direction": "ASC",
+              "columnName": "id"
+            }
+          ]
+        }
+      </column>
+      <where>id = '0cb79a4c-f7eb-4941-a104-745224ae0293'</where>
+    </update>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.1.0/update-drv-loan-details-definition.xml
+++ b/src/main/resources/db/changelog/changes/v1.1.0/update-drv-loan-details-definition.xml
@@ -201,6 +201,7 @@
                 "dataType": "rangedUUIDType"
               },
               "valueGetter": "src_circulation_loan.id",
+              "isIdColumn": true,
               "visibleByDefault": false
             },
             {

--- a/src/main/resources/db/changelog/changes/v1.1.0/update-drv-purchase-order-line-details-definition.xml
+++ b/src/main/resources/db/changelog/changes/v1.1.0/update-drv-purchase-order-line-details-definition.xml
@@ -94,6 +94,7 @@
                 "dataType": "rangedUUIDType"
               },
               "valueGetter": "src_purchase_order_line.id",
+              "isIdColumn": true,
               "visibleByDefault": true
             },
             {

--- a/src/main/resources/db/changelog/changes/v1.1.0/update-drv-user-details-definition.xml
+++ b/src/main/resources/db/changelog/changes/v1.1.0/update-drv-user-details-definition.xml
@@ -218,6 +218,7 @@
                 "dataType":"rangedUUIDType"
               },
               "valueGetter": "src_users_users.id",
+              "isIdColumn": true,
               "visibleByDefault": true
             },
             {

--- a/src/main/resources/db/changelog/changes/v1.1.0/update-query-results-table.xml
+++ b/src/main/resources/db/changelog/changes/v1.1.0/update-query-results-table.xml
@@ -1,0 +1,16 @@
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+  <changeSet id="MODFQMMGR-137" author="bsharp@ebsco.com">
+    <comment>Update result_id column from UUID to string array</comment>
+    <sql>
+      ALTER TABLE query_results DROP CONSTRAINT IF EXISTS query_results_pkey;
+      ALTER TABLE query_results ADD COLUMN new_result_id text[];
+      UPDATE query_results SET new_result_id = ARRAY[result_id];
+      ALTER TABLE query_results DROP COLUMN result_id;
+      ALTER TABLE query_results RENAME COLUMN new_result_id TO result_id;
+      ALTER TABLE query_results ADD PRIMARY KEY (query_id, result_id);
+    </sql>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.1.0/update-src-acquisitions-unit-definition.xml
+++ b/src/main/resources/db/changelog/changes/v1.1.0/update-src-acquisitions-unit-definition.xml
@@ -2,7 +2,7 @@
                    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
-  <changeSet id="update-src-acquisitions-unit-definition" author="bsharp@ebsco.com">
+  <changeSet id="update-src-acquisitions-unit-definition" author="bsharp@ebsco.com" runOnChange="true">
     <update tableName="entity_type_definition">
       <column name="definition">
         {
@@ -17,6 +17,7 @@
                 "dataType": "rangedUUIDType"
               },
               "valueGetter": "src_acquisitions_unit.id",
+              "isIdColumn": true,
               "visibleByDefault": true
             },
             {

--- a/src/main/resources/db/changelog/changes/v1.1.0/update-src-circulation-loan-policy-definition.xml
+++ b/src/main/resources/db/changelog/changes/v1.1.0/update-src-circulation-loan-policy-definition.xml
@@ -2,45 +2,37 @@
                    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
-  <changeSet id="update-src-organizations-definition" author="bsharp@ebsco.com" runOnChange="true">
+  <changeSet id="update-src-circulation-loan-policy-definition" author="bsharp@ebsco.com" runOnChange="true">
     <update tableName="entity_type_definition">
       <column name="definition">
         {
-          "id": "489234a9-8703-48cd-85e3-7f84011bafa3",
-          "name": "src_organizations",
+          "id": "5e7de445-bcc6-4008-8032-8d9602b854d7",
+          "name": "src_circulation_loan_policy",
           "root": true,
-          "fromClause": "src_organizations",
+          "fromClause": "src_circulation_loan_policy",
           "columns": [
             {
               "name": "id",
               "dataType": {
                 "dataType": "rangedUUIDType"
               },
-              "valueGetter": "src_organizations.id",
+              "valueGetter": "src_circulation_loan_policy.id",
               "isIdColumn": true,
               "visibleByDefault": true
             },
             {
-              "name": "vendor_name",
+              "name": "policy_name",
               "dataType": {
                 "dataType": "stringType"
               },
-              "valueGetter": "src_organizations.jsonb ->> 'name'",
-              "visibleByDefault": true
-            },
-            {
-              "name": "vendor_code",
-              "dataType": {
-                "dataType": "stringType"
-              },
-              "valueGetter": "src_organizations.jsonb ->> 'code'",
+              "valueGetter": "src_circulation_loan_policy.jsonb ->> 'name'",
               "visibleByDefault": true
             }
           ],
           "private": true
         }
       </column>
-      <where>id = '489234a9-8703-48cd-85e3-7f84011bafa3'</where>
+      <where>id = '5e7de445-bcc6-4008-8032-8d9602b854d7'</where>
     </update>
   </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.1.0/update-src-inventory-call-number-type-definition.xml
+++ b/src/main/resources/db/changelog/changes/v1.1.0/update-src-inventory-call-number-type-definition.xml
@@ -2,45 +2,37 @@
                    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
-  <changeSet id="update-src-organizations-definition" author="bsharp@ebsco.com" runOnChange="true">
+  <changeSet id="update-src-inventory-call-number-type-definition" author="bsharp@ebsco.com" runOnChange="true">
     <update tableName="entity_type_definition">
       <column name="definition">
         {
-          "id": "489234a9-8703-48cd-85e3-7f84011bafa3",
-          "name": "src_organizations",
+          "id": "5c8315be-13f5-4df5-ae8b-086bae83484d",
+          "name": "src_inventory_call_number_type",
           "root": true,
-          "fromClause": "src_organizations",
+          "fromClause": "src_inventory_call_number_type",
           "columns": [
             {
               "name": "id",
               "dataType": {
                 "dataType": "rangedUUIDType"
               },
-              "valueGetter": "src_organizations.id",
+              "valueGetter": "src_inventory_call_number_type.id",
               "isIdColumn": true,
               "visibleByDefault": true
             },
             {
-              "name": "vendor_name",
+              "name": "call_number_type_name",
               "dataType": {
                 "dataType": "stringType"
               },
-              "valueGetter": "src_organizations.jsonb ->> 'name'",
-              "visibleByDefault": true
-            },
-            {
-              "name": "vendor_code",
-              "dataType": {
-                "dataType": "stringType"
-              },
-              "valueGetter": "src_organizations.jsonb ->> 'code'",
+              "valueGetter": "src_inventory_call_number_type.jsonb ->> 'name'",
               "visibleByDefault": true
             }
           ],
           "private": true
         }
       </column>
-      <where>id = '489234a9-8703-48cd-85e3-7f84011bafa3'</where>
+      <where>id = '5c8315be-13f5-4df5-ae8b-086bae83484d'</where>
     </update>
   </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.1.0/update-src-inventory-location-definition.xml
+++ b/src/main/resources/db/changelog/changes/v1.1.0/update-src-inventory-location-definition.xml
@@ -2,45 +2,45 @@
                    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
-  <changeSet id="update-src-organizations-definition" author="bsharp@ebsco.com" runOnChange="true">
+  <changeSet id="update-src-inventory-location-definition" author="bsharp@ebsco.com" runOnChange="true">
     <update tableName="entity_type_definition">
       <column name="definition">
         {
-          "id": "489234a9-8703-48cd-85e3-7f84011bafa3",
-          "name": "src_organizations",
+          "id": "a9d6305e-fdb4-4fc4-8a73-4a5f76d8410b",
+          "name": "src_inventory_location",
           "root": true,
-          "fromClause": "src_organizations",
+          "fromClause": "src_inventory_location",
           "columns": [
             {
               "name": "id",
               "dataType": {
                 "dataType": "rangedUUIDType"
               },
-              "valueGetter": "src_organizations.id",
+              "valueGetter": "src_inventory_location.id",
               "isIdColumn": true,
               "visibleByDefault": true
             },
             {
-              "name": "vendor_name",
+              "name": "location_name",
               "dataType": {
                 "dataType": "stringType"
               },
-              "valueGetter": "src_organizations.jsonb ->> 'name'",
+              "valueGetter": "src_inventory_location.jsonb ->> 'name'",
               "visibleByDefault": true
             },
             {
-              "name": "vendor_code",
+              "name": "location_code",
               "dataType": {
                 "dataType": "stringType"
               },
-              "valueGetter": "src_organizations.jsonb ->> 'code'",
+              "valueGetter": "src_inventory_location.jsonb ->> 'code'",
               "visibleByDefault": true
             }
           ],
           "private": true
         }
       </column>
-      <where>id = '489234a9-8703-48cd-85e3-7f84011bafa3'</where>
+      <where>id = 'a9d6305e-fdb4-4fc4-8a73-4a5f76d8410b'</where>
     </update>
   </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.1.0/update-src-inventory-loclibrary-definition.xml
+++ b/src/main/resources/db/changelog/changes/v1.1.0/update-src-inventory-loclibrary-definition.xml
@@ -2,45 +2,45 @@
                    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
-  <changeSet id="update-src-organizations-definition" author="bsharp@ebsco.com" runOnChange="true">
+  <changeSet id="update-src-inventory-loclibrary-definition" author="bsharp@ebsco.com" runOnChange="true">
     <update tableName="entity_type_definition">
       <column name="definition">
         {
-          "id": "489234a9-8703-48cd-85e3-7f84011bafa3",
-          "name": "src_organizations",
+          "id": "cf9f5c11-e943-483c-913b-81d1e338accc",
+          "name": "src_inventory_loclibrary",
           "root": true,
-          "fromClause": "src_organizations",
+          "fromClause": "src_inventory_loclibrary",
           "columns": [
             {
               "name": "id",
               "dataType": {
                 "dataType": "rangedUUIDType"
               },
-              "valueGetter": "src_organizations.id",
+              "valueGetter": "src_inventory_loclibrary.id",
               "isIdColumn": true,
               "visibleByDefault": true
             },
             {
-              "name": "vendor_name",
+              "name": "loclibrary_name",
               "dataType": {
                 "dataType": "stringType"
               },
-              "valueGetter": "src_organizations.jsonb ->> 'name'",
+              "valueGetter": "src_inventory_loclibrary.jsonb ->> 'name'",
               "visibleByDefault": true
             },
             {
-              "name": "vendor_code",
+              "name": "loclibrary_code",
               "dataType": {
                 "dataType": "stringType"
               },
-              "valueGetter": "src_organizations.jsonb ->> 'code'",
+              "valueGetter": "src_inventory_loclibrary.jsonb ->> 'code'",
               "visibleByDefault": true
             }
           ],
           "private": true
         }
       </column>
-      <where>id = '489234a9-8703-48cd-85e3-7f84011bafa3'</where>
+      <where>id = 'cf9f5c11-e943-483c-913b-81d1e338accc'</where>
     </update>
   </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.1.0/update-src-inventory-material-type-definition.xml
+++ b/src/main/resources/db/changelog/changes/v1.1.0/update-src-inventory-material-type-definition.xml
@@ -2,45 +2,37 @@
                    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
-  <changeSet id="update-src-organizations-definition" author="bsharp@ebsco.com" runOnChange="true">
+  <changeSet id="update-src-inventory-material-type-definition" author="bsharp@ebsco.com" runOnChange="true">
     <update tableName="entity_type_definition">
       <column name="definition">
         {
-          "id": "489234a9-8703-48cd-85e3-7f84011bafa3",
-          "name": "src_organizations",
+          "id": "917ea5c8-cafe-4fa6-a942-e2388a88c6f6",
+          "name": "src_inventory_material_type",
           "root": true,
-          "fromClause": "src_organizations",
+          "fromClause": "src_inventory_material_type",
           "columns": [
             {
               "name": "id",
               "dataType": {
                 "dataType": "rangedUUIDType"
               },
-              "valueGetter": "src_organizations.id",
+              "valueGetter": "src_inventory_material_type.id",
               "isIdColumn": true,
               "visibleByDefault": true
             },
             {
-              "name": "vendor_name",
+              "name": "material_type_name",
               "dataType": {
                 "dataType": "stringType"
               },
-              "valueGetter": "src_organizations.jsonb ->> 'name'",
-              "visibleByDefault": true
-            },
-            {
-              "name": "vendor_code",
-              "dataType": {
-                "dataType": "stringType"
-              },
-              "valueGetter": "src_organizations.jsonb ->> 'code'",
+              "valueGetter": "src_inventory_material_type.jsonb ->> 'name'",
               "visibleByDefault": true
             }
           ],
           "private": true
         }
       </column>
-      <where>id = '489234a9-8703-48cd-85e3-7f84011bafa3'</where>
+      <where>id = '917ea5c8-cafe-4fa6-a942-e2388a88c6f6'</where>
     </update>
   </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.1.0/update-src-inventory-service-point-definition.xml
+++ b/src/main/resources/db/changelog/changes/v1.1.0/update-src-inventory-service-point-definition.xml
@@ -2,45 +2,45 @@
                    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
-  <changeSet id="update-src-organizations-definition" author="bsharp@ebsco.com" runOnChange="true">
+  <changeSet id="update-src-inventory-service-point-definition" author="bsharp@ebsco.com" runOnChange="true">
     <update tableName="entity_type_definition">
       <column name="definition">
         {
-          "id": "489234a9-8703-48cd-85e3-7f84011bafa3",
-          "name": "src_organizations",
+          "id": "89cdeac4-9582-4388-800b-9ccffd8d7691",
+          "name": "src_inventory_service_point",
           "root": true,
-          "fromClause": "src_organizations",
+          "fromClause": "src_inventory_service_point",
           "columns": [
             {
               "name": "id",
               "dataType": {
                 "dataType": "rangedUUIDType"
               },
-              "valueGetter": "src_organizations.id",
+              "valueGetter": "src_inventory_service_point.id",
               "isIdColumn": true,
               "visibleByDefault": true
             },
             {
-              "name": "vendor_name",
+              "name": "service_point_name",
               "dataType": {
                 "dataType": "stringType"
               },
-              "valueGetter": "src_organizations.jsonb ->> 'name'",
+              "valueGetter": "src_inventory_service_point.jsonb ->> 'name'",
               "visibleByDefault": true
             },
             {
-              "name": "vendor_code",
+              "name": "service_point_code",
               "dataType": {
                 "dataType": "stringType"
               },
-              "valueGetter": "src_organizations.jsonb ->> 'code'",
+              "valueGetter": "src_inventory_service_point.jsonb ->> 'code'",
               "visibleByDefault": true
             }
           ],
           "private": true
         }
       </column>
-      <where>id = '489234a9-8703-48cd-85e3-7f84011bafa3'</where>
+      <where>id = '89cdeac4-9582-4388-800b-9ccffd8d7691'</where>
     </update>
   </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.1.0/update-src-users-addresstypes-definition.xml
+++ b/src/main/resources/db/changelog/changes/v1.1.0/update-src-users-addresstypes-definition.xml
@@ -2,45 +2,37 @@
                    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
-  <changeSet id="update-src-organizations-definition" author="bsharp@ebsco.com" runOnChange="true">
+  <changeSet id="update-src-users-addresstypes-definition" author="bsharp@ebsco.com" runOnChange="true">
     <update tableName="entity_type_definition">
       <column name="definition">
         {
-          "id": "489234a9-8703-48cd-85e3-7f84011bafa3",
-          "name": "src_organizations",
+          "id": "e627a89b-682b-41fe-b532-f4262020a451",
+          "name": "src_users_addresstype",
           "root": true,
-          "fromClause": "src_organizations",
+          "fromClause": "src_users_addresstype",
           "columns": [
             {
               "name": "id",
               "dataType": {
                 "dataType": "rangedUUIDType"
               },
-              "valueGetter": "src_organizations.id",
+              "valueGetter": "src_users_addresstype.id",
               "isIdColumn": true,
               "visibleByDefault": true
             },
             {
-              "name": "vendor_name",
+              "name": "addressType",
               "dataType": {
                 "dataType": "stringType"
               },
-              "valueGetter": "src_organizations.jsonb ->> 'name'",
-              "visibleByDefault": true
-            },
-            {
-              "name": "vendor_code",
-              "dataType": {
-                "dataType": "stringType"
-              },
-              "valueGetter": "src_organizations.jsonb ->> 'code'",
+              "valueGetter": "src_users_addresstype.jsonb ->> 'addressType'",
               "visibleByDefault": true
             }
           ],
           "private": true
         }
       </column>
-      <where>id = '489234a9-8703-48cd-85e3-7f84011bafa3'</where>
+      <where>id = 'e627a89b-682b-41fe-b532-f4262020a451'</where>
     </update>
   </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.1.0/update-src-users-departments-definition.xml
+++ b/src/main/resources/db/changelog/changes/v1.1.0/update-src-users-departments-definition.xml
@@ -2,45 +2,37 @@
                    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
-  <changeSet id="update-src-organizations-definition" author="bsharp@ebsco.com" runOnChange="true">
+  <changeSet id="update-src-users-departments-definition" author="bsharp@ebsco.com" runOnChange="true">
     <update tableName="entity_type_definition">
       <column name="definition">
         {
-          "id": "489234a9-8703-48cd-85e3-7f84011bafa3",
-          "name": "src_organizations",
+          "id": "c8364551-7e51-475d-8473-88951181452d",
+          "name": "src_users_departments",
           "root": true,
-          "fromClause": "src_organizations",
+          "fromClause": "src_users_departments",
           "columns": [
             {
               "name": "id",
               "dataType": {
                 "dataType": "rangedUUIDType"
               },
-              "valueGetter": "src_organizations.id",
+              "valueGetter": "src_users_departments.id",
               "isIdColumn": true,
               "visibleByDefault": true
             },
             {
-              "name": "vendor_name",
+              "name": "department",
               "dataType": {
                 "dataType": "stringType"
               },
-              "valueGetter": "src_organizations.jsonb ->> 'name'",
-              "visibleByDefault": true
-            },
-            {
-              "name": "vendor_code",
-              "dataType": {
-                "dataType": "stringType"
-              },
-              "valueGetter": "src_organizations.jsonb ->> 'code'",
+              "valueGetter": "src_users_departments.jsonb ->> 'name'",
               "visibleByDefault": true
             }
           ],
           "private": true
         }
       </column>
-      <where>id = '489234a9-8703-48cd-85e3-7f84011bafa3'</where>
+      <where>id = 'c8364551-7e51-475d-8473-88951181452d'</where>
     </update>
   </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.1.0/update-src-users-groups-definition.xml
+++ b/src/main/resources/db/changelog/changes/v1.1.0/update-src-users-groups-definition.xml
@@ -2,45 +2,37 @@
                    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
-  <changeSet id="update-src-organizations-definition" author="bsharp@ebsco.com" runOnChange="true">
+  <changeSet id="update-src-users-groups-definition" author="bsharp@ebsco.com" runOnChange="true">
     <update tableName="entity_type_definition">
       <column name="definition">
         {
-          "id": "489234a9-8703-48cd-85e3-7f84011bafa3",
-          "name": "src_organizations",
+          "id": "e611264d-377e-4d87-a93f-f1ca327d3db0",
+          "name": "src_users_groups",
           "root": true,
-          "fromClause": "src_organizations",
+          "fromClause": "src_users_groups",
           "columns": [
             {
               "name": "id",
               "dataType": {
                 "dataType": "rangedUUIDType"
               },
-              "valueGetter": "src_organizations.id",
+              "valueGetter": "src_users_groups.id",
               "isIdColumn": true,
               "visibleByDefault": true
             },
             {
-              "name": "vendor_name",
+              "name": "group",
               "dataType": {
                 "dataType": "stringType"
               },
-              "valueGetter": "src_organizations.jsonb ->> 'name'",
-              "visibleByDefault": true
-            },
-            {
-              "name": "vendor_code",
-              "dataType": {
-                "dataType": "stringType"
-              },
-              "valueGetter": "src_organizations.jsonb ->> 'code'",
+              "valueGetter": "src_users_groups.jsonb ->> 'group'",
               "visibleByDefault": true
             }
           ],
           "private": true
         }
       </column>
-      <where>id = '489234a9-8703-48cd-85e3-7f84011bafa3'</where>
+      <where>id = 'e611264d-377e-4d87-a93f-f1ca327d3db0'</where>
     </update>
   </changeSet>
 </databaseChangeLog>

--- a/src/test/java/org/folio/fqm/controller/FqlQueryControllerTest.java
+++ b/src/test/java/org/folio/fqm/controller/FqlQueryControllerTest.java
@@ -183,7 +183,8 @@ class FqlQueryControllerTest {
   @Test
   void shouldRunSynchronousQueryWithOptionalParametersAndReturnResults() throws Exception {
     UUID entityTypeId = UUID.randomUUID();
-    UUID afterId = UUID.randomUUID();
+    UUID afterUUID = UUID.randomUUID();
+    List<String> afterId = List.of(afterUUID.toString());
     String fqlQuery = """
                       {"field1": {"$in": ["value1", "value2", "value3", "value4", "value5" ] }}
                       """;
@@ -203,7 +204,7 @@ class FqlQueryControllerTest {
       .queryParam("query", fqlQuery)
       .queryParam("entityTypeId", entityTypeId.toString())
       .queryParam("fields", fields)
-      .queryParam("afterId", afterId.toString())
+      .queryParam("afterId", afterUUID.toString())
       .queryParam("limit", limit.toString());
     mockMvc.perform(builder)
       .andExpect(status().isOk())
@@ -275,7 +276,10 @@ class FqlQueryControllerTest {
     UUID queryId = UUID.randomUUID();
     Integer offset = 0;
     Integer limit = 100;
-    List<UUID> expectedIds = List.of(UUID.randomUUID(), UUID.randomUUID());
+    List<List<String>> expectedIds = List.of(
+      List.of(UUID.randomUUID().toString()),
+      List.of(UUID.randomUUID().toString())
+    );
     when(queryManagementService.getSortedIds(queryId, offset, limit)).thenReturn(expectedIds);
     RequestBuilder builder = get("/query/" + queryId + "/sortedIds").contentType(MediaType.APPLICATION_JSON)
       .header(XOkapiHeaders.TENANT, TENANT_ID)
@@ -283,8 +287,8 @@ class FqlQueryControllerTest {
       .queryParam("limit", limit.toString());
     mockMvc.perform(builder)
       .andExpect(status().isOk())
-      .andExpect(jsonPath("$.[0]", is(expectedIds.get(0).toString())))
-      .andExpect(jsonPath("$.[1]", is(expectedIds.get(1).toString())));
+      .andExpect(jsonPath("$.[0]", is(expectedIds.get(0))))
+      .andExpect(jsonPath("$.[1]", is(expectedIds.get(1))));
   }
 
   @Test
@@ -307,7 +311,10 @@ class FqlQueryControllerTest {
     UUID id1 = UUID.randomUUID();
     UUID id2 = UUID.randomUUID();
     List<String> fields = List.of("id", "field1", "field2");
-    List<UUID> ids = List.of(id1, id2);
+    List<List<String>> ids = List.of(
+      List.of(id1.toString()),
+      List.of(id2.toString())
+    );
     ContentsRequest contentsRequest = new ContentsRequest().entityTypeId(entityTypeId)
       .fields(fields)
       .ids(ids);
@@ -336,7 +343,10 @@ class FqlQueryControllerTest {
     UUID id1 = UUID.randomUUID();
     UUID id2 = UUID.randomUUID();
     List<String> fields = List.of("id", "field1", "field2");
-    List<UUID> ids = List.of(id1, id2);
+    List<List<String>> ids = List.of(
+      List.of(id1.toString()),
+      List.of(id2.toString())
+    );
     ContentsRequest contentsRequest = new ContentsRequest().entityTypeId(entityTypeId)
       .fields(fields)
       .ids(ids);
@@ -354,7 +364,10 @@ class FqlQueryControllerTest {
     UUID id1 = UUID.randomUUID();
     UUID id2 = UUID.randomUUID();
     List<String> fields = List.of("id", "field1", "field2");
-    List<UUID> ids = List.of(id1, id2);
+    List<List<String>> ids = List.of(
+      List.of(id1.toString()),
+      List.of(id2.toString())
+    );
     ContentsRequest contentsRequest = new ContentsRequest().fields(fields)
       .ids(ids);
     RequestBuilder builder = post("/query/contents").contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/org/folio/fqm/repository/QueryResultsRepositoryTest.java
+++ b/src/test/java/org/folio/fqm/repository/QueryResultsRepositoryTest.java
@@ -8,6 +8,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -31,12 +32,17 @@ class QueryResultsRepositoryTest {
       """;
     List<String> fields = List.of("id", "field1");
     UUID queryId = UUID.randomUUID();
-    List<UUID> expectedResultIds = List.of(UUID.randomUUID(), UUID.randomUUID());
+    List<List<String>> expectedResultIds = List.of(
+      List.of(UUID.randomUUID().toString()),
+      List.of(UUID.randomUUID().toString())
+    );
+    List<String[]> expectedResultIdArray = new ArrayList<>();
+    expectedResultIds.forEach(id -> expectedResultIdArray.add(id.toArray(new String[0])));
     Query query = new Query(queryId, UUID.randomUUID(), fqlQuery, fields,
       UUID.randomUUID(), OffsetDateTime.now(), null, QueryStatus.IN_PROGRESS, null);
     queryRepository.saveQuery(query);
-    queryResultsRepository.saveQueryResults(queryId, expectedResultIds);
-    List<UUID> actualResultIds = queryResultsRepository.getQueryResultIds(queryId, 0, 100);
+    queryResultsRepository.saveQueryResults(queryId, expectedResultIdArray);
+    List<List<String>> actualResultIds = queryResultsRepository.getQueryResultIds(queryId, 0, 100);
     assertThat(expectedResultIds).containsExactlyInAnyOrderElementsOf(actualResultIds);
   }
 
@@ -47,7 +53,10 @@ class QueryResultsRepositoryTest {
       """;
     List<String> fields = List.of("id", "field1");
     UUID queryId = UUID.randomUUID();
-    List<UUID> resultIds = List.of(UUID.randomUUID(), UUID.randomUUID());
+    List<String[]> resultIds = List.of(
+      new String[]{UUID.randomUUID().toString()},
+      new String[]{UUID.randomUUID().toString()}
+    );
     Query mockQuery = new Query(queryId, UUID.randomUUID(), fqlQuery, fields,
       UUID.randomUUID(), OffsetDateTime.now(), null, QueryStatus.IN_PROGRESS, null);
     queryRepository.saveQuery(mockQuery);
@@ -63,7 +72,10 @@ class QueryResultsRepositoryTest {
       """;
     List<String> fields = List.of("id", "field1");
     UUID queryId = UUID.randomUUID();
-    List<UUID> resultIds = List.of(UUID.randomUUID(), UUID.randomUUID());
+    List<String[]> resultIds = List.of(
+      new String[]{UUID.randomUUID().toString()},
+      new String[]{UUID.randomUUID().toString()}
+    );
     Query mockQuery = new Query(queryId, UUID.randomUUID(), fqlQuery, fields,
       UUID.randomUUID(), OffsetDateTime.now(), null, QueryStatus.IN_PROGRESS, null);
     queryRepository.saveQuery(mockQuery);

--- a/src/test/java/org/folio/fqm/repository/ResultSetRepositoryArrayTest.java
+++ b/src/test/java/org/folio/fqm/repository/ResultSetRepositoryArrayTest.java
@@ -33,7 +33,9 @@ class ResultSetRepositoryArrayTest {
 
   @Test
   void getResultSetShouldHandleArray() {
-    List<UUID> listIds = List.of(UUID.randomUUID());
+    List<List<String>> listIds = List.of(
+      List.of(UUID.randomUUID().toString())
+    );
     List<String> fields = List.of("id", "testField");
     List<Map<String, Object>> expectedFullList = ResultSetRepositoryArrayTestDataProvider.TEST_ENTITY_WITH_ARRAY_CONTENTS;
     List<Map<String, Object>> expectedList = List.of(

--- a/src/test/java/org/folio/fqm/repository/ResultSetRepositoryArrayTestDataProvider.java
+++ b/src/test/java/org/folio/fqm/repository/ResultSetRepositoryArrayTestDataProvider.java
@@ -6,6 +6,7 @@ import lombok.SneakyThrows;
 import org.folio.querytool.domain.dto.EntityDataType;
 import org.folio.querytool.domain.dto.EntityType;
 import org.folio.querytool.domain.dto.EntityTypeColumn;
+import org.folio.querytool.domain.dto.RangedUUIDType;
 import org.jooq.*;
 import org.jooq.Record;
 import org.jooq.impl.DSL;
@@ -38,7 +39,7 @@ public class ResultSetRepositoryArrayTestDataProvider implements MockDataProvide
 
   private static final EntityType ARRAY_ENTITY_TYPE = new EntityType()
     .columns(List.of(
-      new EntityTypeColumn().name(ID_FIELD_NAME),
+      new EntityTypeColumn().name(ID_FIELD_NAME).dataType(new RangedUUIDType().dataType("rangedUUIDType")).valueGetter(ID_FIELD_NAME).isIdColumn(true),
       new EntityTypeColumn().name("testField").dataType(new EntityDataType().dataType("arrayType"))
     ))
     .name("TEST_ARRAY_ENTITY_TYPE")

--- a/src/test/java/org/folio/fqm/repository/ResultSetRepositoryTest.java
+++ b/src/test/java/org/folio/fqm/repository/ResultSetRepositoryTest.java
@@ -2,6 +2,7 @@ package org.folio.fqm.repository;
 
 import org.folio.fql.model.EqualsCondition;
 import org.folio.fql.model.Fql;
+import org.folio.fql.model.field.FqlField;
 import org.jooq.DSLContext;
 import org.jooq.SQLDialect;
 import org.jooq.impl.DSL;
@@ -35,7 +36,10 @@ class ResultSetRepositoryTest {
 
   @Test
   void getResultSetWithNullFieldsShouldReturnEmptyList() {
-    List<UUID> listIds = List.of(UUID.randomUUID(), UUID.randomUUID());
+    List<List<String>> listIds = List.of(
+      List.of(UUID.randomUUID().toString()),
+      List.of(UUID.randomUUID().toString())
+    );
     List<Map<String, Object>> expectedList = List.of();
     List<Map<String, Object>> actualList = repo.getResultSet(UUID.randomUUID(), null, listIds);
     assertEquals(expectedList, actualList);
@@ -43,7 +47,10 @@ class ResultSetRepositoryTest {
 
   @Test
   void getResultSetWithEmptyFieldsShouldEmptyList() {
-    List<UUID> listIds = List.of(UUID.randomUUID(), UUID.randomUUID());
+    List<List<String>> listIds = List.of(
+      List.of(UUID.randomUUID().toString()),
+      List.of(UUID.randomUUID().toString())
+    );
     List<String> fields = List.of();
     List<Map<String, Object>> expectedList = List.of();
     List<Map<String, Object>> actualList = repo.getResultSet(UUID.randomUUID(), fields, listIds);
@@ -52,7 +59,11 @@ class ResultSetRepositoryTest {
 
   @Test
   void getResultSetShouldReturnResultsWithRequestedFields() {
-    List<UUID> listIds = List.of(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
+    List<List<String>> listIds = List.of(
+      List.of(UUID.randomUUID().toString()),
+      List.of(UUID.randomUUID().toString()),
+      List.of(UUID.randomUUID().toString())
+    );
     List<String> fields = List.of("id", "key1");
     List<Map<String, Object>> expectedFullList = ResultSetRepositoryTestDataProvider.TEST_ENTITY_CONTENTS;
     // Since we are only asking for "id" and "key2" fields, create expected list without key1 included
@@ -68,9 +79,9 @@ class ResultSetRepositoryTest {
   @Test
   void shouldRunSynchronousQueryAndReturnContents() {
     UUID entityTypeId = UUID.randomUUID();
-    UUID afterId = UUID.randomUUID();
+    List<String> afterId = List.of(UUID.randomUUID().toString());
     int limit = 100;
-    Fql fql = new Fql(new EqualsCondition("key1", "value1"));
+    Fql fql = new Fql(new EqualsCondition(new FqlField("key1"), "value1"));
     List<String> fields = List.of("id", "key1");
     List<Map<String, Object>> expectedFullList = ResultSetRepositoryTestDataProvider.TEST_ENTITY_CONTENTS;
     // Since we are only asking for "id" and "key1" fields, create expected list without key2 included
@@ -86,9 +97,9 @@ class ResultSetRepositoryTest {
   @Test
   void shouldReturnEmptyResultSetForSynchronousQueryWithEmptyFields() {
     UUID entityTypeId = UUID.randomUUID();
-    UUID afterId = UUID.randomUUID();
+    List<String> afterId = List.of(UUID.randomUUID().toString());
     int limit = 100;
-    Fql fql = new Fql(new EqualsCondition("key1", "value1"));
+    Fql fql = new Fql(new EqualsCondition(new FqlField("key1"), "value1"));
     List<String> fields = List.of();
     List<Map<String, Object>> expectedList = List.of();
     List<Map<String, Object>> actualList = repo.getResultSet(entityTypeId, fql, fields, afterId, limit);
@@ -98,9 +109,9 @@ class ResultSetRepositoryTest {
   @Test
   void shouldReturnEmptyResultSetForSynchronousQueryWithNullFields() {
     UUID entityTypeId = UUID.randomUUID();
-    UUID afterId = UUID.randomUUID();
+    List<String> afterId = List.of(UUID.randomUUID().toString());
     int limit = 100;
-    Fql fql = new Fql(new EqualsCondition("key1", "value1"));
+    Fql fql = new Fql(new EqualsCondition(new FqlField("key1"), "value1"));
     List<Map<String, Object>> expectedList = List.of();
     List<Map<String, Object>> actualList = repo.getResultSet(entityTypeId, fql, null, afterId, limit);
     assertEquals(expectedList, actualList);
@@ -110,7 +121,7 @@ class ResultSetRepositoryTest {
   void shouldRunSynchronousQueryAndHandleNullAfterIdParameter() {
     UUID entityTypeId = UUID.randomUUID();
     int limit = 100;
-    Fql fql = new Fql(new EqualsCondition("key1", "value1"));
+    Fql fql = new Fql(new EqualsCondition(new FqlField("key1"), "value1"));
     List<String> fields = List.of("id", "key1", "key2");
     List<Map<String, Object>> actualList = repo.getResultSet(entityTypeId, fql, fields, null, limit);
     assertEquals(ResultSetRepositoryTestDataProvider.TEST_ENTITY_CONTENTS, actualList);

--- a/src/test/java/org/folio/fqm/repository/ResultSetRepositoryTestDataProvider.java
+++ b/src/test/java/org/folio/fqm/repository/ResultSetRepositoryTestDataProvider.java
@@ -2,9 +2,7 @@ package org.folio.fqm.repository;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.SneakyThrows;
-import org.folio.querytool.domain.dto.EntityDataType;
-import org.folio.querytool.domain.dto.EntityType;
-import org.folio.querytool.domain.dto.EntityTypeColumn;
+import org.folio.querytool.domain.dto.*;
 import org.jooq.*;
 import org.jooq.Record;
 import org.jooq.impl.DSL;
@@ -43,9 +41,9 @@ public class ResultSetRepositoryTestDataProvider implements MockDataProvider {
 
   private static final EntityType ENTITY_TYPE = new EntityType()
     .columns(List.of(
-      new EntityTypeColumn().name(ID_FIELD_NAME).valueGetter(ID_FIELD_NAME),
-      new EntityTypeColumn().name("key1").dataType(new EntityDataType().dataType("stringType")).valueGetter("key1"),
-      new EntityTypeColumn().name("key2").dataType(new EntityDataType().dataType("stringType")).valueGetter("key2")
+      new EntityTypeColumn().name(ID_FIELD_NAME).dataType(new RangedUUIDType().dataType("rangedUUIDType")).valueGetter(ID_FIELD_NAME).isIdColumn(true),
+      new EntityTypeColumn().name("key1").dataType(new StringType().dataType("stringType")).valueGetter("key1").valueGetter("key1"),
+      new EntityTypeColumn().name("key2").dataType(new StringType().dataType("stringType")).valueGetter("key2").valueGetter("key2")
     ))
     .name("TEST_ENTITY_TYPE")
     .fromClause("TEST_ENTITY_TYPE");

--- a/src/test/java/org/folio/fqm/service/QueryExecutionCallbacksTest.java
+++ b/src/test/java/org/folio/fqm/service/QueryExecutionCallbacksTest.java
@@ -35,7 +35,10 @@ class QueryExecutionCallbacksTest {
   @Test
   void shouldHandleDataBatch() {
     UUID queryId = UUID.randomUUID();
-    List<UUID> resultIds = List.of(UUID.randomUUID(), UUID.randomUUID());
+    List<String[]> resultIds = List.of(
+      new String[] {UUID.randomUUID().toString()},
+      new String[] {UUID.randomUUID().toString()}
+    );
     IdsWithCancelCallback idsWithCancelCallback = new IdsWithCancelCallback(resultIds, () -> {});
     Query expectedQuery = new Query(queryId, UUID.randomUUID(), "", List.of(), UUID.randomUUID(),
       OffsetDateTime.now(), null, QueryStatus.IN_PROGRESS, null);
@@ -48,7 +51,10 @@ class QueryExecutionCallbacksTest {
   void shouldHandleDataBatchForCancelledQuery() {
     AtomicBoolean streamClosed = new AtomicBoolean(false);
     UUID queryId = UUID.randomUUID();
-    List<UUID> resultIds = List.of(UUID.randomUUID(), UUID.randomUUID());
+    List<String[]> resultIds = List.of(
+      new String[] {UUID.randomUUID().toString()},
+      new String[] {UUID.randomUUID().toString()}
+    );
     IdsWithCancelCallback idsWithCancelCallback = new IdsWithCancelCallback(resultIds, () -> streamClosed.set(true));
     assertFalse(streamClosed.get());
     Query expectedQuery = new Query(queryId, UUID.randomUUID(), "", List.of(), UUID.randomUUID(),

--- a/src/test/java/org/folio/fqm/service/QueryManagementServiceTest.java
+++ b/src/test/java/org/folio/fqm/service/QueryManagementServiceTest.java
@@ -137,7 +137,10 @@ class QueryManagementServiceTest {
     boolean includeResults = true;
     int offset = 0;
     int limit = 100;
-    List<UUID> resultIds = List.of(UUID.randomUUID(), UUID.randomUUID());
+    List<List<String>> resultIds = List.of(
+      List.of(UUID.randomUUID().toString()),
+      List.of(UUID.randomUUID().toString())
+    );
     List<Map<String, Object>> contents = List.of(
       Map.of("id", resultIds.get(0), "field1", "value1", "field2", "value2"),
       Map.of("id", resultIds.get(1), "field1", "value1", "field2", "value2")
@@ -165,7 +168,10 @@ class QueryManagementServiceTest {
     boolean includeResults = true;
     int offset = 0;
     int limit = 100;
-    List<UUID> resultIds = List.of(UUID.randomUUID(), UUID.randomUUID());
+    List<List<String>> resultIds = List.of(
+      List.of(UUID.randomUUID().toString()),
+      List.of(UUID.randomUUID().toString())
+    );
     List<Map<String, Object>> contents = List.of(
       Map.of("id", resultIds.get(0)),
       Map.of("id", resultIds.get(1))
@@ -195,7 +201,10 @@ class QueryManagementServiceTest {
     boolean includeResults = true;
     int offset = 0;
     int limit = 100;
-    List<UUID> resultIds = List.of(UUID.randomUUID(), UUID.randomUUID());
+    List<List<String>> resultIds = List.of(
+      List.of(UUID.randomUUID().toString()),
+      List.of(UUID.randomUUID().toString())
+    );
     List<Map<String, Object>> contents = List.of(
       Map.of("id", resultIds.get(0)),
       Map.of("id", resultIds.get(1))
@@ -226,7 +235,10 @@ class QueryManagementServiceTest {
     boolean includeResults = true;
     int offset = 0;
     int limit = 100;
-    List<UUID> resultIds = List.of(UUID.randomUUID(), UUID.randomUUID());
+    List<List<String>> resultIds = List.of(
+      List.of(UUID.randomUUID().toString()),
+      List.of(UUID.randomUUID().toString())
+    );
     List<Map<String, Object>> contents = List.of(
       Map.of("id", resultIds.get(0), "field1", "value1", "field2", "value2"),
       Map.of("id", resultIds.get(1), "field1", "value1", "field2", "value2")
@@ -399,11 +411,14 @@ class QueryManagementServiceTest {
     Query query = TestDataFixture.getMockQuery(QueryStatus.SUCCESS);
     int offset = 0;
     int limit = 0;
-    List<UUID> expectedIds = List.of(UUID.randomUUID(), UUID.randomUUID());
+    List<List<String>> expectedIds = List.of(
+      List.of(UUID.randomUUID().toString()),
+      List.of(UUID.randomUUID().toString())
+    );
     when(queryRepository.getQuery(query.queryId(), false)).thenReturn(Optional.of(query));
     when(entityTypeService.getDerivedTableName(query.entityTypeId())).thenReturn(derivedTableName);
     when(queryResultsSorterService.getSortedIds(query.queryId(), offset, limit)).thenReturn(expectedIds);
-    List<UUID> actualIds = queryManagementService.getSortedIds(query.queryId(), offset, limit);
+    List<List<String>> actualIds = queryManagementService.getSortedIds(query.queryId(), offset, limit);
     assertEquals(expectedIds, actualIds);
   }
 
@@ -431,7 +446,10 @@ class QueryManagementServiceTest {
   @Test
   void shouldGetContents() {
     UUID entityTypeId = UUID.randomUUID();
-    List<UUID> ids = List.of(UUID.randomUUID(), UUID.randomUUID());
+    List<List<String>> ids = List.of(
+      List.of(UUID.randomUUID().toString()),
+      List.of(UUID.randomUUID().toString())
+    );
     List<String> fields = List.of("id", "field1", "field2");
     List<Map<String, Object>> expectedContents = List.of(
       Map.of("id", UUID.randomUUID(), "field1", "value1", "field2", "value2"),

--- a/src/test/java/org/folio/fqm/service/QueryProcessorServiceTest.java
+++ b/src/test/java/org/folio/fqm/service/QueryProcessorServiceTest.java
@@ -2,6 +2,7 @@ package org.folio.fqm.service;
 
 import org.folio.fql.model.EqualsCondition;
 import org.folio.fql.model.Fql;
+import org.folio.fql.model.field.FqlField;
 import org.folio.fql.service.FqlService;
 import org.folio.fqm.model.FqlQueryWithContext;
 import org.folio.fqm.model.IdsWithCancelCallback;
@@ -36,7 +37,7 @@ class QueryProcessorServiceTest {
 
   @Test
   void shouldGetIdsInBatch() {
-    Fql fql = new Fql(new EqualsCondition("status", "missing"));
+    Fql fql = new Fql(new EqualsCondition(new FqlField("status"), "missing"));
     String tenantId = "tenant_01";
     String fqlCriteria = "{\"status\": {\"$eq\": \"missing\"}}";
     UUID entityTypeId = UUID.randomUUID();
@@ -65,7 +66,7 @@ class QueryProcessorServiceTest {
 
   @Test
   void shouldConsumeButNotThrowError() {
-    Fql fql = new Fql(new EqualsCondition("status", "missing"));
+    Fql fql = new Fql(new EqualsCondition(new FqlField("status"), "missing"));
     String tenantId = "tenant_01";
     String fqlCriteria = "{\"status\": {\"$eq\": \"missing\"}}";
     UUID entityTypeId = UUID.randomUUID();
@@ -102,9 +103,9 @@ class QueryProcessorServiceTest {
     String fqlQuery = """
       {"field1": {"eq": "value1" }}
       """;
-    UUID afterId = UUID.randomUUID();
+    List<String> afterId = List.of(UUID.randomUUID().toString());
     int limit = 100;
-    Fql expectedFql = new Fql(new EqualsCondition("field1", "value1"));
+    Fql expectedFql = new Fql(new EqualsCondition(new FqlField("status"), "value1"));
     List<String> fields = List.of("field1", "field2");
     List<Map<String, Object>> expectedContent = List.of(
       Map.of("field1", "value1", "field2", "value2"),

--- a/src/test/java/org/folio/fqm/service/QueryResultsSorterServiceTest.java
+++ b/src/test/java/org/folio/fqm/service/QueryResultsSorterServiceTest.java
@@ -1,8 +1,5 @@
 package org.folio.fqm.service;
 
-import static org.folio.fqm.repository.EntityTypeRepository.ID_FIELD_NAME;
-import static org.jooq.impl.DSL.field;
-import static org.jooq.impl.DSL.select;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -15,8 +12,6 @@ import java.util.function.Consumer;
 import java.util.function.IntConsumer;
 import org.folio.fqm.model.IdsWithCancelCallback;
 import org.folio.fqm.repository.IdStreamer;
-import org.jooq.Condition;
-import org.jooq.impl.DSL;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -35,10 +30,6 @@ class QueryResultsSorterServiceTest {
   void shouldStreamSortedIds() {
     UUID queryId = UUID.randomUUID();
     int batchSize = 100;
-    var sqlSelectionClause = select(field("result_id"))
-      .from("corsair_lib_mod_fqm_manager.query_results")
-      .where(field("query_id").eq(queryId));
-    Condition sqlWhereClause = DSL.field(ID_FIELD_NAME).in(sqlSelectionClause);
     Consumer<IdsWithCancelCallback> idsConsumer = mock(Consumer.class);
     IntConsumer totalCountConsumer = mock(IntConsumer.class);
     Consumer<Throwable> errorConsumer = mock(Consumer.class);
@@ -60,10 +51,12 @@ class QueryResultsSorterServiceTest {
     int offset = 0;
     int limit = 0;
     String derivedTableName = "query_results";
-    List<UUID> expectedIds = List.of(UUID.randomUUID(), UUID.randomUUID());
+    List<List<String>> expectedIds = List.of(
+      List.of(UUID.randomUUID().toString()), List.of(UUID.randomUUID().toString())
+    );
     when(idStreamer.getSortedIds(derivedTableName, offset, limit, queryId))
       .thenReturn(expectedIds);
-    List<UUID> actualIds = queryResultsSorterService.getSortedIds(
+    List<List<String>> actualIds = queryResultsSorterService.getSortedIds(
       queryId,
       offset,
       limit

--- a/src/test/java/org/folio/fqm/service/ResultSetServiceTest.java
+++ b/src/test/java/org/folio/fqm/service/ResultSetServiceTest.java
@@ -7,25 +7,27 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.Lists;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 
+import org.folio.fqm.repository.EntityTypeRepository;
 import org.folio.fqm.repository.ResultSetRepository;
 import org.folio.fqm.testutil.TestDataFixture;
+import org.folio.querytool.domain.dto.EntityType;
+import org.folio.querytool.domain.dto.EntityTypeColumn;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class ResultSetServiceTest {
 
   private ResultSetRepository resultSetRepository;
+  private EntityTypeRepository entityTypeRepository;
   private ResultSetService service;
 
   @BeforeEach
   void setUp() {
     this.resultSetRepository = mock(ResultSetRepository.class);
-    this.service = new ResultSetService(resultSetRepository);
+    this.entityTypeRepository = mock(EntityTypeRepository.class);
+    this.service = new ResultSetService(resultSetRepository, entityTypeRepository);
   }
 
   @Test
@@ -34,13 +36,30 @@ class ResultSetServiceTest {
     UUID deletedContentId = UUID.randomUUID();
     List<Map<String, Object>> expectedResult = new ArrayList<>(TestDataFixture.getEntityContents());
     List<Map<String, Object>> reversedContent = new ArrayList<>(Lists.reverse(expectedResult));
-    expectedResult.add(Map.of("id", deletedContentId, "_deleted", true));
+    expectedResult.add(Map.of("id", deletedContentId.toString(), "_deleted", true));
     List<String> fields = List.of("id", "key1", "key2");
-    List<UUID> listIds = new ArrayList<>();
+    List<List<String>> listIds = new ArrayList<>();
     expectedResult.forEach(content ->
-      listIds.add((UUID) content.get(ID_FIELD_NAME))
+      listIds.add(List.of(content.get(ID_FIELD_NAME).toString()))
     );
 
+    when(
+      entityTypeRepository.getEntityTypeDefinition(entityTypeId)
+    )
+    .thenReturn(
+      Optional.of(
+        new EntityType()
+        .name("test_entity")
+        .id(entityTypeId.toString())
+        .columns(
+          List.of(
+            new EntityTypeColumn().name("id").isIdColumn(true),
+            new EntityTypeColumn().name("key1"),
+            new EntityTypeColumn().name("key2")
+          )
+        )
+      )
+    );
     when(
       resultSetRepository.getResultSet(entityTypeId, fields, listIds)
     )

--- a/src/test/java/org/folio/fqm/utils/IdColumnUtilsTest.java
+++ b/src/test/java/org/folio/fqm/utils/IdColumnUtilsTest.java
@@ -1,0 +1,35 @@
+package org.folio.fqm.utils;
+
+import org.jooq.Field;
+import org.jooq.impl.DSL;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import static org.folio.fqm.utils.IdStreamerTestDataProvider.TEST_ENTITY_TYPE_DEFINITION;
+
+class IdColumnUtilsTest {
+
+  @Test
+  void shouldGetIdColumnNames() {
+    List<String> expectedIdColumnNames = List.of("id");
+    List<String> actualIdColumnNames = IdColumnUtils.getIdColumnNames(TEST_ENTITY_TYPE_DEFINITION);
+    assertEquals(expectedIdColumnNames, actualIdColumnNames);
+  }
+
+  @Test
+  void shouldGetIdColumnValueGetters() {
+    List<String> expectedIdColumnValueGetters = List.of("id");
+    List<String> actualIdColumnValueGetters = IdColumnUtils.getIdColumnValueGetters(TEST_ENTITY_TYPE_DEFINITION);
+    assertEquals(expectedIdColumnValueGetters, actualIdColumnValueGetters);
+  }
+
+  @Test
+  void shouldGetResultIdValueGetter() {
+    Field<String[]> expectedField = DSL.cast(DSL.array(new Field[] {DSL.field("id")}), String[].class);
+    Field<String[]> actualField = IdColumnUtils.getResultIdValueGetter(TEST_ENTITY_TYPE_DEFINITION);
+    assertEquals(expectedField, actualField);
+  }
+}

--- a/src/test/resources/test-db/changelog-test.xml
+++ b/src/test/resources/test-db/changelog-test.xml
@@ -6,4 +6,5 @@
 
   <include file="db/changelog/changes/v1.0.0/core-tables.xml" relativeToChangelogFile="false"/>
   <include file="test-entity-type-definitions.xml" relativeToChangelogFile="true"/>
+  <include file="db/changelog/changes/v1.1.0/update-query-results-table.xml" relativeToChangelogFile="false"/>
 </databaseChangeLog>


### PR DESCRIPTION
## Purpose
[MODFQMMGR-137](https://folio-org.atlassian.net/browse/MODFQMMGR-137): Change how we identify unique records for lists

Currently a single UUID id field is used to distinguish distinct records in FQM. This PR is to rework that logic and use an array of strings as the unique identifier instead. This will allow us to use as many fields as we like as the unique record identifier in FQM.

## Testing
- [x] All unit tests passed
- [x] Query workflow works for single or composite result ids