### PR TITLE
Don't aggregate languages across tenants

### DIFF
--- a/src/main/java/org/folio/fqm/client/SimpleHttpClient.java
+++ b/src/main/java/org/folio/fqm/client/SimpleHttpClient.java
@@ -31,6 +31,6 @@ public interface SimpleHttpClient {
    * @param tenant      - FOLIO tenant from which to retrieve data
    * @return the body of the response (JSON)
    */
-  @GetMapping(value = "/{path}?{queryParams}", produces = MediaType.APPLICATION_JSON_VALUE)
+  @GetMapping(value = "/{path}", produces = MediaType.APPLICATION_JSON_VALUE)
   String get(@PathVariable String path, @SpringQueryMap Map<String, String> queryParams, @RequestHeader("X-Okapi-Tenant") String tenant);
 }

--- a/src/test/java/org/folio/fqm/service/EntityTypeServiceTest.java
+++ b/src/test/java/org/folio/fqm/service/EntityTypeServiceTest.java
@@ -396,7 +396,7 @@ class EntityTypeServiceTest {
 
     when(entityTypeFlatteningService.getFlattenedEntityType(entityTypeId, null)).thenReturn(entityType);
     when(crossTenantQueryService.getTenantsToQueryForColumnValues(entityType)).thenReturn(tenantList);
-    when(simpleHttpClient.get(eq("search/instances/facets"), anyMap(), eq("tenant_01"))).thenReturn("""
+    when(simpleHttpClient.get(eq("search/instances/facets"), anyMap())).thenReturn("""
            {
              "facets": {
                "languages": {
@@ -451,7 +451,7 @@ class EntityTypeServiceTest {
 
     when(entityTypeFlatteningService.getFlattenedEntityType(entityTypeId, null)).thenReturn(entityType);
     when(crossTenantQueryService.getTenantsToQueryForColumnValues(entityType)).thenReturn(tenantList);
-    when(simpleHttpClient.get(eq("search/instances/facets"), anyMap(), eq("tenant_01"))).thenReturn("""
+    when(simpleHttpClient.get(eq("search/instances/facets"), anyMap())).thenReturn("""
            {
              "facets": {
                "languages": {
@@ -520,7 +520,7 @@ class EntityTypeServiceTest {
 
     when(entityTypeFlatteningService.getFlattenedEntityType(entityTypeId, null)).thenReturn(entityType);
     when(crossTenantQueryService.getTenantsToQueryForColumnValues(entityType)).thenReturn(tenantList);
-    when(simpleHttpClient.get(eq("search/instances/facets"), anyMap(), eq("tenant_01"))).thenThrow(FeignException.BadRequest.class);
+    when(simpleHttpClient.get(eq("search/instances/facets"), anyMap())).thenThrow(FeignException.BadRequest.class);
 
     assertDoesNotThrow(() -> entityTypeService.getFieldValues(entityTypeId, valueColumnName, ""));
   }


### PR DESCRIPTION
## Purpose
Mod-search doesn't like our feign client sending the okapi tenant in the request (works fine for other APIs). Removing it for now to get things mostly working for languages.