### PR TITLE
[MODFQMMGR-419] Fix column values for several entity types

### DIFF
--- a/src/main/resources/entity-types/finance/composite_ledger__fund.json5
+++ b/src/main/resources/entity-types/finance/composite_ledger__fund.json5
@@ -1,29 +1,29 @@
 {
-  id: "a9afda34-3f10-48e4-8cb3-38ff9e5c9eb9",
-  name: "composite_ledger_fund",
+  id: 'a9afda34-3f10-48e4-8cb3-38ff9e5c9eb9',
+  name: 'composite_ledger_fund',
   private: true,
   sources: [
     {
-      type: "entity-type",
-      id: "4c63c7f5-1a28-4394-b401-98c02c31492d",
-      alias: "fund",
-      useIdColumns: true
+      type: 'entity-type',
+      id: '4c63c7f5-1a28-4394-b401-98c02c31492d', // drv_fund_details
+      alias: 'fund',
+      useIdColumns: true,
     },
     {
-      type: "entity-type",
-      id: "abce1078-b099-467f-811b-367bd05638e3",
-      alias: "ledger",
+      type: 'entity-type',
+      id: 'abce1078-b099-467f-811b-367bd05638e3',
+      alias: 'ledger',
       join: {
-        type: "left join",
-        joinTo: "fund",
-        condition: "(:that.jsonb ->> 'ledgerId')::uuid = :this.id"
-      }
+        type: 'left join',
+        joinTo: 'fund.fund',
+        condition: "(:that.jsonb ->> 'ledgerId')::uuid = :this.id",
+      },
     },
   ],
   defaultSort: [
     {
-      columnName: "fund.id",
-      direction: "ASC"
-    }
-  ]
+      columnName: '"fund.fund".id',
+      direction: 'ASC',
+    },
+  ],
 }

--- a/src/main/resources/entity-types/inventory/composite_instances.json5
+++ b/src/main/resources/entity-types/inventory/composite_instances.json5
@@ -42,7 +42,7 @@
   ],
   defaultSort: [
     {
-      columnName: '"instance.id"',
+      columnName: '"instance.inst".id',
       direction: 'ASC',
     },
   ],

--- a/src/main/resources/entity-types/invoice/composite_invoice__voucher_line__fund_distribution.json5
+++ b/src/main/resources/entity-types/invoice/composite_invoice__voucher_line__fund_distribution.json5
@@ -25,7 +25,7 @@
       alias: 'fund_type',
       join: {
         type: 'LEFT JOIN',
-        joinTo: 'fund',
+        joinTo: 'fund.fund',
         condition: "(:that.jsonb ->> 'fundTypeId')::uuid = :this.id",
       },
     },
@@ -52,7 +52,7 @@
   ],
   defaultSort: [
     {
-      columnName: 'voucher_line__fund_distribution.voucher_line.id',
+      columnName: '"voucher_line".id',
       direction: 'ASC',
     },
   ],

--- a/src/main/resources/entity-types/invoice/composite_invoice__voucher_line__ledger_fund__organization.json5
+++ b/src/main/resources/entity-types/invoice/composite_invoice__voucher_line__ledger_fund__organization.json5
@@ -54,11 +54,11 @@
   ],
   defaultSort: [
     {
-      columnName: 'ledger_fund.fund.name',
+      columnName: '"ledger_fund.fund".name',
       direction: 'ASC',
     },
     {
-      columnName: 'voucher_line.external_account_number',
+      columnName: '"voucher_line.voucher_lines".external_account_number',
       direction: 'ASC',
     },
   ],

--- a/src/main/resources/entity-types/invoice/composite_invoice__voucher_line__organization.json5
+++ b/src/main/resources/entity-types/invoice/composite_invoice__voucher_line__organization.json5
@@ -63,7 +63,7 @@
   ],
   defaultSort: [
     {
-      columnName: 'po_instance.organization.vendor_name',
+      columnName: '"po_instance.organization".vendor_name',
       direction: 'ASC',
     },
   ],

