### PR TITLE
MODFQMMGR-303: Add additional holdings-storage version to module descriptor

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -203,7 +203,7 @@
     },
     {
       "id": "holdings-storage",
-      "version": "6.0"
+      "version": "6.0 7.0"
     },
     {
       "id": "instance-storage",


### PR DESCRIPTION
## Purpose
[MODFQMMGR-303](https://folio-org.atlassian.net/browse/MODFQMMGR-303): holdings-storage API version update

The version update introduces a breaking change, making one new field required in the holdings schema. This shouldn't affect mod-fqm-manager in any way though.
