### PR TITLE
MODFQMMGR-290: Fix instance_status join condition

### DIFF
--- a/src/main/resources/entity-types/inventory/drv_instances.json5
+++ b/src/main/resources/entity-types/inventory/drv_instances.json5
@@ -2,7 +2,7 @@
   id: '6b08439b-4f8e-4468-8046-ea620f5cfb74',
   name: 'drv_instances',
   private: false,
-  fromClause: "src_inventory_instance JOIN src_inventory_instance_status inst_stat ON inst_stat.id :: text = src_inventory_instance.jsonb ->> 'statusId' :: text LEFT JOIN src_inventory_mode_of_issuance mode_issuance ON mode_issuance.id :: text = src_inventory_instance.jsonb ->> 'modeOfIssuanceId'::text",
+  fromClause: "src_inventory_instance LEFT JOIN src_inventory_instance_status inst_stat ON inst_stat.id :: text = src_inventory_instance.jsonb ->> 'statusId' :: text LEFT JOIN src_inventory_mode_of_issuance mode_issuance ON mode_issuance.id :: text = src_inventory_instance.jsonb ->> 'modeOfIssuanceId'::text",
   columns: [
     {
       name: 'instance_cataloged_date',


### PR DESCRIPTION
## Purpose
[MODFQMMGR-290: Fix instance_status join condition](https://folio-org.atlassian.net/browse/MODFQMMGR-290)

Make instance_status join a LEFT JOIN so that instance info is maintained even if statusId is null.
