### PR TITLE
[LIBFQMQUER-12] Use special field resolution for querying

### DIFF
--- a/src/main/java/org/folio/fqm/service/FqlToSqlConverterService.java
+++ b/src/main/java/org/folio/fqm/service/FqlToSqlConverterService.java
@@ -153,6 +153,12 @@ public class FqlToSqlConverterService {
       .orElseThrow(() -> new FieldNotFoundException(entityType.getName(), fieldCondition.field()));
   }
 
+  private static Field getFieldForFiltering(FieldCondition<?> fieldCondition, EntityType entityType) {
+    return FqlValidationService
+      .findFieldDefinitionForQuerying(fieldCondition.field(), entityType)
+      .orElseThrow(() -> new FieldNotFoundException(entityType.getName(), fieldCondition.field()));
+  }
+
   private static boolean isDateCondition(FieldCondition<?> fieldCondition, EntityType entityType) {
     EntityDataType dataType = getField(fieldCondition, entityType).getDataType();
     return dataType instanceof DateType
@@ -273,7 +279,7 @@ public class FqlToSqlConverterService {
   }
 
   private static org.jooq.Field<Object> field(FieldCondition<?> condition, EntityType entityType) {
-    return SqlFieldIdentificationUtils.getSqlFilterField(getField(condition, entityType));
+    return SqlFieldIdentificationUtils.getSqlFilterField(getFieldForFiltering(condition, entityType));
   }
 
   private static String getFieldDataType(EntityType entityType, FieldCondition<?> fieldCondition) {


### PR DESCRIPTION
# [Jira LIBFQMQUER-12](https://issues.folio.org/browse/LIBFQMQUER-12)

## Purpose
Additional logic was added for querying fields in https://github.com/folio-org/lib-fqm-query-processor/pull/21; we want to be sure to use this logic instead of the default for resolving fields during filtration.

This logic will resolve a "base" column, enabling queries against columns with `idColumnName` without explicitly specifying the ID column in the query.