### PR TITLE
MODFQMMGR-178 Fix bug with regex+valueFunctions

### DIFF
--- a/src/main/java/org/folio/fqm/service/FqlToSqlConverterService.java
+++ b/src/main/java/org/folio/fqm/service/FqlToSqlConverterService.java
@@ -90,7 +90,7 @@ public class FqlToSqlConverterService {
       case "GreaterThanCondition" -> handleGreaterThan((GreaterThanCondition) fqlCondition, entityType, field);
       case "LessThanCondition" -> handleLessThan((LessThanCondition) fqlCondition, entityType, field);
       case "AndCondition" -> handleAnd((AndCondition) fqlCondition, entityType);
-      case "RegexCondition" -> handleRegEx((RegexCondition) fqlCondition, field);
+      case "RegexCondition" -> handleRegEx((RegexCondition) fqlCondition, entityType, field);
       case "ContainsCondition" -> handleContains((ContainsCondition) fqlCondition, entityType, field);
       case "NotContainsCondition" -> handleNotContains((NotContainsCondition) fqlCondition, entityType, field);
       case "EmptyCondition" -> handleEmpty((EmptyCondition) fqlCondition, entityType, field);
@@ -218,9 +218,9 @@ public class FqlToSqlConverterService {
     return and(andCondition.value().stream().map(c -> getSqlCondition(c, entityType)).toList());
   }
 
-  private static Condition handleRegEx(RegexCondition regexCondition, org.jooq.Field<Object> field) {
+  private static Condition handleRegEx(RegexCondition regexCondition, EntityType entityType, org.jooq.Field<Object> field) {
     // perform case-insensitive regex search
-    return condition("{0} ~* {1}", field, val(regexCondition.value()));
+    return condition("{0} ~* {1}", field, valueField(regexCondition.value(), regexCondition, entityType));
   }
 
   private static Condition handleContains(ContainsCondition containsCondition, EntityType entityType, org.jooq.Field<Object> field) {

--- a/src/test/java/org/folio/fqm/service/FqlToSqlConverterServiceTest.java
+++ b/src/test/java/org/folio/fqm/service/FqlToSqlConverterServiceTest.java
@@ -234,6 +234,12 @@ class FqlToSqlConverterServiceTest {
         condition("{0} ~* {1}", field("field1"), val("some_text"))
       ),
       Arguments.of(
+        "regex",
+        """
+          {"fieldWithAValueFunction": {"$regex": "some_text"}}""",
+        condition("{0} ~* {1}", field("fieldWithAValueFunction"), field("upper(:value)", String.class, param("value", "some_text")))
+      ),
+      Arguments.of(
         "in list",
         """
           {"field1": {"$in": ["value1", 2, true]}}""",


### PR DESCRIPTION
This fixes a bug where valueFunctions were not getting used when converting regex conditions to SQL, which could lead to unexpected results.

Worth noting: this changes the behavior of regex conditions in a subtle way that could lead to other expected results in the rare cases where a field's valueFunction changes/breaks the semantics of a given regex. This should be extremely rare, though, since the regex produced by the query builder UI plugin only produces regular expressions that shouldn't break in unexpected ways (and when the semantics does change, the changes will generally be consistent with other operators)