### PR TITLE
[MODFQMMGR-387] Pre-resolve locale-related information before starting async tasks

### DIFF
--- a/src/main/java/org/folio/fqm/model/FqlQueryWithContext.java
+++ b/src/main/java/org/folio/fqm/model/FqlQueryWithContext.java
@@ -1,6 +1,5 @@
 package org.folio.fqm.model;
 
-import java.util.UUID;
+import org.folio.querytool.domain.dto.EntityType;
 
-public record FqlQueryWithContext(String tenantId, UUID entityTypeId, String fqlQuery, boolean sortResults) {
-}
+public record FqlQueryWithContext(String tenantId, EntityType entityType, String fqlQuery, boolean sortResults) {}

--- a/src/main/java/org/folio/fqm/repository/IdStreamer.java
+++ b/src/main/java/org/folio/fqm/repository/IdStreamer.java
@@ -47,13 +47,11 @@ public class IdStreamer {
   /**
    * Executes the given Fql Query and stream the result Ids back.
    */
-  public int streamIdsInBatch(UUID entityTypeId,
+  public int streamIdsInBatch(EntityType entityType,
                               boolean sortResults,
                               Fql fql,
                               int batchSize,
                               Consumer<IdsWithCancelCallback> idsConsumer) {
-    EntityType entityType = entityTypeFlatteningService
-      .getFlattenedEntityType(entityTypeId, true);
     Condition sqlWhereClause = FqlToSqlConverterService.getSqlCondition(fql.fqlCondition(), entityType);
     return this.streamIdsInBatch(entityType, sortResults, sqlWhereClause, batchSize, idsConsumer);
   }

--- a/src/main/java/org/folio/fqm/service/QueryManagementService.java
+++ b/src/main/java/org/folio/fqm/service/QueryManagementService.java
@@ -77,7 +77,7 @@ public class QueryManagementService {
     int maxQuerySize = submitQuery.getMaxSize() == null ? maxConfiguredQuerySize : Math.min(submitQuery.getMaxSize(), maxConfiguredQuerySize);
     validateQuery(submitQuery.getEntityTypeId(), submitQuery.getFqlQuery());
     QueryIdentifier queryIdentifier = queryRepository.saveQuery(query);
-    queryExecutionService.executeQueryAsync(query, maxQuerySize);
+    queryExecutionService.executeQueryAsync(query, entityType, maxQuerySize);
     return queryIdentifier;
   }
 

--- a/src/main/java/org/folio/fqm/service/QueryProcessorService.java
+++ b/src/main/java/org/folio/fqm/service/QueryProcessorService.java
@@ -48,7 +48,7 @@ public class QueryProcessorService {
     try {
       Fql fql = fqlService.getFql(fqlQueryWithContext.fqlQuery());
       int idsCount = idStreamer.streamIdsInBatch(
-        fqlQueryWithContext.entityTypeId(),
+        fqlQueryWithContext.entityType(),
         fqlQueryWithContext.sortResults(),
         fql,
         batchSize,

--- a/src/test/java/org/folio/fqm/service/QueryExecutionServiceTest.java
+++ b/src/test/java/org/folio/fqm/service/QueryExecutionServiceTest.java
@@ -2,6 +2,7 @@ package org.folio.fqm.service;
 
 import org.folio.fqm.domain.Query;
 import org.folio.fqm.model.FqlQueryWithContext;
+import org.folio.querytool.domain.dto.EntityType;
 import org.folio.spring.FolioExecutionContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,6 +34,7 @@ class QueryExecutionServiceTest {
   void testQueryExecutionService() {
     String tenantId = "Tenant_01";
     UUID entityTypeId = UUID.randomUUID();
+    EntityType entityType = new EntityType();
     UUID createdById = UUID.randomUUID();
     String fqlQuery = "{“item_status“: {“$in“: [\"missing\", \"lost\"]}}";
     List<String> fields = List.of();
@@ -40,8 +42,8 @@ class QueryExecutionServiceTest {
     int maxSize = 100;
     when(executionContext.getTenantId()).thenReturn(tenantId);
 
-    queryExecutionService.executeQueryAsync(query, maxSize);
-    FqlQueryWithContext fqlQueryWithContext = new FqlQueryWithContext(tenantId, entityTypeId, fqlQuery, false);
+    queryExecutionService.executeQueryAsync(query, entityType, maxSize);
+    FqlQueryWithContext fqlQueryWithContext = new FqlQueryWithContext(tenantId, entityType, fqlQuery, false);
     verify(queryProcessorService, times(1)).getIdsInBatch(
       eq(fqlQueryWithContext),
       anyInt(),

--- a/src/test/java/org/folio/fqm/service/QueryManagementServiceTest.java
+++ b/src/test/java/org/folio/fqm/service/QueryManagementServiceTest.java
@@ -109,7 +109,7 @@ class QueryManagementServiceTest {
     when(queryRepository.saveQuery(any())).thenReturn(expectedIdentifier);
     QueryIdentifier actualIdentifier = queryManagementService.runFqlQueryAsync(submitQuery);
     assertEquals(expectedIdentifier, actualIdentifier);
-    verify(queryExecutionService, times(1)).executeQueryAsync(any(), eq(maxQuerySize));
+    verify(queryExecutionService, times(1)).executeQueryAsync(any(), eq(entityType), eq(maxQuerySize));
   }
 
   @Test
@@ -134,7 +134,7 @@ class QueryManagementServiceTest {
     when(queryRepository.saveQuery(any())).thenReturn(expectedIdentifier);
     QueryIdentifier actualIdentifier = queryManagementService.runFqlQueryAsync(submitQuery);
     assertEquals(expectedIdentifier, actualIdentifier);
-    verify(queryExecutionService, times(1)).executeQueryAsync(any(), eq(maxConfiguredQuerySize));
+    verify(queryExecutionService, times(1)).executeQueryAsync(any(), eq(entityType), eq(maxConfiguredQuerySize));
   }
 
   @Test
@@ -167,7 +167,7 @@ class QueryManagementServiceTest {
     QueryIdentifier actualIdentifier = queryManagementService.runFqlQueryAsync(submitQuery);
     assertEquals(expectedIdentifier, actualIdentifier);
 
-    verify(queryExecutionService, times(1)).executeQueryAsync(queryCaptor.capture(), eq(maxConfiguredQuerySize));
+    verify(queryExecutionService, times(1)).executeQueryAsync(queryCaptor.capture(), eq(entityType), eq(maxConfiguredQuerySize));
     assertEquals(expectedFields, queryCaptor.getValue().fields());
   }
 
@@ -185,7 +185,7 @@ class QueryManagementServiceTest {
     when(entityTypeService.getEntityTypeDefinition(entityTypeId)).thenReturn(entityType);
     when(fqlValidationService.validateFql(entityType, fqlQuery)).thenReturn(Map.of("field1", "Field is invalid"));
     assertThrows(InvalidFqlException.class, () -> queryManagementService.runFqlQueryAsync(submitQuery));
-    verify(queryExecutionService, times(0)).executeQueryAsync(any(), eq(maxQuerySize));
+    verify(queryExecutionService, times(0)).executeQueryAsync(any(), eq(entityType), eq(maxQuerySize));
   }
 
   @Test
@@ -399,7 +399,6 @@ class QueryManagementServiceTest {
     assertThrows(QueryNotFoundException.class, () -> queryManagementService.deleteQuery(queryId));
   }
 
-  // TODO: remove commented lines
   @Test
   void shouldGetSortedIds() {
     Query query = TestDataFixture.getMockQuery(QueryStatus.SUCCESS);

--- a/src/test/java/org/folio/fqm/service/QueryProcessorServiceTest.java
+++ b/src/test/java/org/folio/fqm/service/QueryProcessorServiceTest.java
@@ -8,6 +8,7 @@ import org.folio.fqm.model.FqlQueryWithContext;
 import org.folio.fqm.model.IdsWithCancelCallback;
 import org.folio.fqm.repository.IdStreamer;
 import org.folio.fqm.repository.ResultSetRepository;
+import org.folio.querytool.domain.dto.EntityType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -40,13 +41,13 @@ class QueryProcessorServiceTest {
     Fql fql = new Fql(new EqualsCondition(new FqlField("status"), "missing"));
     String tenantId = "tenant_01";
     String fqlCriteria = "{\"status\": {\"$eq\": \"missing\"}}";
-    UUID entityTypeId = UUID.randomUUID();
+    EntityType entityType = new EntityType();
     Consumer<IdsWithCancelCallback> idsConsumer = mock(Consumer.class);
     IntConsumer totalCountConsumer = mock(IntConsumer.class);
     Consumer<Throwable> errorConsumer = mock(Consumer.class);
 
     when(fqlService.getFql(fqlCriteria)).thenReturn(fql);
-    FqlQueryWithContext fqlQueryWithContext = new FqlQueryWithContext(tenantId, entityTypeId, fqlCriteria, true);
+    FqlQueryWithContext fqlQueryWithContext = new FqlQueryWithContext(tenantId, entityType, fqlCriteria, true);
     service.getIdsInBatch(fqlQueryWithContext,
       DEFAULT_BATCH_SIZE,
       idsConsumer,
@@ -56,7 +57,7 @@ class QueryProcessorServiceTest {
 
     verify(idStreamer, times(1))
       .streamIdsInBatch(
-        fqlQueryWithContext.entityTypeId(),
+        fqlQueryWithContext.entityType(),
         fqlQueryWithContext.sortResults(),
         fql,
         DEFAULT_BATCH_SIZE,
@@ -69,7 +70,7 @@ class QueryProcessorServiceTest {
     Fql fql = new Fql(new EqualsCondition(new FqlField("status"), "missing"));
     String tenantId = "tenant_01";
     String fqlCriteria = "{\"status\": {\"$eq\": \"missing\"}}";
-    UUID entityTypeId = UUID.randomUUID();
+    EntityType entityType = new EntityType();
     Consumer<IdsWithCancelCallback> idsConsumer = mock(Consumer.class);
     IntConsumer totalCountConsumer = mock(IntConsumer.class);
     AtomicInteger actualErrorCount = new AtomicInteger(0);
@@ -77,12 +78,12 @@ class QueryProcessorServiceTest {
     int expectedErrorCount = 1;
 
     when(fqlService.getFql(fqlCriteria)).thenReturn(fql);
-    FqlQueryWithContext fqlQueryWithContext = new FqlQueryWithContext(tenantId, entityTypeId, fqlCriteria, true);
+    FqlQueryWithContext fqlQueryWithContext = new FqlQueryWithContext(tenantId, entityType, fqlCriteria, true);
 
     doThrow(new RuntimeException("something went wrong"))
       .when(idStreamer)
       .streamIdsInBatch(
-        fqlQueryWithContext.entityTypeId(),
+        fqlQueryWithContext.entityType(),
         fqlQueryWithContext.sortResults(),
         fql,
         1000,


### PR DESCRIPTION
# [MODFQMMGR-387](https://folio-org.atlassian.net/browse/MODFQMMGR-387/)

The localization service uses information from the current thread to determine which locale(s) should be used; this normally works fine, however, Spring discards this information when we are processing queries asynchronously, causing a large quantity of logged errors. This does not affect the results (since the translated names are not used for query processing), however, it is annoying to look at.

It [is possible to share context](https://stackoverflow.com/a/50138897/4236490) with async threads in Spring, however, just doing this alone causes weirder issues where Tomcat will discard the request context once the request completes, causing it to no longer be accessible when the async thread attempts to access it — I was unable to find any way around this without disabling request recycling entirely, which is asking for memory leaks (and [Spring maintainers specifically mention that this context will be unreliable outside the thread](https://github.com/spring-projects/spring-boot/issues/36763#issuecomment-1667382305)).

To solve this, I'm just passing the fully resolved entity type as part of the query task, so no resolution needs to be done inside the async task. This is already being resolved/flattened/translated before the job is kicked off, it was just redone in the task, so, if anything, this should be a performance increase.