### PR TITLE
Add lombok version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
     <openapi-generator.version>6.2.1</openapi-generator.version>
     <copy-rename-maven-plugin.version>1.0.1</copy-rename-maven-plugin.version>
     <maven-release-plugin.version>3.0.0-M7</maven-release-plugin.version>
+    <lombok.version>1.18.30</lombok.version>
 
     <!-- other properties -->
     <java.version>17</java.version>
@@ -106,7 +107,8 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <optional>true</optional>
+      <version>${lombok.version}</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Explicitly add a version for Lombok to combat [this issue](https://stackoverflow.com/questions/77171270/compilation-error-after-upgrading-to-jdk-21-nosuchfielderror-jcimport-does-n) with JDK 21.