### PR TITLE
MODFQMMGR-421 Make instance tenant_id not be ECS-only

### DIFF
--- a/src/main/resources/entity-types/inventory/simple_instance.json5
+++ b/src/main/resources/entity-types/inventory/simple_instance.json5
@@ -1132,7 +1132,7 @@
         type: 'fqm',
         name: 'tenant_id'
       },
-      ecsOnly: true,
+      ecsOnly: false,
     },
     {
       name: 'jsonb',


### PR DESCRIPTION
This is a temporary change, to ensure the tenant ID is available as part of the ID, even in non-ECS environments. After consumers have switched away from the `.../sortedIds` endpoint, so that they can retrieve the tenant ID more directly via query results, we can switch this back to ECS-only.