### PR TITLE
MODFQMMGR-289:custom fields not available when building queries

### DIFF
--- a/src/main/java/org/folio/fqm/repository/EntityTypeRepository.java
+++ b/src/main/java/org/folio/fqm/repository/EntityTypeRepository.java
@@ -146,6 +146,7 @@ public class EntityTypeRepository {
       .visibleByDefault(false)
       .valueGetter(sourceViewExtractor + " ->> '" + refId + "'")
       .labelAlias(value)
+      .queryable(true)
       .isCustomField(true);
   }
 

--- a/src/test/java/org/folio/fqm/repository/EntityTypeRepositoryTest.java
+++ b/src/test/java/org/folio/fqm/repository/EntityTypeRepositoryTest.java
@@ -94,6 +94,7 @@ class EntityTypeRepositoryTest {
         .labelAlias("custom_column_1")
         .values(values)
         .visibleByDefault(false)
+        .queryable(true)
         .isCustomField(true),
       new EntityTypeColumn()
         .name("custom_column_2")
@@ -102,6 +103,7 @@ class EntityTypeRepositoryTest {
         .labelAlias("custom_column_2")
         .values(values)
         .visibleByDefault(false)
+        .queryable(true)
         .isCustomField(true)
     );
     EntityType expectedEntityType = new EntityType()


### PR DESCRIPTION
<img width="407" alt="Screen Shot 2024-05-15 at 12 55 17 PM" src="https://github.com/folio-org/mod-fqm-manager/assets/114437186/5294d265-a691-4a72-b468-2847d4b2f156">
