### PR TITLE
Treat null values as false for holdings_suppress_from_discovery field

### DIFF
--- a/src/main/resources/db/changelog/changes/v1.1.0/sql/entity-type-definitions/insert-holdings-definition.sql
+++ b/src/main/resources/db/changelog/changes/v1.1.0/sql/entity-type-definitions/insert-holdings-definition.sql
@@ -3,7 +3,7 @@ INSERT INTO entity_type_definition (id, derived_table_name, definition)
              "id": "8418e512-feac-4a6a-a56d-9006aab31e33",
              "name":"drv_holdings_record_details",
              "private" : false,
-             "fromClause" : "src_inventory_holdings_record hrd JOIN src_inventory_location effective_location ON effective_location.id = hrd.effectivelocationid JOIN src_inventory_loclibrary effective_library ON effective_library.id = effective_location.libraryid JOIN src_inventory_location permanent_location ON permanent_location.id = hrd.permanentlocationid JOIN src_inventory_location temporary_location ON temporary_location.id = hrd.temporarylocationid",
+             "fromClause" : "src_inventory_holdings_record hrd LEFT JOIN src_inventory_location effective_location ON effective_location.id = hrd.effectivelocationid LEFT JOIN src_inventory_loclibrary effective_library ON effective_library.id = effective_location.libraryid LEFT JOIN src_inventory_location permanent_location ON permanent_location.id = hrd.permanentlocationid LEFT JOIN src_inventory_location temporary_location ON temporary_location.id = hrd.temporarylocationid",
              "columns": [
                  {
                    "name": "holdings_effective_location",
@@ -194,7 +194,7 @@ INSERT INTO entity_type_definition (id, derived_table_name, definition)
                         }
                       ],
                       "valueGetter": "hrd.jsonb ->> ''discoverySuppress''",
-                      "filterValueGetter": "\"left\"(lower(hrd.jsonb ->> ''discoverySuppress''::text), 600)",
+                      "filterValueGetter": "COALESCE(\"left\"(lower(hrd.jsonb ->> ''discoverySuppress''::text), 600), ''false'')",
                       "valueFunction": "\"left\"(lower(:value), 600)",
                       "visibleByDefault": true
                  },


### PR DESCRIPTION
## Purpose
Treat null values as false for holdings_suppress_from_discovery field, to meet the requirements of [MODFQMMGR-126](https://folio-org.atlassian.net/browse/MODFQMMGR-126) 

This is done with a filterValueGetter, so nulls will be treated as false in the WHERE clause of a query, but not in the SELECT clause (see below)


<img width="752" alt="Screenshot 2024-02-28 at 1 10 14 PM" src="https://github.com/folio-org/mod-fqm-manager/assets/97990858/a1058423-7958-43ea-92fd-3ab12695621b">
