### PR TITLE
MODFQMMGR-172: Set a limit on the maximum number of query results

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ mvn clean install
 | DB_USERNAME                        | postgres      | Postgres username                     |
 | DB_PASSWORD                        | postgres      | Postgres password                     |
 | DB_DATABASE                        | postgres      | Postgres database name                |
+| MAX_QUERY_SIZE                     | 1250000       | max result count per query            |
 | server.port                        | 8081          | Server port                           |
 | QUERY_RETENTION_DURATION           | 3h            | Older queries get deleted             |
 | task.execution.pool.core-size      | 9             | Core number of concurrent async tasks |

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -307,6 +307,9 @@
       },
       { "name": "task.execution.pool.max-size",
         "value": "10"
+      },
+      { "name": "MAX_QUERY_SIZE",
+        "value": "1250000"
       }
     ]
   }

--- a/src/main/java/org/folio/fqm/config/FqmConfiguration.java
+++ b/src/main/java/org/folio/fqm/config/FqmConfiguration.java
@@ -1,0 +1,18 @@
+package org.folio.fqm.config;
+
+import org.folio.fqm.repository.QueryRepository;
+import org.folio.fqm.repository.QueryResultsRepository;
+import org.folio.fqm.service.DataBatchCallback;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.function.Supplier;
+
+@Configuration
+public class FqmConfiguration {
+  @Bean
+  public Supplier<DataBatchCallback> dataBatchCallbackSupplier(QueryRepository queryRepository,
+                                                               QueryResultsRepository queryResultsRepository) {
+    return () -> new DataBatchCallback(queryRepository, queryResultsRepository);
+  }
+}

--- a/src/main/java/org/folio/fqm/exception/MaxQuerySizeExceededException.java
+++ b/src/main/java/org/folio/fqm/exception/MaxQuerySizeExceededException.java
@@ -1,0 +1,22 @@
+package org.folio.fqm.exception;
+
+import lombok.RequiredArgsConstructor;
+import org.folio.fqm.domain.dto.Error;
+
+import java.util.UUID;
+
+@RequiredArgsConstructor
+public class MaxQuerySizeExceededException extends RuntimeException {
+  private final UUID queryId;
+  private final int querySize;
+  private final int maxSize;
+
+  @Override
+  public String getMessage() {
+    return String.format("Query %s with size %d has exceeded the maximum size of %d.", queryId, querySize, maxSize);
+  }
+
+  public Error getError() {
+    return new Error().message(getMessage());
+  }
+}

--- a/src/main/java/org/folio/fqm/exceptionhandler/FqmExceptionHandler.java
+++ b/src/main/java/org/folio/fqm/exceptionhandler/FqmExceptionHandler.java
@@ -5,6 +5,7 @@ import org.folio.fqm.domain.dto.Error;
 import org.folio.fqm.exception.InvalidFqlException;
 import org.folio.fqm.exception.FieldNotFoundException;
 import org.folio.fqm.exception.EntityTypeNotFoundException;
+import org.folio.fqm.exception.MaxQuerySizeExceededException;
 import org.folio.fqm.exception.QueryNotFoundException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.http.HttpHeaders;
@@ -33,5 +34,12 @@ public class FqmExceptionHandler extends ResponseEntityExceptionHandler {
     String url = webRequest.getHttpMethod() + " " + webRequest.getRequest().getRequestURI();
     log.error("Request failed. URL: {}. Failure reason : {}", url, exception.getMessage());
     return new ResponseEntity<>(exception.getError(), exception.getHttpStatus());
+  }
+
+  @ExceptionHandler(MaxQuerySizeExceededException.class)
+  public ResponseEntity<Error> handleMaxSizeExceeded(MaxQuerySizeExceededException exception,
+                                                       ServletWebRequest webRequest) {
+    log.error("Unexpected exception: {}", exception.getMessage(), exception);
+    return new ResponseEntity<>(exception.getError(), HttpStatus.BAD_REQUEST);
   }
 }

