### PR TITLE
MODFQMMGR-339: Include ECS columns in query builder

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -334,6 +334,12 @@
       "version": "1.1"
     }
   ],
+  "optional": [
+    {
+      "id": "consortia",
+      "version": "1.0"
+    }
+  ],
   "launchDescriptor": {
     "dockerImage": "@artifactId@:@version@",
     "dockerPull": false,

--- a/src/main/resources/entity-types/inventory/simple_instance.json5
+++ b/src/main/resources/entity-types/inventory/simple_instance.json5
@@ -1047,7 +1047,7 @@
       queryable: true,
       visibleByDefault: true,
       valueGetter: "CASE \
-                      WHEN (SELECT central_tenant_id from ${tenant_id}_mod_consortia.consortia_configuration) = '${tenant_id}' \
+                      WHEN '${central_tenant_id}' = '${tenant_id}' \
                         THEN 'Shared'\
                       ELSE \
                         CASE \
@@ -1056,7 +1056,17 @@
                           ELSE 'Local' \
                         END \
                     END",
-      ecsOnly: true
+      values: [
+        {
+          value: 'Shared',
+          label: 'Shared',
+        },
+        {
+          value: 'Local',
+          label: 'Local',
+        },
+      ],
+      ecsOnly: true,
     },
     {
       name: 'source_tenant_id',
@@ -1068,16 +1078,26 @@
       queryable: true,
       visibleByDefault: true,
       valueGetter: "CASE \
-                      WHEN (SELECT central_tenant_id from ${tenant_id}_mod_consortia.consortia_configuration) = '${tenant_id}' \
+                      WHEN '${central_tenant_id}' = '${tenant_id}' \
                         THEN '${tenant_id}' \
                       ELSE \
                         CASE \
                           WHEN \"left\"(lower(:sourceAlias.jsonb ->> 'source'::text), 600) = 'consortium-folio' OR \"left\"(lower(:sourceAlias.jsonb ->> 'source'::text), 600) = 'consortium-marc' \
-                            THEN (SELECT central_tenant_id FROM ${tenant_id}_mod_consortia.consortia_configuration) \
+                            THEN '${central_tenant_id}' \
                           ELSE '${tenant_id}' \
                         END \
                     END",
-      ecsOnly: true
+      values: [
+        {
+          value: '${tenant_id}',
+          label: '${tenant_id}',
+        },
+        {
+          value: '${central_tenant_id}',
+          label: '${central_tenant_id}',
+        },
+      ],
+      ecsOnly: true,
     }
   ],
 }

--- a/src/test/java/org/folio/fqm/context/TestDbSetupConfiguration.java
+++ b/src/test/java/org/folio/fqm/context/TestDbSetupConfiguration.java
@@ -2,9 +2,11 @@ package org.folio.fqm.context;
 
 import jakarta.annotation.PostConstruct;
 import java.io.IOException;
+import java.util.Map;
 import javax.sql.DataSource;
 import liquibase.integration.spring.SpringLiquibase;
 import org.folio.fqm.IntegrationTestBase;
+import org.folio.fqm.client.SimpleHttpClient;
 import org.folio.fqm.repository.EntityTypeRepository;
 import org.folio.fqm.service.EntityTypeInitializationService;
 import org.folio.spring.FolioExecutionContext;
@@ -14,6 +16,9 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.io.support.ResourcePatternResolver;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * This class is responsible for inserting test data into a PostgreSQL test container database.
@@ -47,6 +52,8 @@ public class TestDbSetupConfiguration {
 
     @PostConstruct
     public void populateEntityTypes() throws IOException {
+      SimpleHttpClient ecsClient = mock(SimpleHttpClient.class);
+      when(ecsClient.get("consortia-configuration", Map.of("limit", String.valueOf(100)))).thenReturn("{\"centralTenantId\": \"tenant_01\"}");
       new EntityTypeInitializationService(
         entityTypeRepository,
         new FolioExecutionContext() {
@@ -55,7 +62,8 @@ public class TestDbSetupConfiguration {
             return IntegrationTestBase.TENANT_ID;
           }
         },
-        resourceResolver
+        resourceResolver,
+        ecsClient
       )
         .initializeEntityTypes();
     }


### PR DESCRIPTION
## Purpose
[MODFQMMGR-339: Extend entity type response to add additional data column for query builder](https://folio-org.atlassian.net/browse/MODFQMMGR-339)

This story makes the new ECS columns available for use from the query builder.
