### PR TITLE
MODFQMMGR-361 Add available values for a loan policy field

### DIFF
--- a/src/main/resources/entity-types/circulation/simple_loan_policy.json5
+++ b/src/main/resources/entity-types/circulation/simple_loan_policy.json5
@@ -124,17 +124,6 @@
       valueGetter: ":sourceAlias.jsonb->'loansPolicy'->>'profileId'",
     },
     {
-      name: 'closed_library_due_date_management',
-      sourceAlias: 'lp',
-      dataType: {
-        dataType: 'stringType',
-      },
-      isIdColumn: false,
-      queryable: true,
-      visibleByDefault: false,
-      valueGetter: ":sourceAlias.jsonb->'loansPolicy'->>'closedLibraryDueDateManagementId'",
-    },
-    {
       name: 'renewable',
       sourceAlias: 'lp',
       dataType: {
@@ -273,6 +262,32 @@
       queryable: true,
       visibleByDefault: false,
       valueGetter: ":sourceAlias.jsonb->'loansPolicy'->>'closedLibraryDueDateManagementId'",
+      values: [ // From https://github.com/folio-org/mod-circulation/blob/master/src/main/java/org/folio/circulation/domain/policy/DueDateManagement.java
+        {
+          label: 'CURRENT_DUE_DATE',
+          value: 'CURRENT_DUE_DATE',
+        },
+        {
+          label: 'END_OF_THE_PREVIOUS_OPEN_DAY',
+          value: 'END_OF_THE_PREVIOUS_OPEN_DAY',
+        },
+        {
+          label: 'END_OF_THE_NEXT_OPEN_DAY',
+          value: 'END_OF_THE_NEXT_OPEN_DAY',
+        },
+        {
+          label: 'CURRENT_DUE_DATE_TIME',
+          value: 'CURRENT_DUE_DATE_TIME',
+        },
+        {
+          label: 'END_OF_THE_CURRENT_SERVICE_POINT_HOURS',
+          value: 'END_OF_THE_CURRENT_SERVICE_POINT_HOURS',
+        },
+        {
+          label: 'BEGINNING_OF_THE_NEXT_OPEN_SERVICE_POINT_HOURS',
+          value: 'BEGINNING_OF_THE_NEXT_OPEN_SERVICE_POINT_HOURS',
+        },
+      ],
     },
     {
       name: 'loans_policy_grace_period_duration',

--- a/translations/mod-fqm-manager/ar.json
+++ b/translations/mod-fqm-manager/ar.json
@@ -1177,7 +1177,6 @@
     "entityType.simple_instance.updated_by": "Updated by user UUID",
     "entityType.simple_instance.version": "Record version",
     "entityType.simple_loan_policy": "Loan policies",
-    "entityType.simple_loan_policy.closed_library_due_date_management": "Closed library due date management",
     "entityType.simple_loan_policy.created_at": "Created at",
     "entityType.simple_loan_policy.created_by": "Created by user UUID",
     "entityType.simple_loan_policy.description": "Description",

--- a/translations/mod-fqm-manager/ber.json
+++ b/translations/mod-fqm-manager/ber.json
@@ -1177,7 +1177,6 @@
     "entityType.simple_instance.updated_by": "Updated by user UUID",
     "entityType.simple_instance.version": "Record version",
     "entityType.simple_loan_policy": "Loan policies",
-    "entityType.simple_loan_policy.closed_library_due_date_management": "Closed library due date management",
     "entityType.simple_loan_policy.created_at": "Created at",
     "entityType.simple_loan_policy.created_by": "Created by user UUID",
     "entityType.simple_loan_policy.description": "Description",

--- a/translations/mod-fqm-manager/ca.json
+++ b/translations/mod-fqm-manager/ca.json
@@ -1177,7 +1177,6 @@
     "entityType.simple_instance.updated_by": "Updated by user UUID",
     "entityType.simple_instance.version": "Record version",
     "entityType.simple_loan_policy": "Loan policies",
-    "entityType.simple_loan_policy.closed_library_due_date_management": "Closed library due date management",
     "entityType.simple_loan_policy.created_at": "Created at",
     "entityType.simple_loan_policy.created_by": "Created by user UUID",
     "entityType.simple_loan_policy.description": "Description",

--- a/translations/mod-fqm-manager/cs_CZ.json
+++ b/translations/mod-fqm-manager/cs_CZ.json
@@ -1177,7 +1177,6 @@
     "entityType.simple_instance.updated_by": "Aktualizováno uživatelem UUID",
     "entityType.simple_instance.version": "Verze záznamu",
     "entityType.simple_loan_policy": "Pravidla pro výpůjčky",
-    "entityType.simple_loan_policy.closed_library_due_date_management": "Určení termínu vrácení v době uzavření knihovny",
     "entityType.simple_loan_policy.created_at": "Vytvořeno v",
     "entityType.simple_loan_policy.created_by": "Vytvořeno uživatelem UUID",
     "entityType.simple_loan_policy.description": "Popis",

--- a/translations/mod-fqm-manager/da.json
+++ b/translations/mod-fqm-manager/da.json
@@ -1177,7 +1177,6 @@
     "entityType.simple_instance.updated_by": "Updated by user UUID",
     "entityType.simple_instance.version": "Record version",
     "entityType.simple_loan_policy": "Loan policies",
-    "entityType.simple_loan_policy.closed_library_due_date_management": "Closed library due date management",
     "entityType.simple_loan_policy.created_at": "Created at",
     "entityType.simple_loan_policy.created_by": "Created by user UUID",
     "entityType.simple_loan_policy.description": "Description",

--- a/translations/mod-fqm-manager/de.json
+++ b/translations/mod-fqm-manager/de.json
@@ -1177,7 +1177,6 @@
     "entityType.simple_instance.updated_by": "Updated by user UUID",
     "entityType.simple_instance.version": "Record version",
     "entityType.simple_loan_policy": "Loan policies",
-    "entityType.simple_loan_policy.closed_library_due_date_management": "Closed library due date management",
     "entityType.simple_loan_policy.created_at": "Created at",
     "entityType.simple_loan_policy.created_by": "Created by user UUID",
     "entityType.simple_loan_policy.description": "Description",

--- a/translations/mod-fqm-manager/en.json
+++ b/translations/mod-fqm-manager/en.json
@@ -1152,7 +1152,6 @@
   "entityType.simple_instance_type.code": "Code",
   "entityType.simple_instance_type.id": "Type UUID",
   "entityType.simple_loan_policy": "Loan policies",
-  "entityType.simple_loan_policy.closed_library_due_date_management": "Closed library due date management",
   "entityType.simple_loan_policy.created_at": "Created at",
   "entityType.simple_loan_policy.created_by": "Created by user UUID",
   "entityType.simple_loan_policy.description": "Description",

--- a/translations/mod-fqm-manager/en_GB.json
+++ b/translations/mod-fqm-manager/en_GB.json
@@ -1177,7 +1177,6 @@
     "entityType.simple_instance.updated_by": "Updated by user UUID",
     "entityType.simple_instance.version": "Record version",
     "entityType.simple_loan_policy": "Loan policies",
-    "entityType.simple_loan_policy.closed_library_due_date_management": "Closed library due date management",
     "entityType.simple_loan_policy.created_at": "Created at",
     "entityType.simple_loan_policy.created_by": "Created by user UUID",
     "entityType.simple_loan_policy.description": "Description",

--- a/translations/mod-fqm-manager/en_SE.json
+++ b/translations/mod-fqm-manager/en_SE.json
@@ -1177,7 +1177,6 @@
     "entityType.simple_instance.updated_by": "Updated by user UUID",
     "entityType.simple_instance.version": "Record version",
     "entityType.simple_loan_policy": "Loan policies",
-    "entityType.simple_loan_policy.closed_library_due_date_management": "Closed library due date management",
     "entityType.simple_loan_policy.created_at": "Created at",
     "entityType.simple_loan_policy.created_by": "Created by user UUID",
     "entityType.simple_loan_policy.description": "Description",

--- a/translations/mod-fqm-manager/en_US.json
+++ b/translations/mod-fqm-manager/en_US.json
@@ -1152,7 +1152,6 @@
   "entityType.simple_instance_type.code": "Code",
   "entityType.simple_instance_type.id": "Type UUID",
   "entityType.simple_loan_policy": "Loan policies",
-  "entityType.simple_loan_policy.closed_library_due_date_management": "Closed library due date management",
   "entityType.simple_loan_policy.created_at": "Created at",
   "entityType.simple_loan_policy.created_by": "Created by user UUID",
   "entityType.simple_loan_policy.description": "Description",

--- a/translations/mod-fqm-manager/es.json
+++ b/translations/mod-fqm-manager/es.json
@@ -1177,7 +1177,6 @@
     "entityType.simple_instance.updated_by": "Updated by user UUID",
     "entityType.simple_instance.version": "Record version",
     "entityType.simple_loan_policy": "Loan policies",
-    "entityType.simple_loan_policy.closed_library_due_date_management": "Closed library due date management",
     "entityType.simple_loan_policy.created_at": "Created at",
     "entityType.simple_loan_policy.created_by": "Created by user UUID",
     "entityType.simple_loan_policy.description": "Description",

--- a/translations/mod-fqm-manager/es_419.json
+++ b/translations/mod-fqm-manager/es_419.json
@@ -1177,7 +1177,6 @@
     "entityType.simple_instance.updated_by": "Updated by user UUID",
     "entityType.simple_instance.version": "Record version",
     "entityType.simple_loan_policy": "Loan policies",
-    "entityType.simple_loan_policy.closed_library_due_date_management": "Closed library due date management",
     "entityType.simple_loan_policy.created_at": "Created at",
     "entityType.simple_loan_policy.created_by": "Created by user UUID",
     "entityType.simple_loan_policy.description": "Description",

--- a/translations/mod-fqm-manager/es_ES.json
+++ b/translations/mod-fqm-manager/es_ES.json
@@ -1177,7 +1177,6 @@
     "entityType.simple_instance.updated_by": "Updated by user UUID",
     "entityType.simple_instance.version": "Record version",
     "entityType.simple_loan_policy": "Loan policies",
-    "entityType.simple_loan_policy.closed_library_due_date_management": "Closed library due date management",
     "entityType.simple_loan_policy.created_at": "Created at",
     "entityType.simple_loan_policy.created_by": "Created by user UUID",
     "entityType.simple_loan_policy.description": "Description",

--- a/translations/mod-fqm-manager/fr.json
+++ b/translations/mod-fqm-manager/fr.json
@@ -1177,7 +1177,6 @@
     "entityType.simple_instance.updated_by": "Updated by user UUID",
     "entityType.simple_instance.version": "Record version",
     "entityType.simple_loan_policy": "Loan policies",
-    "entityType.simple_loan_policy.closed_library_due_date_management": "Closed library due date management",
     "entityType.simple_loan_policy.created_at": "Created at",
     "entityType.simple_loan_policy.created_by": "Created by user UUID",
     "entityType.simple_loan_policy.description": "Description",

--- a/translations/mod-fqm-manager/fr_FR.json
+++ b/translations/mod-fqm-manager/fr_FR.json
@@ -1177,7 +1177,6 @@
     "entityType.simple_instance.updated_by": "Updated by user UUID",
     "entityType.simple_instance.version": "Record version",
     "entityType.simple_loan_policy": "Loan policies",
-    "entityType.simple_loan_policy.closed_library_due_date_management": "Closed library due date management",
     "entityType.simple_loan_policy.created_at": "Created at",
     "entityType.simple_loan_policy.created_by": "Created by user UUID",
     "entityType.simple_loan_policy.description": "Description",

--- a/translations/mod-fqm-manager/he.json
+++ b/translations/mod-fqm-manager/he.json
@@ -1177,7 +1177,6 @@
     "entityType.simple_instance.updated_by": "Updated by user UUID",
     "entityType.simple_instance.version": "Record version",
     "entityType.simple_loan_policy": "Loan policies",
-    "entityType.simple_loan_policy.closed_library_due_date_management": "Closed library due date management",
     "entityType.simple_loan_policy.created_at": "Created at",
     "entityType.simple_loan_policy.created_by": "Created by user UUID",
     "entityType.simple_loan_policy.description": "Description",

--- a/translations/mod-fqm-manager/hi_IN.json
+++ b/translations/mod-fqm-manager/hi_IN.json
@@ -1177,7 +1177,6 @@
     "entityType.simple_instance.updated_by": "Updated by user UUID",
     "entityType.simple_instance.version": "Record version",
     "entityType.simple_loan_policy": "Loan policies",
-    "entityType.simple_loan_policy.closed_library_due_date_management": "Closed library due date management",
     "entityType.simple_loan_policy.created_at": "Created at",
     "entityType.simple_loan_policy.created_by": "Created by user UUID",
     "entityType.simple_loan_policy.description": "Description",

--- a/translations/mod-fqm-manager/hu.json
+++ b/translations/mod-fqm-manager/hu.json
@@ -1177,7 +1177,6 @@
     "entityType.simple_instance.updated_by": "Updated by user UUID",
     "entityType.simple_instance.version": "Record version",
     "entityType.simple_loan_policy": "Loan policies",
-    "entityType.simple_loan_policy.closed_library_due_date_management": "Closed library due date management",
     "entityType.simple_loan_policy.created_at": "Created at",
     "entityType.simple_loan_policy.created_by": "Created by user UUID",
     "entityType.simple_loan_policy.description": "Description",

--- a/translations/mod-fqm-manager/it_IT.json
+++ b/translations/mod-fqm-manager/it_IT.json
@@ -1177,7 +1177,6 @@
     "entityType.simple_instance.updated_by": "Updated by user UUID",
     "entityType.simple_instance.version": "Record version",
     "entityType.simple_loan_policy": "Loan policies",
-    "entityType.simple_loan_policy.closed_library_due_date_management": "Closed library due date management",
     "entityType.simple_loan_policy.created_at": "Created at",
     "entityType.simple_loan_policy.created_by": "Created by user UUID",
     "entityType.simple_loan_policy.description": "Description",

--- a/translations/mod-fqm-manager/ja.json
+++ b/translations/mod-fqm-manager/ja.json
@@ -1177,7 +1177,6 @@
     "entityType.simple_instance.updated_by": "Updated by user UUID",
     "entityType.simple_instance.version": "Record version",
     "entityType.simple_loan_policy": "Loan policies",
-    "entityType.simple_loan_policy.closed_library_due_date_management": "Closed library due date management",
     "entityType.simple_loan_policy.created_at": "Created at",
     "entityType.simple_loan_policy.created_by": "Created by user UUID",
     "entityType.simple_loan_policy.description": "Description",

--- a/translations/mod-fqm-manager/ko.json
+++ b/translations/mod-fqm-manager/ko.json
@@ -1177,7 +1177,6 @@
     "entityType.simple_instance.updated_by": "Updated by user UUID",
     "entityType.simple_instance.version": "Record version",
     "entityType.simple_loan_policy": "Loan policies",
-    "entityType.simple_loan_policy.closed_library_due_date_management": "Closed library due date management",
     "entityType.simple_loan_policy.created_at": "Created at",
     "entityType.simple_loan_policy.created_by": "Created by user UUID",
     "entityType.simple_loan_policy.description": "Description",

--- a/translations/mod-fqm-manager/nb.json
+++ b/translations/mod-fqm-manager/nb.json
@@ -1177,7 +1177,6 @@
     "entityType.simple_instance.updated_by": "Updated by user UUID",
     "entityType.simple_instance.version": "Record version",
     "entityType.simple_loan_policy": "Loan policies",
-    "entityType.simple_loan_policy.closed_library_due_date_management": "Closed library due date management",
     "entityType.simple_loan_policy.created_at": "Created at",
     "entityType.simple_loan_policy.created_by": "Created by user UUID",
     "entityType.simple_loan_policy.description": "Description",

--- a/translations/mod-fqm-manager/nl.json
+++ b/translations/mod-fqm-manager/nl.json
@@ -1177,7 +1177,6 @@
     "entityType.simple_instance.updated_by": "Updated by user UUID",
     "entityType.simple_instance.version": "Record version",
     "entityType.simple_loan_policy": "Loan policies",
-    "entityType.simple_loan_policy.closed_library_due_date_management": "Closed library due date management",
     "entityType.simple_loan_policy.created_at": "Created at",
     "entityType.simple_loan_policy.created_by": "Created by user UUID",
     "entityType.simple_loan_policy.description": "Description",

--- a/translations/mod-fqm-manager/nn.json
+++ b/translations/mod-fqm-manager/nn.json
@@ -1177,7 +1177,6 @@
     "entityType.simple_instance.updated_by": "Updated by user UUID",
     "entityType.simple_instance.version": "Record version",
     "entityType.simple_loan_policy": "Loan policies",
-    "entityType.simple_loan_policy.closed_library_due_date_management": "Closed library due date management",
     "entityType.simple_loan_policy.created_at": "Created at",
     "entityType.simple_loan_policy.created_by": "Created by user UUID",
     "entityType.simple_loan_policy.description": "Description",

--- a/translations/mod-fqm-manager/pl.json
+++ b/translations/mod-fqm-manager/pl.json
@@ -1177,7 +1177,6 @@
     "entityType.simple_instance.updated_by": "Updated by user UUID",
     "entityType.simple_instance.version": "Record version",
     "entityType.simple_loan_policy": "Loan policies",
-    "entityType.simple_loan_policy.closed_library_due_date_management": "Closed library due date management",
     "entityType.simple_loan_policy.created_at": "Created at",
     "entityType.simple_loan_policy.created_by": "Created by user UUID",
     "entityType.simple_loan_policy.description": "Description",

--- a/translations/mod-fqm-manager/pt_BR.json
+++ b/translations/mod-fqm-manager/pt_BR.json
@@ -1177,7 +1177,6 @@
     "entityType.simple_instance.updated_by": "Atualizado por usuário de UUID",
     "entityType.simple_instance.version": "Versão do registro",
     "entityType.simple_loan_policy": "Políticas de empréstimos",
-    "entityType.simple_loan_policy.closed_library_due_date_management": "Gestão da data de vencimento da biblioteca fechada",
     "entityType.simple_loan_policy.created_at": "Criado em",
     "entityType.simple_loan_policy.created_by": "Criado por usuário de UUID",
     "entityType.simple_loan_policy.description": "Descrição",

--- a/translations/mod-fqm-manager/pt_PT.json
+++ b/translations/mod-fqm-manager/pt_PT.json
@@ -1177,7 +1177,6 @@
     "entityType.simple_instance.updated_by": "Updated by user UUID",
     "entityType.simple_instance.version": "Record version",
     "entityType.simple_loan_policy": "Loan policies",
-    "entityType.simple_loan_policy.closed_library_due_date_management": "Closed library due date management",
     "entityType.simple_loan_policy.created_at": "Created at",
     "entityType.simple_loan_policy.created_by": "Created by user UUID",
     "entityType.simple_loan_policy.description": "Description",

--- a/translations/mod-fqm-manager/ru.json
+++ b/translations/mod-fqm-manager/ru.json
@@ -1177,7 +1177,6 @@
     "entityType.simple_instance.updated_by": "Updated by user UUID",
     "entityType.simple_instance.version": "Record version",
     "entityType.simple_loan_policy": "Loan policies",
-    "entityType.simple_loan_policy.closed_library_due_date_management": "Closed library due date management",
     "entityType.simple_loan_policy.created_at": "Created at",
     "entityType.simple_loan_policy.created_by": "Created by user UUID",
     "entityType.simple_loan_policy.description": "Description",

--- a/translations/mod-fqm-manager/sk.json
+++ b/translations/mod-fqm-manager/sk.json
@@ -1177,7 +1177,6 @@
     "entityType.simple_instance.updated_by": "Updated by user UUID",
     "entityType.simple_instance.version": "Record version",
     "entityType.simple_loan_policy": "Loan policies",
-    "entityType.simple_loan_policy.closed_library_due_date_management": "Closed library due date management",
     "entityType.simple_loan_policy.created_at": "Created at",
     "entityType.simple_loan_policy.created_by": "Created by user UUID",
     "entityType.simple_loan_policy.description": "Description",

--- a/translations/mod-fqm-manager/sv.json
+++ b/translations/mod-fqm-manager/sv.json
@@ -1177,7 +1177,6 @@
     "entityType.simple_instance.updated_by": "Updated by user UUID",
     "entityType.simple_instance.version": "Record version",
     "entityType.simple_loan_policy": "Loan policies",
-    "entityType.simple_loan_policy.closed_library_due_date_management": "Closed library due date management",
     "entityType.simple_loan_policy.created_at": "Created at",
     "entityType.simple_loan_policy.created_by": "Created by user UUID",
     "entityType.simple_loan_policy.description": "Description",

--- a/translations/mod-fqm-manager/ur.json
+++ b/translations/mod-fqm-manager/ur.json
@@ -1177,7 +1177,6 @@
     "entityType.simple_instance.updated_by": "Updated by user UUID",
     "entityType.simple_instance.version": "Record version",
     "entityType.simple_loan_policy": "Loan policies",
-    "entityType.simple_loan_policy.closed_library_due_date_management": "Closed library due date management",
     "entityType.simple_loan_policy.created_at": "Created at",
     "entityType.simple_loan_policy.created_by": "Created by user UUID",
     "entityType.simple_loan_policy.description": "Description",

--- a/translations/mod-fqm-manager/zh_CN.json
+++ b/translations/mod-fqm-manager/zh_CN.json
@@ -1177,7 +1177,6 @@
     "entityType.simple_instance.updated_by": "由用户UUID更新",
     "entityType.simple_instance.version": "记录版本",
     "entityType.simple_loan_policy": "借阅政策",
-    "entityType.simple_loan_policy.closed_library_due_date_management": "闭馆到期日管理",
     "entityType.simple_loan_policy.created_at": "创建于",
     "entityType.simple_loan_policy.created_by": "由用户UUID创建",
     "entityType.simple_loan_policy.description": "描述",

--- a/translations/mod-fqm-manager/zh_TW.json
+++ b/translations/mod-fqm-manager/zh_TW.json
@@ -1177,7 +1177,6 @@
     "entityType.simple_instance.updated_by": "Updated by user UUID",
     "entityType.simple_instance.version": "Record version",
     "entityType.simple_loan_policy": "Loan policies",
-    "entityType.simple_loan_policy.closed_library_due_date_management": "Closed library due date management",
     "entityType.simple_loan_policy.created_at": "Created at",
     "entityType.simple_loan_policy.created_by": "Created by user UUID",
     "entityType.simple_loan_policy.description": "Description",


### PR DESCRIPTION
This commit adds a hard-coded list of available values to loans_policy_closed_library_due_date_management_type in simple_loan_policy. This list of values hasn't changed in 5 years (see https://github.com/folio-org/mod-circulation/blob/master/src/main/java/org/folio/circulation/domain/policy/DueDateManagement.java).

Additionally, this commit removes the
closed_library_due_date_management field, since it's a duplicate of loans_policy_closed_library_due_date_management_type, along with its translations