### PR TITLE
MODFQMMGR-201 Add limit param to value source API calls

### DIFF
--- a/src/main/java/org/folio/fqm/client/SimpleHttpClient.java
+++ b/src/main/java/org/folio/fqm/client/SimpleHttpClient.java
@@ -1,18 +1,23 @@
 package org.folio.fqm.client;
 
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.cloud.openfeign.SpringQueryMap;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.Map;
 
 @Service
 @FeignClient(name = "simple-http-client", url = ".")
 public interface SimpleHttpClient {
   /**
    * Retrieve arbitrary data from a FOLIO API endpoint.
+   * @param path - the path of the API endpoint
+   * @param queryParams - a map of query parameters to pass to the API endpoint
    * @return the body of the response (JSON)
    */
-  @GetMapping(value = "/{path}", produces = MediaType.APPLICATION_JSON_VALUE)
-  String get(@PathVariable String path);
+  @GetMapping(value = "/{path}?{queryParams}", produces = MediaType.APPLICATION_JSON_VALUE)
+  String get(@PathVariable String path, @SpringQueryMap Map<String, String> queryParams);
 }

--- a/src/main/java/org/folio/fqm/service/EntityTypeService.java
+++ b/src/main/java/org/folio/fqm/service/EntityTypeService.java
@@ -109,7 +109,7 @@ public class EntityTypeService {
   }
 
   private ColumnValues getFieldValuesFromApi(Field field, String searchText) {
-    String rawJson = fieldValueClient.get(field.getValueSourceApi().getPath());
+    String rawJson = fieldValueClient.get(field.getValueSourceApi().getPath(), Map.of("limit", String.valueOf(COLUMN_VALUE_DEFAULT_PAGE_SIZE)));
     DocumentContext parsedJson = JsonPath.parse(rawJson);
     List<String> values = parsedJson.read(field.getValueSourceApi().getValueJsonPath());
     List<String> labels = parsedJson.read(field.getValueSourceApi().getLabelJsonPath());

--- a/src/test/java/org/folio/fqm/service/EntityTypeServiceTest.java
+++ b/src/test/java/org/folio/fqm/service/EntityTypeServiceTest.java
@@ -205,7 +205,7 @@ class EntityTypeServiceTest {
       ));
 
     when(repo.getEntityTypeDefinition(entityTypeId)).thenReturn(Optional.of(entityType));
-    when(simpleHttpClient.get("fake-path")).thenReturn("""
+    when(simpleHttpClient.get(eq("fake-path"), anyMap())).thenReturn("""
            {
              "what": {
                "ever": {


### PR DESCRIPTION
This commit adds a "limit" query parameter with a value of 1000 to every value source API call, since some API endpoints have a fairly low default limit. This brings the API approach to source values in line with the DB approach (which also limits to 1000). In the future, we may need to make this more flexible, in case we run into API endpoints in FOLIO that reject this query parameter