### PR TITLE
MODFQMMGR-188: fix null/empty operator for nested fields

### DIFF
--- a/src/test/java/org/folio/fqm/service/FqlToSqlConverterServiceTest.java
+++ b/src/test/java/org/folio/fqm/service/FqlToSqlConverterServiceTest.java
@@ -17,6 +17,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.util.Arrays;
 import java.util.List;
 
+
+import static org.folio.fqm.service.FqlToSqlConverterService.ALL_NULLS;
+import static org.folio.fqm.service.FqlToSqlConverterService.NOT_ALL_NULLS;
 import static org.jooq.impl.DSL.and;
 import static org.jooq.impl.DSL.array;
 import static org.jooq.impl.DSL.arrayOverlap;
@@ -464,13 +467,13 @@ class FqlToSqlConverterServiceTest {
         "empty array",
         """
           {"arrayField": {"$empty": true}}""",
-        field("arrayField").isNull().or(cardinality(cast(field("arrayField"), String[].class)).eq(0))
+        field("arrayField").isNull().or(cardinality(cast(field("arrayField"), String[].class)).eq(0)).or(ALL_NULLS.formatted("arrayField"))
       ),
       Arguments.of(
         "not empty array",
         """
           {"arrayField": {"$empty": false}}""",
-        field("arrayField").isNotNull().and(cardinality(cast(field("arrayField"), String[].class)).ne(0))
+        field("arrayField").isNotNull().and(cardinality(cast(field("arrayField"), String[].class)).ne(0)).and(NOT_ALL_NULLS.formatted("arrayField"))
       )
     );
   }


### PR DESCRIPTION
## Purpose
[MODFQMMGR-188](https://folio-org.atlassian.net/browse/MODFQMMGR-188): fix null/empty operator for nested fields

For an array field _arrayField_ and a nested element _nestedElement_, $empty queries are handled in the following ways:

- If arrayField is not present, then 'arrayField.nestedElement IS EMPTY' returns true
-  If arrayField is an empty array, then 'arrayField.nestedElement IS EMPTY' returns true
- If arrayField is not empty, but none of the elements contain nestedElement, then 'arrayField.nestedElement IS EMPTY' returns true
- If arrayField is not empty, and any of the elements contain nestedElement, then 'arrayField.nestedElement IS EMPTY' returns false
