### PR TITLE
MODFQMMGR-134 Implement support for value source APIs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,11 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.jayway.jsonpath</groupId>
+      <artifactId>json-path</artifactId>
+      <version>2.9.0</version>
+    </dependency>
 
     <!-- Test dependencies -->
     <dependency>

--- a/src/main/java/org/folio/fqm/ModFqmManagerApplication.java
+++ b/src/main/java/org/folio/fqm/ModFqmManagerApplication.java
@@ -3,11 +3,13 @@ package org.folio.fqm;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
 @EnableAsync
 @EnableCaching
+@EnableFeignClients
 public class ModFqmManagerApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/org/folio/fqm/client/SimpleHttpClient.java
+++ b/src/main/java/org/folio/fqm/client/SimpleHttpClient.java
@@ -1,0 +1,18 @@
+package org.folio.fqm.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Service
+@FeignClient(name = "simple-http-client", url = ".")
+public interface SimpleHttpClient {
+  /**
+   * Retrieve arbitrary data from a FOLIO API endpoint.
+   * @return the body of the response (JSON)
+   */
+  @GetMapping(value = "/{path}", produces = MediaType.APPLICATION_JSON_VALUE)
+  String get(@PathVariable String path);
+}

--- a/src/main/resources/db/changelog/changes/v1.1.0/update-drv-item-details-definition.xml
+++ b/src/main/resources/db/changelog/changes/v1.1.0/update-drv-item-details-definition.xml
@@ -18,7 +18,7 @@
         SELECT COUNT(*) FROM pg_matviews WHERE schemaname = '${tenant_id}_mod_fqm_manager'AND matviewname = 'drv_inventory_item_status';
       </sqlCheck>
     </preConditions>
-    <comment>Add filterValueGetters and valueFunctions to various columns</comment>
+    <comment>Add filterValueGetters, valueFunctions, and valueSourceApis to various columns</comment>
     <update tableName="entity_type_definition">
       <column name="definition">
         {
@@ -239,14 +239,14 @@
             },
             {
               "name": "item_material_type",
-              "source": {
-                "columnName": "material_type_name",
-                "entityTypeId": "917ea5c8-cafe-4fa6-a942-e2388a88c6f6"
-              },
               "dataType": {
                 "dataType": "stringType"
               },
-              "idColumnName": "item_material_type_id",
+              "valueSourceApi": {
+                "path": "material-types",
+                "valueJsonPath": "$.mtypes.*.id",
+                "labelJsonPath": "$.mtypes.*.name"
+              },
               "filterValueGetter": "lower(${tenant_id}_mod_inventory_storage.f_unaccent(material_type_ref_data.jsonb ->> 'name'::text))",
               "valueFunction": "lower(${tenant_id}_mod_inventory_storage.f_unaccent(:value))",
               "valueGetter": "material_type_ref_data.jsonb ->> 'name'",


### PR DESCRIPTION
This commit makes it so we can retrieve available values for columns from configured APIs. It also expands the functionality of the column values API endpoint by making it support values coming from the entity type definition, the DB, or APIs (prior to this, it only supported the DB)
