### PR TITLE
Increase memory to 600 MiB

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -267,7 +267,7 @@
     "dockerPull": false,
     "dockerArgs": {
       "HostConfig": {
-        "Memory": 357913941,
+        "Memory": 629145600,
         "PortBindings": { "8081/tcp": [ { "HostPort": "%p" } ] }
       }
     },


### PR DESCRIPTION
## Purpose
Increase memory to 600 MiB so that snapshot doesn't die constantly
