### PR TITLE
Add required interfaces to module descriptor

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -308,6 +308,10 @@
     {
       "id": "circulation",
       "version": "14.2"
+    },
+    {
+      "id": "orders",
+      "version": "12.0"
     }
   ],
   "launchDescriptor": {

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -304,6 +304,10 @@
     {
       "id": "finance.exchange-rate",
       "version": "1.0"
+    },
+    {
+      "id": "circulation",
+      "version": "14.2"
     }
   ],
   "launchDescriptor": {

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -312,6 +312,10 @@
     {
       "id": "orders",
       "version": "12.0"
+    },
+    {
+      "id": "organizations.organizations",
+      "version": "1.2"
     }
   ],
   "launchDescriptor": {


### PR DESCRIPTION
## Purpose
We use permissions provided by mod-orders, mod-organizations, and mod-circulation, but don't have any interfaces from those modules in our module descriptor. This is a PR to add the missing interfaces.