--- a/src/main/java/org/folio/fqm/service/DataBatchCallback.java
+++ b/src/main/java/org/folio/fqm/service/DataBatchCallback.java
@@ -1,0 +1,47 @@
+package org.folio.fqm.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.apache.commons.lang3.function.TriConsumer;
+import org.folio.fqm.domain.Query;
+import org.folio.fqm.domain.QueryStatus;
+import org.folio.fqm.exception.MaxQuerySizeExceededException;
+import org.folio.fqm.exception.QueryNotFoundException;
+import org.folio.fqm.model.IdsWithCancelCallback;
+import org.folio.fqm.repository.QueryRepository;
+import org.folio.fqm.repository.QueryResultsRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+public class DataBatchCallback implements TriConsumer<UUID, IdsWithCancelCallback, Integer> {
+
+  private final QueryRepository queryRepository;
+  private final QueryResultsRepository queryResultsRepository;
+  private int sortSequence = 0;
+
+  @Override
+  public void accept(UUID queryId, IdsWithCancelCallback idsWithCancelCallback, Integer maxQuerySize) {
+    Query query = queryRepository.getQuery(queryId, true)
+      .orElseThrow(() -> new QueryNotFoundException(queryId));
+    if (query.status() == QueryStatus.CANCELLED) {
+      log.info("Query {} has been cancelled, closing id stream", queryId);
+      idsWithCancelCallback.cancel();
+      return;
+    }
+    List<String[]> resultIds = idsWithCancelCallback.ids();
+    log.info("Saving query results for queryId: {}. Count: {}", queryId, resultIds.size());
+    queryResultsRepository.saveQueryResults(queryId, resultIds);
+    sortSequence += resultIds.size();
+    if (sortSequence > maxQuerySize) {
+      log.info("Query {} with size {} has exceeded maximum query size of {}. Marking execution as failed.",
+        queryId, sortSequence, maxQuerySize);
+      idsWithCancelCallback.cancel();
+      throw new MaxQuerySizeExceededException(queryId, sortSequence, maxQuerySize);
+    }
+  }
+}

--- a/src/main/java/org/folio/fqm/service/QueryExecutionCallbacks.java
+++ b/src/main/java/org/folio/fqm/service/QueryExecutionCallbacks.java
@@ -5,14 +5,10 @@ import lombok.extern.log4j.Log4j2;
 import org.folio.fqm.domain.Query;
 import org.folio.fqm.domain.QueryStatus;
 import org.folio.fqm.exception.QueryNotFoundException;
-import org.folio.fqm.model.IdsWithCancelCallback;
 import org.folio.fqm.repository.QueryRepository;
-import org.folio.fqm.repository.QueryResultsRepository;
 import org.springframework.stereotype.Service;
 
 import java.time.OffsetDateTime;
