### PR TITLE
MODFQMMGR-373 Fix bug with contains_all

### DIFF
--- a/src/main/java/org/folio/fqm/repository/IdStreamer.java
+++ b/src/main/java/org/folio/fqm/repository/IdStreamer.java
@@ -10,7 +10,6 @@ import org.folio.fqm.utils.StreamHelper;
 import org.folio.fql.model.Fql;
 import org.folio.querytool.domain.dto.EntityType;
 import org.folio.querytool.domain.dto.EntityTypeDefaultSort;
-import org.folio.querytool.domain.dto.EntityTypeSource;
 import org.jooq.Condition;
 import org.jooq.Cursor;
 import org.jooq.DSLContext;
@@ -82,12 +81,6 @@ public class IdStreamer {
                                Consumer<IdsWithCancelCallback> idsConsumer) {
     String finalJoinClause = entityTypeFlatteningService.getJoinClause(entityType);
     Field<String[]> idValueGetter = IdColumnUtils.getResultIdValueGetter(entityType);
-    String finalWhereClause = sqlWhereClause.toString();
-    for (EntityTypeSource source : entityType.getSources()) {
-      String toReplace = ":" + source.getAlias();
-      String alias = "\"" + source.getAlias() + "\"";
-      finalWhereClause = finalWhereClause.replace(toReplace, alias);
-    }
     ResultQuery<Record1<String[]>> query = null;
     if (!isEmpty(entityType.getGroupByFields())) {
       Field<?>[] groupByFields = entityType
@@ -100,7 +93,7 @@ public class IdStreamer {
       query = jooqContext.dsl()
         .select(field(idValueGetter))
         .from(finalJoinClause)
-        .where(finalWhereClause)
+        .where(sqlWhereClause)
         .groupBy(groupByFields)
         .orderBy(getSortFields(entityType, sortResults))
         .fetchSize(batchSize);
@@ -108,7 +101,7 @@ public class IdStreamer {
       query = jooqContext.dsl()
         .select(field(idValueGetter))
         .from(finalJoinClause)
-        .where(finalWhereClause)
+        .where(sqlWhereClause)
         .orderBy(getSortFields(entityType, sortResults))
         .fetchSize(batchSize);
     }

--- a/src/main/java/org/folio/fqm/repository/ResultSetRepository.java
+++ b/src/main/java/org/folio/fqm/repository/ResultSetRepository.java
@@ -13,7 +13,6 @@ import java.util.UUID;
 
 import org.folio.fql.model.Fql;
 import org.folio.fqm.exception.FieldNotFoundException;
-import org.folio.fqm.exception.EntityTypeNotFoundException;
 import org.folio.fqm.service.EntityTypeFlatteningService;
 import org.folio.fqm.service.FqlToSqlConverterService;
 import org.folio.fqm.utils.IdColumnUtils;
@@ -23,7 +22,6 @@ import org.folio.querytool.domain.dto.EntityType;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.folio.querytool.domain.dto.EntityTypeColumn;
-import org.folio.querytool.domain.dto.EntityTypeSource;
 import org.jooq.Condition;
 import org.jooq.DSLContext;
 import org.jooq.Field;
@@ -124,13 +122,6 @@ public class ResultSetRepository {
     }
 
     Condition condition = FqlToSqlConverterService.getSqlCondition(fql.fqlCondition(), entityType);
-    // TODO: might want to put next 5 lines in its own method in EntityTypeFlatteningService
-    String finalWhereClause = condition.toString();
-    for (EntityTypeSource source : entityType.getSources()) {
-      String toReplace = ":" + source.getAlias();
-      String alias = "\"" + source.getAlias() + "\"";
-      finalWhereClause = finalWhereClause.replace(toReplace, alias);
-    }
     var fieldsToSelect = getSqlFields(entityType, fields);
     String idColumnName = entityType
       .getColumns()
@@ -143,7 +134,7 @@ public class ResultSetRepository {
     String fromClause = entityTypeFlatteningService.getJoinClause(entityType);
     var result = jooqContext.select(fieldsToSelect)
       .from(fromClause)
-      .where(finalWhereClause)
+      .where(condition)
       .and(afterIdCondition)
       .orderBy(sortCriteria)
       .limit(limit)

--- a/src/main/resources/entity-types/users/simple_user_details.json5
+++ b/src/main/resources/entity-types/users/simple_user_details.json5
@@ -511,19 +511,19 @@
         },
       },
       isIdColumn: false,
-      queryable: false,
+      queryable: true,
       visibleByDefault: false,
       valueGetter: "(\
         SELECT\
           array_agg(elems.value::text)\
         FROM\
-          jsonb_array_elements(:sourceAlias.jsonb->'departments') AS elems\
+          jsonb_array_elements_text(:sourceAlias.jsonb->'departments') AS elems\
       )",
       filterValueGetter: "(\
         SELECT\
           array_agg(lower(elems.value::text))\
         FROM\
-          jsonb_array_elements(:sourceAlias.jsonb->'departments') AS elems\
+          jsonb_array_elements_text(:sourceAlias.jsonb->'departments') AS elems\
       )",
     },
     {


### PR DESCRIPTION
We had some effectively dead code that was causing us to render the WHERE clause of converted FQL queries without the jOOQ context that normally tells it to render for PostgreSQL. The contains_all operator depends on jOOQ's special handling for PostgreSQL, so rendering without the right context was breaking the operator
This commit removes that code, so that the WHERE clause is rendered with the correct context
