### PR TITLE
MODFQMMGR-186 Bump Spring Boot dependency version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.1.2</version>
+    <version>3.2.3</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
   <groupId>org.folio</groupId>
@@ -23,7 +23,7 @@
 
   <properties>
     <!-- runtime dependencies -->
-    <folio-spring-base.version>7.1.2</folio-spring-base.version>
+    <folio-spring-base.version>8.1.0</folio-spring-base.version>
     <folio-query-tool-metadata.version>1.2.0-SNAPSHOT</folio-query-tool-metadata.version>
     <mapstruct.version>1.5.2.Final</mapstruct.version>
     <lib-fqm-query-processor.version>1.2.0-SNAPSHOT</lib-fqm-query-processor.version>

--- a/src/test/java/org/folio/fqm/ModFqmManagerApplicationTest.java
+++ b/src/test/java/org/folio/fqm/ModFqmManagerApplicationTest.java
@@ -2,8 +2,7 @@ package org.folio.fqm;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import javax.validation.Valid;
-
+import jakarta.validation.Valid;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
This commit bumps our dependency on Spring Boot from 3.1.2 to 3.2.3 (the latest stable release). This also bumps folio-spring-base from 7.1.2 to 8.1.0, to keep our transitive Spring dependencies in sync with our Boot version