-import java.util.List;
-import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -20,20 +16,6 @@ import java.util.UUID;
 public class QueryExecutionCallbacks {
 
   private final QueryRepository queryRepository;
-  private final QueryResultsRepository queryResultsRepository;
-
-  public void handleDataBatch(UUID queryId, IdsWithCancelCallback idsWithCancelCallback) {
-    Query query = queryRepository.getQuery(queryId, true)
-      .orElseThrow(() -> new QueryNotFoundException(queryId));
-    if (query.status() == QueryStatus.CANCELLED) {
-      log.info("Query {} has been cancelled, closing id stream", queryId);
-      idsWithCancelCallback.cancel();
-      return;
-    }
-    List<String[]> resultIds = idsWithCancelCallback.ids();
-    log.info("Saving query results for queryId: {}. Count: {}", queryId, resultIds.size());
-    queryResultsRepository.saveQueryResults(queryId, resultIds);
-  }
 
   public void handleSuccess(Query query, int totalCount) {
     Query savedQuery = queryRepository.getQuery(query.queryId(), true)

--- a/src/main/java/org/folio/fqm/service/QueryExecutionService.java
+++ b/src/main/java/org/folio/fqm/service/QueryExecutionService.java
@@ -8,6 +8,8 @@ import org.folio.spring.FolioExecutionContext;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
+import java.util.function.Supplier;
+
 @Log4j2
 @Service
 @RequiredArgsConstructor
@@ -17,18 +19,20 @@ public class QueryExecutionService {
   private final QueryProcessorService queryProcessorService;
   private final FolioExecutionContext folioExecutionContext;
   private final QueryExecutionCallbacks callbacks;
+  private final Supplier<DataBatchCallback> dataBatchCallbackSupplier;
 
   @Async
   // Long-running method. Running this method within a transaction boundary will hog db connection for
   // long time. Hence, do not run this method in a transaction.
-  public void executeQueryAsync(Query query) {
+  public void executeQueryAsync(Query query, int maxQuerySize) {
     try {
       log.info("Executing query {}", query.queryId());
       var fqlQueryWithContext = new FqlQueryWithContext(folioExecutionContext.getTenantId(), query.entityTypeId(), query.fqlQuery(), false);
+      DataBatchCallback dataBatchCallback = dataBatchCallbackSupplier.get();
       queryProcessorService.getIdsInBatch(
         fqlQueryWithContext,
         DEFAULT_BATCH_SIZE,
-        resultIds -> callbacks.handleDataBatch(query.queryId(), resultIds),
+        resultIds -> dataBatchCallback.accept(query.queryId(), resultIds, maxQuerySize),
         totalCount -> callbacks.handleSuccess(query, totalCount),
         throwable -> callbacks.handleFailure(query, throwable)
       );

--- a/src/main/java/org/folio/fqm/service/QueryManagementService.java
+++ b/src/main/java/org/folio/fqm/service/QueryManagementService.java
@@ -1,6 +1,7 @@
 package org.folio.fqm.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.collections4.CollectionUtils;
 import org.folio.fql.model.Fql;
@@ -57,6 +58,9 @@ public class QueryManagementService {
   private final FqlService fqlService;
   @Value("${mod-fqm-manager.query-retention-duration}")
   private Duration queryRetentionDuration;
+  @Setter
+  @Value("${mod-fqm-manager.max-query-size}")
+  private int maxConfiguredQuerySize;
 
   /**
    * Initiates the asynchronous execution of a query and returns the corresponding query ID.
@@ -80,9 +84,10 @@ public class QueryManagementService {
       submitQuery.getFqlQuery(),
       fields,
       executionContext.getUserId());
+    int maxQuerySize = submitQuery.getMaxSize() == null ? maxConfiguredQuerySize : Math.min(submitQuery.getMaxSize(), maxConfiguredQuerySize);
     validateQuery(submitQuery.getEntityTypeId(), submitQuery.getFqlQuery());
     QueryIdentifier queryIdentifier = queryRepository.saveQuery(query);
-    queryExecutionService.executeQueryAsync(query);
+    queryExecutionService.executeQueryAsync(query, maxQuerySize);
     return queryIdentifier;
   }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,6 @@
 mod-fqm-manager:
   query-retention-duration: 3h
+  max-query-size: ${MAX_QUERY_SIZE:1250000}
 server:
   port: 8081
 spring:

--- a/src/test/java/org/folio/fqm/service/DataBatchCallbackTest.java
+++ b/src/test/java/org/folio/fqm/service/DataBatchCallbackTest.java
@@ -1,0 +1,94 @@
+package org.folio.fqm.service;
+
+import org.folio.fqm.domain.Query;
+import org.folio.fqm.domain.QueryStatus;
+import org.folio.fqm.domain.dto.Error;
+import org.folio.fqm.exception.MaxQuerySizeExceededException;
+import org.folio.fqm.model.IdsWithCancelCallback;
+import org.folio.fqm.repository.QueryRepository;
+import org.folio.fqm.repository.QueryResultsRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+@ExtendWith(MockitoExtension.class)
+class DataBatchCallbackTest {
+
+  @InjectMocks
+  private DataBatchCallback dataBatchCallback;
+  @Mock
+  private QueryRepository queryRepository;
+  @Mock
+  private QueryResultsRepository queryResultsRepository;
+
+  @Test
+  void shouldHandleDataBatch() {
+    UUID queryId = UUID.randomUUID();
+    int maxQuerySize = 100;
+    List<String[]> resultIds = List.of(
+      new String[]{UUID.randomUUID().toString()},
+      new String[]{UUID.randomUUID().toString()}
+    );
+    IdsWithCancelCallback idsWithCancelCallback = new IdsWithCancelCallback(resultIds, () -> {});
+    Query expectedQuery = new Query(queryId, UUID.randomUUID(), "", List.of(), UUID.randomUUID(),
+      OffsetDateTime.now(), null, QueryStatus.IN_PROGRESS, null);
+    when(queryRepository.getQuery(queryId, true)).thenReturn(Optional.of(expectedQuery));
+    dataBatchCallback.accept(queryId, idsWithCancelCallback, maxQuerySize);
+    verify(queryResultsRepository, times(1)).saveQueryResults(queryId, resultIds);
+  }
+
+  @Test
+  void shouldHandleDataBatchForCancelledQuery() {
+    AtomicBoolean streamClosed = new AtomicBoolean(false);
+    UUID queryId = UUID.randomUUID();
+    int maxQuerySize = 100;
+    List<String[]> resultIds = List.of(
+      new String[]{UUID.randomUUID().toString()},
+      new String[]{UUID.randomUUID().toString()}
+    );
+    IdsWithCancelCallback idsWithCancelCallback = new IdsWithCancelCallback(resultIds, () -> streamClosed.set(true));
+    assertFalse(streamClosed.get());
+    Query expectedQuery = new Query(queryId, UUID.randomUUID(), "", List.of(), UUID.randomUUID(),
+      OffsetDateTime.now(), null, QueryStatus.CANCELLED, null);
+    when(queryRepository.getQuery(queryId, true)).thenReturn(Optional.of(expectedQuery));
+    dataBatchCallback.accept(queryId, idsWithCancelCallback, maxQuerySize);
+    assertTrue(streamClosed.get());
+  }
+
+  @Test
+  void shouldThrowExceptionWhenMaxQuerySizeExceeded() {
+    UUID queryId = UUID.randomUUID();
+    int maxQuerySize = 1;
+    List<String[]> resultIds = List.of(
+      new String[]{UUID.randomUUID().toString()},
+      new String[]{UUID.randomUUID().toString()}
+    );
+    IdsWithCancelCallback idsWithCancelCallback = new IdsWithCancelCallback(resultIds, () -> {});
+    Query expectedQuery = new Query(queryId, UUID.randomUUID(), "", List.of(), UUID.randomUUID(),
+      OffsetDateTime.now(), null, QueryStatus.IN_PROGRESS, null);
+    String expectedMessage = String.format("Query %s with size %d has exceeded the maximum size of %d.", queryId, 2, maxQuerySize);
+    Error expectedError = new Error().message(expectedMessage);
+    when(queryRepository.getQuery(queryId, true)).thenReturn(Optional.of(expectedQuery));
+    MaxQuerySizeExceededException actualException = assertThrows(MaxQuerySizeExceededException.class, () -> dataBatchCallback.accept(queryId, idsWithCancelCallback, maxQuerySize));
+    assertEquals(expectedMessage, actualException.getMessage());
+    assertEquals(expectedError, actualException.getError());
+  }
+}

--- a/src/test/java/org/folio/fqm/service/QueryExecutionCallbacksTest.java
+++ b/src/test/java/org/folio/fqm/service/QueryExecutionCallbacksTest.java
@@ -3,7 +3,6 @@ package org.folio.fqm.service;
 import org.folio.fql.deserializer.FqlParsingException;
 import org.folio.fqm.domain.Query;
 import org.folio.fqm.domain.QueryStatus;
-import org.folio.fqm.model.IdsWithCancelCallback;
 import org.folio.fqm.repository.QueryRepository;
 import org.folio.fqm.repository.QueryResultsRepository;
 import org.folio.fqm.testutil.TestDataFixture;
@@ -17,10 +16,12 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.mockito.Mockito.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class QueryExecutionCallbacksTest {
@@ -31,38 +32,6 @@ class QueryExecutionCallbacksTest {
   private QueryRepository queryRepository;
   @Mock
   private QueryResultsRepository queryResultsRepository;
-
-  @Test
-  void shouldHandleDataBatch() {
-    UUID queryId = UUID.randomUUID();
-    List<String[]> resultIds = List.of(
-      new String[] {UUID.randomUUID().toString()},
-      new String[] {UUID.randomUUID().toString()}
-    );
-    IdsWithCancelCallback idsWithCancelCallback = new IdsWithCancelCallback(resultIds, () -> {});
-    Query expectedQuery = new Query(queryId, UUID.randomUUID(), "", List.of(), UUID.randomUUID(),
-      OffsetDateTime.now(), null, QueryStatus.IN_PROGRESS, null);
-    when(queryRepository.getQuery(queryId, true)).thenReturn(Optional.of(expectedQuery));
-    callbacks.handleDataBatch(queryId, idsWithCancelCallback);
-    verify(queryResultsRepository, times(1)).saveQueryResults(queryId, resultIds);
-  }
-
-  @Test
-  void shouldHandleDataBatchForCancelledQuery() {
-    AtomicBoolean streamClosed = new AtomicBoolean(false);
-    UUID queryId = UUID.randomUUID();
-    List<String[]> resultIds = List.of(
-      new String[] {UUID.randomUUID().toString()},
-      new String[] {UUID.randomUUID().toString()}
-    );
-    IdsWithCancelCallback idsWithCancelCallback = new IdsWithCancelCallback(resultIds, () -> streamClosed.set(true));
-    assertFalse(streamClosed.get());
-    Query expectedQuery = new Query(queryId, UUID.randomUUID(), "", List.of(), UUID.randomUUID(),
-      OffsetDateTime.now(), null, QueryStatus.CANCELLED, null);
-    when(queryRepository.getQuery(queryId, true)).thenReturn(Optional.of(expectedQuery));
-    callbacks.handleDataBatch(queryId, idsWithCancelCallback);
-    assertTrue(streamClosed.get());
-  }
 
   @Test
   void shouldHandleSuccess() {

--- a/src/test/java/org/folio/fqm/service/QueryExecutionServiceTest.java
+++ b/src/test/java/org/folio/fqm/service/QueryExecutionServiceTest.java
@@ -11,6 +11,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.function.Supplier;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -25,6 +26,8 @@ class QueryExecutionServiceTest {
   private QueryProcessorService queryProcessorService;
   @Mock
   private FolioExecutionContext executionContext;
+  @Mock
+  private Supplier<DataBatchCallback> dataBatchCallbackSupplier;
 
   @Test
   void testQueryExecutionService() {
@@ -34,8 +37,10 @@ class QueryExecutionServiceTest {
     String fqlQuery = "{“item_status“: {“$in“: [\"missing\", \"lost\"]}}";
     List<String> fields = List.of();
     Query query = Query.newQuery(entityTypeId, fqlQuery, fields, createdById);
+    int maxSize = 100;
     when(executionContext.getTenantId()).thenReturn(tenantId);
-    queryExecutionService.executeQueryAsync(query);
+
+    queryExecutionService.executeQueryAsync(query, maxSize);
     FqlQueryWithContext fqlQueryWithContext = new FqlQueryWithContext(tenantId, entityTypeId, fqlQuery, false);
     verify(queryProcessorService, times(1)).getIdsInBatch(
       eq(fqlQueryWithContext),


### PR DESCRIPTION
## Purpose
[MODFQMMGR-172](https://folio-org.atlassian.net/browse/MODFQMMGR-172): Set a limit on the maximum number of query results

## Approach
- Define a variable max-query-size in application.yml. This is the application-wide maximum query size
- Define a variable in SubmitQuery requests called maxSize. This is the maximum query size for an individual query.
- If SubmitQuery doesn't contain a maxSize field, use the application-wide max query size. If SubmitQuery does contain a maxSize field, use min(application-wide-max-query-size, individual-query-max-query-size) as the maximum size.
- If maximum size is exceeded, throw MaxQuerySizeExceededException
