### PR TITLE
MODFQMMGR-547 Update a join condition to use an index

### DIFF
--- a/src/main/resources/entity-types/inventory/composite_instances.json5
+++ b/src/main/resources/entity-types/inventory/composite_instances.json5
@@ -19,7 +19,7 @@
       join: {
         type: 'left join',
         joinTo: 'instance.inst',
-        condition: ":this.id = (:that.jsonb ->> 'statusId')::uuid",
+        condition: ":this.id = :that.instancestatusid",
       },
     },
     {


### PR DESCRIPTION
This commit switches the join condition for simple_instance_status in composite_instances away from a JSONB property to a regular column, since the column version has an index available