### PR TITLE
MODFQMMGR-538 Fix defaultSort in composite ETs

### DIFF
--- a/src/main/resources/entity-types/circulation/composite_loan_details.json5
+++ b/src/main/resources/entity-types/circulation/composite_loan_details.json5
@@ -108,4 +108,10 @@
       },
     },
   ],
+  defaultSort: [
+    {
+      columnName: '"loans.loan".id',
+      direction: 'ASC',
+    },
+  ]
 }

--- a/src/main/resources/entity-types/inventory/composite_holdings_record.json5
+++ b/src/main/resources/entity-types/inventory/composite_holdings_record.json5
@@ -58,7 +58,7 @@
   ],
   defaultSort: [
     {
-      columnName: 'id',
+      columnName: '"holdings.hrd".id',
       direction: 'ASC',
     },
   ],

--- a/src/main/resources/entity-types/inventory/composite_item_details.json5
+++ b/src/main/resources/entity-types/inventory/composite_item_details.json5
@@ -111,4 +111,10 @@
       },
     },
   ],
+  defaultSort: [
+    {
+      columnName: '"items.item".id',
+      direction: 'ASC',
+    },
+  ]
 }

--- a/src/main/resources/entity-types/orders/composite_purchase_order_lines.json5
+++ b/src/main/resources/entity-types/orders/composite_purchase_order_lines.json5
@@ -122,7 +122,7 @@
   ],
   defaultSort: [
     {
-      columnName: 'id',
+      columnName: '"pol.pol".id',
       direction: 'ASC',
     },
   ]

--- a/src/main/resources/entity-types/organizations/simple_organizations.json5
+++ b/src/main/resources/entity-types/organizations/simple_organizations.json5
@@ -2128,4 +2128,10 @@
       valueGetter: ":sourceAlias.jsonb::text",
     }
   ],
+  defaultSort: [
+    {
+      columnName: 'id',
+      direction: 'ASC',
+    },
+  ]
 }


### PR DESCRIPTION
This commit fixes the defaultSort property in these entity types into fully qualified column references, to fix an issue where these entity types just didn't work with the synchronous query endpoint