### PR TITLE
[MODFQMMGR-180] Use proper checks for insensitive comparison

### DIFF
--- a/src/main/java/org/folio/fqm/service/FqlToSqlConverterService.java
+++ b/src/main/java/org/folio/fqm/service/FqlToSqlConverterService.java
@@ -160,7 +160,7 @@ public class FqlToSqlConverterService {
   }
 
   private static boolean isDateCondition(FieldCondition<?> fieldCondition, EntityType entityType) {
-    EntityDataType dataType = getField(fieldCondition, entityType).getDataType();
+    EntityDataType dataType = getFieldForFiltering(fieldCondition, entityType).getDataType();
     return dataType instanceof DateType
       && ((String) fieldCondition.value()).matches(DATE_REGEX);
   }
@@ -242,7 +242,7 @@ public class FqlToSqlConverterService {
   }
 
   private static Condition handleEmpty(EmptyCondition emptyCondition, EntityType entityType, org.jooq.Field<Object> field) {
-    String fieldType = getField(emptyCondition, entityType)
+    String fieldType = getFieldForFiltering(emptyCondition, entityType)
       .getDataType()
       .getDataType();
     boolean isEmpty = Boolean.TRUE.equals(emptyCondition.value());
@@ -270,7 +270,7 @@ public class FqlToSqlConverterService {
   private static Condition caseInsensitiveComparison(FieldCondition<?> fieldCondition, EntityType entityType, org.jooq.Field<Object> field, String value,
                                                      BiFunction<org.jooq.Field<Object>, org.jooq.Field<String>, Condition> toCaseInsensitiveCondition,
                                                      BiFunction<org.jooq.Field<Object>, org.jooq.Field<Object>, Condition> toCaseSensitiveCondition) {
-    Field entityField = getField(fieldCondition, entityType);
+    Field entityField = getFieldForFiltering(fieldCondition, entityType);
     boolean shouldConvertColumnToLower = entityField.getFilterValueGetter() == null;
 
     return shouldConvertColumnToLower


### PR DESCRIPTION
# [Jira MODFQMMGR-180](https://folio-org.atlassian.net/browse/MODFQMMGR-180)

## Purpose
As part of #147 , we added some logic to perform filtering on underlying ID columns, rather than the derived columns (e.g. vendor_id instead of vendor_code). This needs to be updated to also check the type of the underlying column, to ensure that we appropriately apply lowercase, date, and other conversions.