### PR TITLE
Add sortColumns parameter to getEntityTypeDefinition method

### DIFF
--- a/src/main/java/org/folio/fqm/resource/EntityTypeController.java
+++ b/src/main/java/org/folio/fqm/resource/EntityTypeController.java
@@ -24,7 +24,7 @@ public class EntityTypeController implements org.folio.fqm.resource.EntityTypesA
   @EntityTypePermissionsRequired
   @Override
   public ResponseEntity<EntityType> getEntityType(UUID entityTypeId, Boolean includeHidden) {
-    return ResponseEntity.ok(entityTypeService.getEntityTypeDefinition(entityTypeId, Boolean.TRUE.equals(includeHidden)));
+    return ResponseEntity.ok(entityTypeService.getEntityTypeDefinition(entityTypeId, Boolean.TRUE.equals(includeHidden), true));
   }
 
   @Override

--- a/src/main/java/org/folio/fqm/service/EntityTypeService.java
+++ b/src/main/java/org/folio/fqm/service/EntityTypeService.java
@@ -77,17 +77,20 @@ public class EntityTypeService {
   /**
    * Returns the definition of a given entity type.
    *
-   * @param entityTypeId the ID to search for
+   * @param entityTypeId  the ID to search for
    * @param includeHidden Indicates whether the hidden column should be displayed.
    *                      If set to true, the hidden column will be included in the output
+   * @param sortColumns   If true, columns will be alphabetically sorted by their translations
    * @return the entity type definition if found, empty otherwise
    */
-  public EntityType getEntityTypeDefinition(UUID entityTypeId, boolean includeHidden) {
+  public EntityType getEntityTypeDefinition(UUID entityTypeId, boolean includeHidden, boolean sortColumns) {
     EntityType entityType = entityTypeFlatteningService.getFlattenedEntityType(entityTypeId, null);
-    entityType.columns(entityType.getColumns().stream()
-      .filter(column -> includeHidden || !Boolean.TRUE.equals(column.getHidden())) // Filter based on includeHidden flag
-      .sorted(nullsLast(comparing(Field::getLabelAlias, String.CASE_INSENSITIVE_ORDER)))
-      .toList());
+    if (sortColumns) {
+      entityType.columns(entityType.getColumns().stream()
+        .filter(column -> includeHidden || !Boolean.TRUE.equals(column.getHidden())) // Filter based on includeHidden flag
+        .sorted(nullsLast(comparing(Field::getLabelAlias, String.CASE_INSENSITIVE_ORDER)))
+        .toList());
+    }
     return entityType;
   }
 

--- a/src/main/java/org/folio/fqm/service/EntityTypeService.java
+++ b/src/main/java/org/folio/fqm/service/EntityTypeService.java
@@ -12,6 +12,7 @@ import org.folio.fqm.exception.InvalidEntityTypeDefinitionException;
 import org.folio.fqm.repository.EntityTypeRepository;
 import org.folio.querytool.domain.dto.ColumnValues;
 import org.folio.querytool.domain.dto.EntityType;
+import org.folio.querytool.domain.dto.EntityTypeColumn;
 import org.folio.querytool.domain.dto.Field;
 import org.folio.querytool.domain.dto.SourceColumn;
 import org.folio.querytool.domain.dto.ValueWithLabel;
@@ -85,13 +86,17 @@ public class EntityTypeService {
    */
   public EntityType getEntityTypeDefinition(UUID entityTypeId, boolean includeHidden, boolean sortColumns) {
     EntityType entityType = entityTypeFlatteningService.getFlattenedEntityType(entityTypeId, null);
+    List<EntityTypeColumn> columns  = entityType
+      .getColumns()
+      .stream()
+      .filter(column -> includeHidden || !Boolean.TRUE.equals(column.getHidden())) // Filter based on includeHidden flag
+      .toList();
     if (sortColumns) {
-      entityType.columns(entityType.getColumns().stream()
-        .filter(column -> includeHidden || !Boolean.TRUE.equals(column.getHidden())) // Filter based on includeHidden flag
+      columns = columns.stream()
         .sorted(nullsLast(comparing(Field::getLabelAlias, String.CASE_INSENSITIVE_ORDER)))
-        .toList());
+        .toList();
     }
-    return entityType;
+    return entityType.columns(columns);
   }
 
   /**

--- a/src/main/java/org/folio/fqm/service/QueryManagementService.java
+++ b/src/main/java/org/folio/fqm/service/QueryManagementService.java
@@ -63,7 +63,7 @@ public class QueryManagementService {
    */
   public QueryIdentifier runFqlQueryAsync(SubmitQuery submitQuery) {
     EntityType entityType = entityTypeService
-      .getEntityTypeDefinition(submitQuery.getEntityTypeId(), true);
+      .getEntityTypeDefinition(submitQuery.getEntityTypeId(), true, false);
     List<String> fields = CollectionUtils.isEmpty(submitQuery.getFields()) ?
       getFieldsFromEntityType(entityType) : new ArrayList<>(submitQuery.getFields());
     List<String> idColumns = EntityTypeUtils.getIdColumnNames(entityType);
@@ -100,7 +100,7 @@ public class QueryManagementService {
     if (CollectionUtils.isEmpty(fields)) {
       fields = new ArrayList<>();
     }
-    EntityType entityType = entityTypeService.getEntityTypeDefinition(entityTypeId, true);
+    EntityType entityType = entityTypeService.getEntityTypeDefinition(entityTypeId, true, false);
     List<String> idColumns = EntityTypeUtils.getIdColumnNames(entityType);
     for (String idColumn : idColumns) {
       if (!fields.contains(idColumn)) {
@@ -166,7 +166,7 @@ public class QueryManagementService {
   }
 
   public void validateQuery(UUID entityTypeId, String fqlQuery) {
-    EntityType entityType = entityTypeService.getEntityTypeDefinition(entityTypeId, true);
+    EntityType entityType = entityTypeService.getEntityTypeDefinition(entityTypeId, true, false);
     Map<String, String> errorMap = fqlValidationService.validateFql(entityType, fqlQuery);
     if (!errorMap.isEmpty()) {
       throw new InvalidFqlException(fqlQuery, errorMap);
@@ -178,13 +178,13 @@ public class QueryManagementService {
     Query query = queryRepository.getQuery(queryId, false).orElseThrow(() -> new QueryNotFoundException(queryId));
 
     // ensures it exists
-    entityTypeService.getEntityTypeDefinition(query.entityTypeId(), true);
+    entityTypeService.getEntityTypeDefinition(query.entityTypeId(), true, false);
 
     return queryResultsSorterService.getSortedIds(queryId, offset, limit);
   }
 
   public List<Map<String, Object>> getContents(UUID entityTypeId, List<String> fields, List<List<String>> ids) {
-    EntityType entityType = entityTypeService.getEntityTypeDefinition(entityTypeId, true);
+    EntityType entityType = entityTypeService.getEntityTypeDefinition(entityTypeId, true, false);
     EntityTypeUtils.getIdColumnNames(entityType)
       .forEach(colName -> {
         if (!fields.contains(colName)) {
@@ -197,7 +197,7 @@ public class QueryManagementService {
 
   private List<Map<String, Object>> getContents(UUID queryId, UUID entityTypeId, List<String> fields, boolean includeResults, int offset, int limit) {
     if (includeResults) {
-      EntityType entityType = entityTypeService.getEntityTypeDefinition(entityTypeId, true);
+      EntityType entityType = entityTypeService.getEntityTypeDefinition(entityTypeId, true, false);
       List<List<String>> resultIds = queryResultsRepository.getQueryResultIds(queryId, offset, limit);
       List<String> tenantsToQuery = crossTenantQueryService.getTenantsToQuery(entityType, false);
       return resultSetService.getResultSet(entityTypeId, fields, resultIds, tenantsToQuery);

--- a/src/test/java/org/folio/fqm/controller/EntityTypeControllerTest.java
+++ b/src/test/java/org/folio/fqm/controller/EntityTypeControllerTest.java
@@ -51,7 +51,7 @@ class EntityTypeControllerTest {
     EntityTypeColumn col = getEntityTypeColumn();
     EntityType mockDefinition = getEntityType(col);
     when(folioExecutionContext.getTenantId()).thenReturn("tenant_01");
-    when(entityTypeService.getEntityTypeDefinition(id,false)).thenReturn(mockDefinition);
+    when(entityTypeService.getEntityTypeDefinition(id,false, true)).thenReturn(mockDefinition);
     RequestBuilder builder = MockMvcRequestBuilders
       .get(GET_DEFINITION_URL, id)
       .accept(MediaType.APPLICATION_JSON)
@@ -73,7 +73,7 @@ class EntityTypeControllerTest {
     EntityTypeColumn col = getHiddenEntityTypeColumn();
     EntityType mockDefinition = getEntityType(col);
     when(folioExecutionContext.getTenantId()).thenReturn("tenant_01");
-    when(entityTypeService.getEntityTypeDefinition(id,true)).thenReturn(mockDefinition);
+    when(entityTypeService.getEntityTypeDefinition(id,true, true)).thenReturn(mockDefinition);
     RequestBuilder builder = MockMvcRequestBuilders
       .get(GET_DEFINITION_URL, id)
       .accept(MediaType.APPLICATION_JSON)

--- a/src/test/java/org/folio/fqm/service/EntityTypeServiceTest.java
+++ b/src/test/java/org/folio/fqm/service/EntityTypeServiceTest.java
@@ -71,7 +71,7 @@ class EntityTypeServiceTest {
       .columns(columns);
 
     when(entityTypeFlatteningService.getFlattenedEntityType(entityTypeId, null)).thenReturn(entityType);
-    EntityType result = entityTypeService.getEntityTypeDefinition(entityTypeId, true, false);
+    EntityType result = entityTypeService.getEntityTypeDefinition(entityTypeId, true, true);
     List<EntityTypeColumn> expectedColumns = columns.stream()
       .sorted(nullsLast(comparing(EntityTypeColumn::getLabelAlias, String.CASE_INSENSITIVE_ORDER)))
       .toList();

--- a/src/test/java/org/folio/fqm/service/EntityTypeServiceTest.java
+++ b/src/test/java/org/folio/fqm/service/EntityTypeServiceTest.java
@@ -71,7 +71,7 @@ class EntityTypeServiceTest {
       .columns(columns);
 
     when(entityTypeFlatteningService.getFlattenedEntityType(entityTypeId, null)).thenReturn(entityType);
-    EntityType result = entityTypeService.getEntityTypeDefinition(entityTypeId, true);
+    EntityType result = entityTypeService.getEntityTypeDefinition(entityTypeId, true, false);
     List<EntityTypeColumn> expectedColumns = columns.stream()
       .sorted(nullsLast(comparing(EntityTypeColumn::getLabelAlias, String.CASE_INSENSITIVE_ORDER)))
       .toList();
@@ -363,7 +363,7 @@ class EntityTypeServiceTest {
       .thenReturn(expectedEntityType);
 
     EntityType actualDefinition = entityTypeService
-      .getEntityTypeDefinition(entityTypeId, false);
+      .getEntityTypeDefinition(entityTypeId, false, false);
 
     assertEquals(expectedEntityType, actualDefinition);
   }

--- a/src/test/java/org/folio/fqm/service/QueryManagementServiceTest.java
+++ b/src/test/java/org/folio/fqm/service/QueryManagementServiceTest.java
@@ -107,7 +107,7 @@ class QueryManagementServiceTest {
     SubmitQuery submitQuery = new SubmitQuery().entityTypeId(entityTypeId).fqlQuery(fqlQuery).maxSize(maxQuerySize);
     QueryIdentifier expectedIdentifier = new QueryIdentifier().queryId(UUID.randomUUID());
     when(executionContext.getUserId()).thenReturn(createdById);
-    when(entityTypeService.getEntityTypeDefinition(entityTypeId, true)).thenReturn(entityType);
+    when(entityTypeService.getEntityTypeDefinition(entityTypeId, true, false)).thenReturn(entityType);
     when(fqlValidationService.validateFql(entityType, fqlQuery)).thenReturn(Map.of());
     when(queryRepository.saveQuery(any())).thenReturn(expectedIdentifier);
     QueryIdentifier actualIdentifier = queryManagementService.runFqlQueryAsync(submitQuery);
@@ -132,7 +132,7 @@ class QueryManagementServiceTest {
     SubmitQuery submitQuery = new SubmitQuery().entityTypeId(entityTypeId).fqlQuery(fqlQuery);
     QueryIdentifier expectedIdentifier = new QueryIdentifier().queryId(UUID.randomUUID());
     when(executionContext.getUserId()).thenReturn(createdById);
-    when(entityTypeService.getEntityTypeDefinition(entityTypeId,true)).thenReturn(entityType);
+    when(entityTypeService.getEntityTypeDefinition(entityTypeId,true, false)).thenReturn(entityType);
     when(fqlValidationService.validateFql(entityType, fqlQuery)).thenReturn(Map.of());
     when(queryRepository.saveQuery(any())).thenReturn(expectedIdentifier);
     QueryIdentifier actualIdentifier = queryManagementService.runFqlQueryAsync(submitQuery);
@@ -164,7 +164,7 @@ class QueryManagementServiceTest {
       .maxSize(maxQuerySize);
     QueryIdentifier expectedIdentifier = new QueryIdentifier().queryId(UUID.randomUUID());
     when(executionContext.getUserId()).thenReturn(createdById);
-    when(entityTypeService.getEntityTypeDefinition(entityTypeId,true)).thenReturn(entityType);
+    when(entityTypeService.getEntityTypeDefinition(entityTypeId,true, false)).thenReturn(entityType);
     when(fqlValidationService.validateFql(entityType, fqlQuery)).thenReturn(Map.of());
     when(queryRepository.saveQuery(any())).thenReturn(expectedIdentifier);
     QueryIdentifier actualIdentifier = queryManagementService.runFqlQueryAsync(submitQuery);
@@ -185,7 +185,7 @@ class QueryManagementServiceTest {
     int maxQuerySize = 100;
     SubmitQuery submitQuery = new SubmitQuery().entityTypeId(entityTypeId).fqlQuery(fqlQuery);
     when(executionContext.getUserId()).thenReturn(createdById);
-    when(entityTypeService.getEntityTypeDefinition(entityTypeId,true)).thenReturn(entityType);
+    when(entityTypeService.getEntityTypeDefinition(entityTypeId,true, false)).thenReturn(entityType);
     when(fqlValidationService.validateFql(entityType, fqlQuery)).thenReturn(Map.of("field1", "Field is invalid"));
     assertThrows(InvalidFqlException.class, () -> queryManagementService.runFqlQueryAsync(submitQuery));
     verify(queryExecutionService, times(0)).executeQueryAsync(any(), eq(entityType), eq(maxQuerySize));
@@ -266,7 +266,7 @@ class QueryManagementServiceTest {
     );
     List<String> fields = List.of("id", "field1", "field2");
     ResultsetPage expectedResults = new ResultsetPage().content(expectedContent);
-    when(entityTypeService.getEntityTypeDefinition(entityTypeId,true)).thenReturn(entityType);
+    when(entityTypeService.getEntityTypeDefinition(entityTypeId,true, false)).thenReturn(entityType);
     when(fqlValidationService.validateFql(entityType, fqlQuery)).thenReturn(Map.of());
     when(queryProcessorService.processQuery(any(EntityType.class), eq(fqlQuery), eq(fields), isNull(), eq(defaultLimit))).thenReturn(expectedContent);
     ResultsetPage actualResults = queryManagementService.runFqlQuery(fqlQuery, entityTypeId, fields, null, defaultLimit);
@@ -294,7 +294,7 @@ class QueryManagementServiceTest {
     );
     List<String> fields = new ArrayList<>(List.of("field1", "field2"));
     ResultsetPage expectedResults = new ResultsetPage().content(expectedContent);
-    when(entityTypeService.getEntityTypeDefinition(entityTypeId, true)).thenReturn(entityType);
+    when(entityTypeService.getEntityTypeDefinition(entityTypeId, true, false)).thenReturn(entityType);
     when(fqlValidationService.validateFql(entityType, fqlQuery)).thenReturn(Map.of());
     when(queryProcessorService.processQuery(any(EntityType.class), eq(fqlQuery), eq(List.of("field1", "field2", "id")), isNull(), eq(defaultLimit)))
       .thenReturn(expectedContent);
@@ -321,7 +321,7 @@ class QueryManagementServiceTest {
       Map.of("id", resultIds.get(1).toString())
     );
     ResultsetPage expectedResults = new ResultsetPage().content(expectedContent);
-    when(entityTypeService.getEntityTypeDefinition(entityTypeId, true)).thenReturn(entityType);
+    when(entityTypeService.getEntityTypeDefinition(entityTypeId, true, false)).thenReturn(entityType);
     when(fqlValidationService.validateFql(entityType, fqlQuery)).thenReturn(Map.of());
     when(queryProcessorService.processQuery(any(EntityType.class), eq(fqlQuery), eq(List.of("id")), isNull(), eq(defaultLimit)))
       .thenReturn(expectedContent);
@@ -336,7 +336,7 @@ class QueryManagementServiceTest {
     String fqlQuery = """
       {"field1": {"$in": ["value1", "value2", "value3", "value4", "value5" ] }}
       """;
-    when(entityTypeService.getEntityTypeDefinition(entityTypeId, true)).thenReturn(entityType);
+    when(entityTypeService.getEntityTypeDefinition(entityTypeId, true, false)).thenReturn(entityType);
     when(fqlValidationService.validateFql(entityType, fqlQuery))
       .thenReturn(Map.of());
     assertDoesNotThrow(() -> queryManagementService.validateQuery(entityTypeId, fqlQuery));
@@ -350,7 +350,7 @@ class QueryManagementServiceTest {
       {"field1": {"$in": ["value1", "value2", "value3", "value4", "value5" ] }}
       """;
     doThrow(new EntityTypeNotFoundException(entityTypeId))
-      .when(entityTypeService).getEntityTypeDefinition(entityTypeId, true);
+      .when(entityTypeService).getEntityTypeDefinition(entityTypeId, true, false);
     assertThrows(EntityTypeNotFoundException.class,
       () -> queryManagementService.validateQuery(entityTypeId, fqlQuery));
   }
@@ -362,7 +362,7 @@ class QueryManagementServiceTest {
     String fqlQuery = """
       {"field1": {"$nn": ["value1", "value2", "value3", "value4", "value5" ] }}
       """;
-    when(entityTypeService.getEntityTypeDefinition(entityTypeId, true)).thenReturn(entityType);
+    when(entityTypeService.getEntityTypeDefinition(entityTypeId, true, false)).thenReturn(entityType);
     when(fqlValidationService.validateFql(entityType, fqlQuery))
       .thenReturn(Map.of("field1", "field is invalid"));
     assertThrows(InvalidFqlException.class,
@@ -415,7 +415,7 @@ class QueryManagementServiceTest {
     );
 
     when(queryRepository.getQuery(query.queryId(), false)).thenReturn(Optional.of(query));
-    when(entityTypeService.getEntityTypeDefinition(query.entityTypeId(), true)).thenReturn(new EntityType());
+    when(entityTypeService.getEntityTypeDefinition(query.entityTypeId(), true, false)).thenReturn(new EntityType());
     when(queryResultsSorterService.getSortedIds(query.queryId(), offset, limit)).thenReturn(expectedIds);
 
     List<List<String>> actualIds = queryManagementService.getSortedIds(query.queryId(), offset, limit);
@@ -431,7 +431,7 @@ class QueryManagementServiceTest {
     int offset = 0;
     int limit = 0;
     when(queryRepository.getQuery(query.queryId(), false)).thenReturn(Optional.of(query));
-    when(entityTypeService.getEntityTypeDefinition(query.entityTypeId(), false)).thenReturn(null);
+    when(entityTypeService.getEntityTypeDefinition(query.entityTypeId(), false, false)).thenReturn(null);
     assertThrows(EntityTypeNotFoundException.class, () -> queryManagementService.getSortedIds(queryId, offset, limit));
   }
 
@@ -463,7 +463,7 @@ class QueryManagementServiceTest {
       Map.of("id", UUID.randomUUID(), "field1", "value1", "field2", "value2"),
       Map.of("id", UUID.randomUUID(), "field1", "value3", "field2", "value4")
     );
-    when(entityTypeService.getEntityTypeDefinition(entityTypeId,true)).thenReturn(entityType);
+    when(entityTypeService.getEntityTypeDefinition(entityTypeId,true, false)).thenReturn(entityType);
     when(crossTenantQueryService.getTenantsToQuery(any(EntityType.class), eq(false))).thenReturn(tenantIds);
     when(resultSetService.getResultSet(entityTypeId, fields, ids, tenantIds)).thenReturn(expectedContents);
     List<Map<String, Object>> actualContents = queryManagementService.getContents(entityTypeId, fields, ids);
@@ -489,7 +489,7 @@ class QueryManagementServiceTest {
       Map.of("id", UUID.randomUUID(), "field1", "value1", "field2", "value2"),
       Map.of("id", UUID.randomUUID(), "field1", "value3", "field2", "value4")
     );
-    when(entityTypeService.getEntityTypeDefinition(entityTypeId, true)).thenReturn(entityType);
+    when(entityTypeService.getEntityTypeDefinition(entityTypeId, true, false)).thenReturn(entityType);
     when(crossTenantQueryService.getTenantsToQuery(any(EntityType.class), eq(false))).thenReturn(tenantIds);
     when(resultSetService.getResultSet(entityTypeId, expectedFields, ids, tenantIds)).thenReturn(expectedContents);
     List<Map<String, Object>> actualContents = queryManagementService.getContents(entityTypeId, providedFields, ids);


### PR DESCRIPTION
## Purpose
Add sortColumns parameter to getEntityTypeDefinition method. sortColumns=true will be used only by the EntityTypeController's getEntityTypeDefinition method. Otherwise it'll be false. This will allow the /entity-type/{entity-type-id} API to sort columns according to their translations, while ensuring columns stay unsorted behind the scenes (so that query results are saved in a consistent manner)