### PR TITLE
MODFQMMGR-208 Change a JOIN to a LEFT JOIN

### DIFF
--- a/src/main/resources/db/changelog/changes/v1.1.0/insert-instances-definition.xml
+++ b/src/main/resources/db/changelog/changes/v1.1.0/insert-instances-definition.xml
@@ -27,7 +27,7 @@
           "id": "6b08439b-4f8e-4468-8046-ea620f5cfb74",
           "name": "drv_instances",
           "private": false,
-          "fromClause": "src_inventory_instance JOIN src_inventory_instance_status inst_stat ON inst_stat.id :: text = src_inventory_instance.jsonb ->> 'statusId' :: text JOIN src_inventory_mode_of_issuance mode_issuance ON mode_issuance.id :: text = src_inventory_instance.jsonb ->> 'modeOfIssuanceId'::text",
+          "fromClause": "src_inventory_instance JOIN src_inventory_instance_status inst_stat ON inst_stat.id :: text = src_inventory_instance.jsonb ->> 'statusId' :: text LEFT JOIN src_inventory_mode_of_issuance mode_issuance ON mode_issuance.id :: text = src_inventory_instance.jsonb ->> 'modeOfIssuanceId'::text",
           "columns": [
             {
               "name": "instance_cataloged_date",


### PR DESCRIPTION
In cases where an instance's mode of issuance is null, the whole instance disappears from the Instances entity type. This commit addresses that bug by changing the join between instances and mode of issuance from an inner join to a left join