### PR TITLE
Remove subpermissions from fqm.entityTypes.item.get permission set

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -138,23 +138,7 @@
       "permissionName": "fqm.entityTypes.item.get",
       "displayName": "FQM - Get details of a single entity type",
       "description": "Get details of a single entity type",
-      "visible":  true,
-      "subPermissions": [
-        "inventory-storage.material-types.collection.get",
-        "inventory-storage.locations.collection.get",
-        "inventory-storage.location-units.libraries.collection.get",
-        "usergroups.collection.get",
-        "circulation-storage.loan-policies.collection.get",
-        "inventory-storage.service-points.collection.get",
-        "organizations.organizations.collection.get",
-        "acquisitions-units.units.collection.get",
-        "addresstypes.collection.get",
-        "departments.collection.get",
-        "acquisitions-units-storage.memberships.collection.get",
-        "acquisitions-units-storage.units.collection.get",
-        "organizations-storage.organizations.collection.get",
-        "inventory-storage.call-number-types.collection.get"
-      ]
+      "visible":  true
     },
     {
       "permissionName": "fqm.entityTypes.item.columnValues.get",

--- a/src/main/resources/entity-types/organizations/drv_organization_contacts.json5
+++ b/src/main/resources/entity-types/organizations/drv_organization_contacts.json5
@@ -4,7 +4,7 @@
   private: false,
   fromClause: 'src_organizations AS org',
   requiredPermissions: [
-    "organizations.organizations.item.get",
+    "organizations.organizations.collection.get",
     "organizations-storage.organization-types.collection.get",
     "organizations-storage.categories.collection.get",
     "acquisitions-units.units.collection.get",

--- a/src/main/resources/entity-types/organizations/drv_organization_details.json5
+++ b/src/main/resources/entity-types/organizations/drv_organization_details.json5
@@ -4,7 +4,7 @@
   private: false,
   fromClause: 'src_organizations as org',
   requiredPermissions: [
-    "organizations.organizations.item.get",
+    "organizations.organizations.collection.get",
     "organizations-storage.organization-types.collection.get",
     "acquisitions-units.units.collection.get",
   ],

--- a/src/main/resources/entity-types/pol/drv_purchase_order_line_details.json5
+++ b/src/main/resources/entity-types/pol/drv_purchase_order_line_details.json5
@@ -7,7 +7,7 @@
     "orders.po-lines.item.get",
     "orders.item.get",
     "acquisitions-units.units.collection.get",
-    "organizations.organizations.item.get",
+    "organizations.organizations.collection.get",
     "users.collection.get",
     "finance.exchange-rate.item.get",
     "configuration.entries.collection.get"

--- a/src/test/java/org/folio/fqm/IntegrationTestBase.java
+++ b/src/test/java/org/folio/fqm/IntegrationTestBase.java
@@ -155,7 +155,7 @@ public class IntegrationTestBase {
       if (recordedRequest.getPath().matches("/perms/users/[-0-9a-f]+/permissions\\?expanded=true&indexField=userId")) {
         return new MockResponse().setBody("""
           {
-            "permissionNames": [ "organizations.organizations.item.get",
+            "permissionNames": [ "organizations.organizations.collection.get",
                                  "organizations-storage.organization-types.collection.get",
                                  "acquisitions-units.units.collection.get"
             ],


### PR DESCRIPTION
## Purpose
Remove subpermissions from the fqm.entityTypes.item.get. Move the permissions to the entity type definitions.

Every permission removed from the MD is now contained within the definitions of any entity types that need it. 2 permissions were removed completely:
`acquisitions-units-storage.memberships.collection.get`
`acquisitions-units-storage.units.collection.get`

These are unneeded, because access to acquisitions units is obtained through `acquisitions-units.units.collection.get`