### PR TITLE
MODFQMMGR-217 Lower contributor-name-types dependency version

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -281,7 +281,7 @@
     },
     {
       "id": "contributor-name-types",
-      "version": "1.3"
+      "version": "1.2"
     },
     {
       "id": "modes-of-issuance",


### PR DESCRIPTION
This change should allow FQM to work with Orchid and Poppy versions of contributor-name-types