### PR TITLE
 MODFQMMGR-221: Create test to verify read-write split is functioning properly

### DIFF
--- a/src/test/java/org/folio/fqm/context/ReadWriteSplitTest.java
+++ b/src/test/java/org/folio/fqm/context/ReadWriteSplitTest.java
@@ -1,0 +1,59 @@
+package org.folio.fqm.context;
+
+import org.folio.fqm.repository.QueryResultsRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+
+import javax.sql.DataSource;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@SpringBootTest
+@ContextConfiguration(classes = ReadWriteSplitTestConfiguration.class)
+@ActiveProfiles("ReadWriteSplit")
+class ReadWriteSplitTest {
+
+  @Autowired
+  @Qualifier("readerDataSource")
+  private DataSource readerDataSource;
+
+  @Autowired
+  @Qualifier("dataSource")
+  private DataSource dataSource;
+
+  @Autowired
+  private QueryResultsRepository queryResultsRepository;
+
+  @Test
+  @DirtiesContext
+  void shouldUseReaderForReadOperations() throws SQLException {
+    UUID queryId = UUID.randomUUID();
+    assertThrows(Exception.class, () -> queryResultsRepository.getQueryResultIds(queryId, 0, 100));
+    verifyNoInteractions(dataSource);
+    verify(readerDataSource, atLeastOnce()).getConnection();
+  }
+
+  @Test
+  @DirtiesContext
+  void shouldUseWriterForWriteOperations() throws SQLException {
+    UUID queryId = UUID.randomUUID();
+    List<String[]> resultIds = List.of(
+      new String[] {"id1"},
+      new String[] {"id2"}
+    );
+    assertThrows(Exception.class, () -> queryResultsRepository.saveQueryResults(queryId, resultIds));
+    verifyNoInteractions(readerDataSource);
+    verify(dataSource, atLeastOnce()).getConnection();
+  }
+}

--- a/src/test/java/org/folio/fqm/context/ReadWriteSplitTestConfiguration.java
+++ b/src/test/java/org/folio/fqm/context/ReadWriteSplitTestConfiguration.java
@@ -1,0 +1,48 @@
+package org.folio.fqm.context;
+
+import org.folio.fqm.repository.QueryResultsRepository;
+import org.jooq.DSLContext;
+import org.jooq.SQLDialect;
+import org.jooq.impl.DSL;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+
+import javax.sql.DataSource;
+
+import static org.mockito.Mockito.mock;
+
+
+@Configuration
+@Profile("ReadWriteSplit")
+public class ReadWriteSplitTestConfiguration {
+
+  @Primary
+  @Bean("dataSource")
+  public DataSource dataSource() {
+    return mock(DataSource.class);
+  }
+
+  @Bean("readerDataSource")
+  public DataSource readerDataSource() {
+    return mock(DataSource.class);
+  }
+
+  @Primary
+  @Bean("jooqContext")
+  public DSLContext writerJooqContext(DataSource dataSource) {
+    return DSL.using(dataSource, SQLDialect.POSTGRES);
+  }
+
+  @Bean("readerJooqContext")
+  public DSLContext readerJooqContext(@Qualifier("readerDataSource") DataSource dataSource) {
+    return DSL.using(dataSource, SQLDialect.POSTGRES);
+  }
+
+  @Bean
+  public QueryResultsRepository queryResultsRepository(@Qualifier("readerJooqContext") DSLContext readerJooqContext, DSLContext jooqContext) {
+    return new QueryResultsRepository(readerJooqContext, jooqContext);
+  }
+}


### PR DESCRIPTION
## Purpose
[MODFQMMGR-221: Create test to verify read-write split is functioning properly](https://folio-org.atlassian.net/browse/MODFQMMGR-221)


## Approach
Create a ReadWriteSplitTestConfiguration class to create required beans with mock datasources. Have spring inject the beans into a repository class. Perform read/write operations and check that the correct datasource is used.
