### PR TITLE
MODFQMMGR-415 Add an entity type defintion cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,22 +37,30 @@ By utilizing the combination of source views, computed views, and other relevant
 mvn clean install
 ```
 ## Environment Variables
-| Name                                              | Default Value | Description                           |
-|---------------------------------------------------|---------------|---------------------------------------|
-| DB_HOST                                           | localhost     | Postgres hostname                     |
-| DB_PORT                                           | 5432          | Postgres port                         |
-| DB_HOST_READER                                    | localhost     | Postgres hostname                     |
-| DB_PORT_READER                                    | 5432          | Postgres port                         |
-| DB_USERNAME                                       | postgres      | Postgres username                     |
-| DB_PASSWORD                                       | postgres      | Postgres password                     |
-| DB_DATABASE                                       | postgres      | Postgres database name                |
-| MAX_QUERY_SIZE                                    | 1250000       | max result count per query            |
-| mod-fqm-manager.permissions-cache-timeout-seconds | 60            | Cache duration for user permissions   |
-| server.port                                       | 8081          | Server port                           |
-| QUERY_RETENTION_DURATION                          | 3h            | Older queries get deleted             |
-| task.execution.pool.core-size                     | 9             | Core number of concurrent async tasks |
-| task.execution.pool.max-size                      | 10            | Max number of concurrent async tasks  |
-| task.execution.pool.queue-capacity                | 1000          | Size of the task queue                |
+| Name                                              | Default Value | Description                                |
+|---------------------------------------------------|---------------|--------------------------------------------|
+| DB_HOST                                           | localhost     | Postgres hostname                          |
+| DB_PORT                                           | 5432          | Postgres port                              |
+| DB_HOST_READER                                    | localhost     | Postgres hostname                          |
+| DB_PORT_READER                                    | 5432          | Postgres port                              |
+| DB_USERNAME                                       | postgres      | Postgres username                          |
+| DB_PASSWORD                                       | postgres      | Postgres password                          |
+| DB_DATABASE                                       | postgres      | Postgres database name                     |
+| MAX_QUERY_SIZE                                    | 1250000       | max result count per query                 |
+| mod-fqm-manager.permissions-cache-timeout-seconds | 60            | Cache duration for user permissions        |
+| mod-fqm-manager.entity-type-cache-timeout-seconds | 3600          | Cache duration for entity type definitions |
+| server.port                                       | 8081          | Server port                                |
+| QUERY_RETENTION_DURATION                          | 3h            | Older queries get deleted                  |
+| task.execution.pool.core-size                     | 9             | Core number of concurrent async tasks      |
+| task.execution.pool.max-size                      | 10            | Max number of concurrent async tasks       |
+| task.execution.pool.queue-capacity                | 1000          | Size of the task queue                     |
+
+> **Note regarding `mod-fqm-manager.entity-type-cache-timeout-seconds`:** The default value defined in the project's
+> module descriptor is `300`, as this value is more appropriate for development environments while still being reasonable
+> for production. In general, production environments will see more benefit with higher values, since entity type
+> definitions are very static and normally only change with module upgrades. `86400` (1 day) or `604800` (1 week) would
+> be entirely reasonable for production. In the event that an entity type was updated in the database and this must be
+> reflected quickly when the cache timeout is very high, simply restarting the module should be sufficient.
 
 ### Resource requirements
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -405,6 +405,9 @@
       },
       { "name": "MAX_QUERY_SIZE",
         "value": "1250000"
+      },
+      { "name": "mod.fqm-manager.entity-type-cache-timeout-seconds",
+        "value": "300"
       }
     ]
   }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,7 @@ mod-fqm-manager:
   query-retention-duration: 3h
   max-query-size: ${MAX_QUERY_SIZE:1250000}
   permissions-cache-timeout-seconds: 60
+  entity-type-cache-timeout-seconds: 3600
 server:
   port: 8081
 spring:

--- a/src/test/java/org/folio/fqm/IntegrationTestBase.java
+++ b/src/test/java/org/folio/fqm/IntegrationTestBase.java
@@ -69,6 +69,7 @@ public class IntegrationTestBase {
       .withEnv("DB_PASSWORD", "mypassword")
       .withEnv("DB_DATABASE", "mypostgres")
       .withEnv("okapi_url", "http://host.testcontainers.internal:" + mokapi.getPort())
+      .withEnv("mod-fqm-manager.entity-type-cache-timeout-seconds", "0")
       .withStartupTimeout(Duration.ofMinutes(3))
       .dependsOn(postgres);
 

--- a/src/test/java/org/folio/fqm/utils/IdStreamerTest.java
+++ b/src/test/java/org/folio/fqm/utils/IdStreamerTest.java
@@ -68,7 +68,8 @@ class IdStreamerTest {
     EntityTypeRepository entityTypeRepository = new EntityTypeRepository(
       readerContext,
       context,
-      new ObjectMapper()
+      new ObjectMapper(),
+      0
     );
     localizationService = mock(LocalizationService.class);
     ecsClient = mock(SimpleHttpClient.class);

--- a/src/test/java/org/folio/fqm/utils/IdStreamerTestDataProvider.java
+++ b/src/test/java/org/folio/fqm/utils/IdStreamerTestDataProvider.java
@@ -66,7 +66,7 @@ public class IdStreamerTestDataProvider implements MockDataProvider {
         .target("target1"))
     );
 
-  private static final String ENTITY_TYPE_DEFINITION_REGEX = "SELECT DEFINITION FROM .*ENTITY_TYPE_DEFINITION WHERE ID IN .*";
+  private static final String ENTITY_TYPE_DEFINITION_REGEX = "SELECT DEFINITION FROM .*ENTITY_TYPE_DEFINITION";
   private static final String GET_IDS_QUERY_REGEX = "SELECT CAST.* AS VARCHAR.* WHERE .*";
   private static final String GET_SORTED_IDS_QUERY_REGEX = "SELECT RESULT_ID FROM .* WHERE .* ORDER BY RESULT_ID .*";
   private static final String GET_ENTITY_TYPE_ID_FROM_QUERY_ID_REGEX = "SELECT ENTITY_TYPE_ID FROM QUERY_DETAILS WHERE QUERY_ID = .*";
@@ -86,7 +86,8 @@ public class IdStreamerTestDataProvider implements MockDataProvider {
       var definitionField = field("definition");
       Result<Record1<Object>> result = create.newResult(definitionField);
       result.add(create.newRecord(definitionField).values(writeValueAsString(TEST_ENTITY_TYPE_DEFINITION)));
-      mockResult = new MockResult(1, result);
+      result.add(create.newRecord(definitionField).values(writeValueAsString(TEST_GROUP_BY_ENTITY_TYPE_DEFINITION)));
+      mockResult = new MockResult(2, result);
     } else if (sql.matches(ADDITIONAL_ECS_REGEX)) {
       Result<Record1<String[]>> result = create.newResult(DSL.cast(DSL.field(EntityTypeRepository.ID_FIELD_NAME), String[].class));
       result.add(create.newRecord(DSL.cast(DSL.field(EntityTypeRepository.ID_FIELD_NAME), String[].class)).values(new String[]{"ecsValue"}));

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -2,6 +2,7 @@ server:
   port: 8081
 mod-fqm-manager:
   permissions-cache-timeout-seconds: 60
+  entity-type-cache-timeout-seconds: 3600
 spring:
   application:
     name: mod-fqm-manager


### PR DESCRIPTION
This commit adds a new cache for entity types to EntityTypeRepository, to cut down on repeated loads of entity types. The default cache duration is 1 hour, but this can be overridden via system property. Additionally, the value in the module descriptor is set to 5 minutes, in order to strike more of a balance between performance and practicality in dev environments (although devs should consider reducing this further when actively creating/updating entity type definitions)

## Purpose
_Describe the purpose of the pull request. Include background information if necessary._

## Approach
_How does this change fulfill the purpose?_

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._

## Pre-Merge Checklist

If you are adding entity type(s), have you:
- [ ] Added the JSON5 definition to the `src/main/resources/entity-types` directory?
- [ ] Ensured that GETing the entity type at `/entity-types/{id}` works as expected?
- [ ] Added translations for all fields, per the [translation guidelines](/translations/README.md)? (Check this by ensuring `GET /entity-types/{id}` does not have `mod-fqm-manager.entityType.` in the response)
- [ ] Added views to liquibase, as applicable?
- [ ] Added required interfaces to the module descriptor?
- [ ] Checked that querying fields works correctly and all SQL is valid?

If you are changing/removing entity type(s), have you:
- [ ] Added migration code for any changes?