### PR TITLE
MODFQMMGR-570 Add missing permissions interfaces to MD

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -406,6 +406,14 @@
     {
       "id": "consortia",
       "version": "1.0"
+    },
+    {
+      "id": "permissions",
+      "version": "5.8"
+    },
+    {
+      "id": "permissions-users",
+      "version": "1.0"
     }
   ],
   "launchDescriptor": {


### PR DESCRIPTION
This commit adds 2 "permissions" interfaces to the module descriptor. The "permissions" interface is for mod-permissions (Okapi), while "permissions-users" is for mod-roles-keycloak (Eureka). These are mutually exclusive, so these dependencies are going into the "optional" section of the MD