### PR TITLE
MODFQMMGR-134 Fix a bug with the material type config

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -129,7 +129,10 @@
       "permissionName": "fqm.entityTypes.item.get",
       "displayName": "FQM - Get details of a single entity type",
       "description": "Get details of a single entity type",
-      "visible":  true
+      "visible":  true,
+      "subPermissions": [
+        "inventory-storage.material-types.collection.get"
+      ]
     },
     {
       "permissionName": "fqm.entityTypes.item.columnValues.get",

--- a/pom.xml
+++ b/pom.xml
@@ -24,9 +24,9 @@
   <properties>
     <!-- runtime dependencies -->
     <folio-spring-base.version>7.1.2</folio-spring-base.version>
-    <folio-query-tool-metadata.version>1.1.0-SNAPSHOT</folio-query-tool-metadata.version>
+    <folio-query-tool-metadata.version>1.1.0</folio-query-tool-metadata.version>
     <mapstruct.version>1.5.2.Final</mapstruct.version>
-    <lib-fqm-query-processor.version>1.1.0-SNAPSHOT</lib-fqm-query-processor.version>
+    <lib-fqm-query-processor.version>1.2.0-SNAPSHOT</lib-fqm-query-processor.version>
     <coffee-boots.version>4.0.0</coffee-boots.version>
     <snakeyaml.version>2.0</snakeyaml.version>
     <org.postgresql.version>42.5.4</org.postgresql.version>

--- a/src/main/resources/db/changelog/changes/v1.1.0/update-drv-item-details-definition.xml
+++ b/src/main/resources/db/changelog/changes/v1.1.0/update-drv-item-details-definition.xml
@@ -248,6 +248,10 @@
                 "valueJsonPath": "$.mtypes.*.id",
                 "labelJsonPath": "$.mtypes.*.name"
               },
+              "source": {
+                "columnName": "item_material_type",
+                "entityTypeId": "0cb79a4c-f7eb-4941-a104-745224ae0292"
+              },
               "filterValueGetter": "lower(${tenant_id}_mod_inventory_storage.f_unaccent(material_type_ref_data.jsonb ->> 'name'::text))",
               "valueFunction": "lower(${tenant_id}_mod_inventory_storage.f_unaccent(:value))",
               "valueGetter": "material_type_ref_data.jsonb ->> 'name'",


### PR DESCRIPTION
This adds the `source` property back to item_material_type in the Items entity type, so that the query builder plugin knows how to ask for the available values.
This commit also adds "inventory-storage.material-types.collection.get" to the GET /entity-types sub-permissions, so that users who can access the entity types can also access the available values for that entity type