### PR TITLE
MODFQMMGR-448 Fix bug with valueSourceApi

### DIFF
--- a/src/main/java/org/folio/fqm/service/EntityTypeService.java
+++ b/src/main/java/org/folio/fqm/service/EntityTypeService.java
@@ -115,6 +115,14 @@ public class EntityTypeService {
       .findFieldDefinition(new FqlField(fieldName), entityType)
       .orElseThrow(() -> new FieldNotFoundException(entityType.getName(), fieldName));
 
+    if (field.getValues() != null) {
+      return getFieldValuesFromEntityTypeDefinition(field, searchText);
+    }
+
+    if (field.getValueSourceApi() != null) {
+      return getFieldValuesFromApi(field, searchText);
+    }
+
     if (field.getSource() != null) {
       if (field.getSource().getType() == SourceColumn.TypeEnum.ENTITY_TYPE) {
         return getFieldValuesFromEntityType(entityType, fieldName, searchText);
@@ -131,14 +139,6 @@ public class EntityTypeService {
           }
         }
       }
-    }
-
-    if (field.getValues() != null) {
-      return getFieldValuesFromEntityTypeDefinition(field, searchText);
-    }
-
-    if (field.getValueSourceApi() != null) {
-      return getFieldValuesFromApi(field, searchText);
     }
 
     throw new InvalidEntityTypeDefinitionException("Unable to retrieve column values for " + fieldName, entityType);


### PR DESCRIPTION
With a recent change, the source property on columns started taking precedence over valueSourceApi, but source is required on columns that use valueSourceApi, making it effectively break all valueSourceApi columns. This commit rearranges taht code, so that valueSourceApi (and values, which is more of an edge case, but has the same bug) has a higher precedence