--- a/src/main/resources/entity-types/invoice/composite_voucher_line__fund_distribution.json5
+++ b/src/main/resources/entity-types/invoice/composite_voucher_line__fund_distribution.json5
@@ -15,7 +15,7 @@
       target: "jsonb_array_elements(voucher_line.jsonb -> 'fundDistributions')",
       join: {
         type: 'CROSS JOIN LATERAL',
-        joinTo: 'voucher_line',
+        joinTo: 'voucher_line.voucher_lines',
       },
     },
   ],
@@ -94,7 +94,7 @@
   ],
   defaultSort: [
     {
-      columnName: 'voucher_line.id',
+      columnName: '"voucher_line.voucher_lines".id',
       direction: 'ASC',
     },
     {

--- a/src/main/resources/entity-types/invoice/composite_voucher_line__voucher__ledger_fund.json5
+++ b/src/main/resources/entity-types/invoice/composite_voucher_line__voucher__ledger_fund.json5
@@ -1,40 +1,40 @@
 {
-  id: "86475f57-7ee2-4b7f-b631-e1a4ead3cdc8",
-  name: "composite_voucher_line__voucher__ledger_fund",
+  id: '86475f57-7ee2-4b7f-b631-e1a4ead3cdc8',
+  name: 'composite_voucher_line__voucher__ledger_fund',
   private: true,
   sources: [
     {
-      type: "entity-type",
-      id: "5db5fbd8-0dfa-4e87-a7fc-a3568e83effb",
-      alias: "voucher_line",
-      useIdColumns: true
+      type: 'entity-type',
+      id: '5db5fbd8-0dfa-4e87-a7fc-a3568e83effb',
+      alias: 'voucher_line',
+      useIdColumns: true,
     },
     {
-      type: "entity-type",
-      id: "e90473d9-00c3-4b84-919b-a4caa0b07450",
-      alias: "voucher",
+      type: 'entity-type',
+      id: 'e90473d9-00c3-4b84-919b-a4caa0b07450',
+      alias: 'voucher',
       join: {
-        type: "left join",
-        joinTo: "voucher_line",
-        condition: "(:that.jsonb ->> 'voucherId')::uuid = :this.id"
-      }
-    },
-    {
-      type: "entity-type",
-      id: "a9afda34-3f10-48e4-8cb3-38ff9e5c9eb9",
-      alias: "ledger_fund",
-      join: {
-        type: "left join",
-        joinTo: "voucher_line",
-        condition: "(:that.jsonb ->> 'externalAccountNumber') = :this.jsonb ->> 'externalAccountNo'"
+        type: 'left join',
+        joinTo: 'voucher_line',
+        condition: "(:that.jsonb ->> 'voucherId')::uuid = :this.id",
       },
-      useIdColumns: true
-    }
+    },
+    {
+      type: 'entity-type',
+      id: 'a9afda34-3f10-48e4-8cb3-38ff9e5c9eb9',
+      alias: 'ledger_fund',
+      join: {
+        type: 'left join',
+        joinTo: 'voucher_line',
+        condition: "(:that.jsonb ->> 'externalAccountNumber') = :this.jsonb ->> 'externalAccountNo'",
+      },
+      useIdColumns: true,
+    },
   ],
   defaultSort: [
     {
-      columnName: "voucher_line.id",
-      direction: "ASC"
-    }
-  ]
+      columnName: '"voucher_line.voucher_lines".id',
+      direction: 'ASC',
+    },
+  ],
 }

--- a/src/main/resources/entity-types/users/composite_users_details.json5
+++ b/src/main/resources/entity-types/users/composite_users_details.json5
@@ -25,7 +25,7 @@
   ],
   defaultSort: [
     {
-      columnName: 'users.id',
+      columnName: '"users.user".id',
       direction: 'ASC',
     },
   ],


### PR DESCRIPTION
This fixes issues with `defaultSort` causing queries to fail.

I can confirm this fixes the issue for instances and user details. The finance entity types have further issues outside the scope of this fix.