### PR TITLE
[MODFQMMGR-573] Consider converted date for timezone offsets, rather than system time

### DIFF
--- a/src/main/java/org/folio/fqm/client/ConfigurationClient.java
+++ b/src/main/java/org/folio/fqm/client/ConfigurationClient.java
@@ -1,12 +1,39 @@
 package org.folio.fqm.client;
 
-import org.springframework.cloud.openfeign.FeignClient;
-import org.springframework.stereotype.Service;
-import org.springframework.web.bind.annotation.GetMapping;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import feign.FeignException;
+import java.time.DateTimeException;
+import java.time.ZoneId;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
-@Service
-@FeignClient(name = "configurations")
-public interface ConfigurationClient {
-  @GetMapping("/entries?query=(module==ORG and configName==localeSettings)")
-  String getLocaleSettings();
+/**
+ * Convenience methods wrapping {@link ConfigurationClientRaw}.
+ */
+// this must be a separate class as feign clients must be interfaces,
+// disallowing any injection (ObjectMapper) or fields (our logger)
+@Log4j2
+@Component
+@RequiredArgsConstructor(onConstructor_ = @Autowired)
+public class ConfigurationClient {
+
+  private final ObjectMapper objectMapper;
+  private final ConfigurationClientRaw underlyingClient;
+
+  public ZoneId getTenantTimezone() {
+    try {
+      String localeSettingsResponse = underlyingClient.getLocaleSettings();
+      JsonNode localeSettingsNode = objectMapper.readTree(localeSettingsResponse);
+      String valueString = localeSettingsNode.path("configs").get(0).path("value").asText();
+      JsonNode valueNode = objectMapper.readTree(valueString);
+      return ZoneId.of(valueNode.path("timezone").asText());
+    } catch (JsonProcessingException | FeignException.Unauthorized | NullPointerException | DateTimeException e) {
+      log.error("Failed to retrieve timezone information from mod-configuration. Defaulting to UTC.", e);
+      return ZoneId.of("UTC");
+    }
+  }
 }

--- a/src/main/java/org/folio/fqm/client/ConfigurationClientRaw.java
+++ b/src/main/java/org/folio/fqm/client/ConfigurationClientRaw.java
@@ -1,0 +1,15 @@
+package org.folio.fqm.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.GetMapping;
+
+/**
+ * Provides raw access to the mod-configurations API. You probably want {@link ConfigurationClient} instead.
+ */
+@Service
+@FeignClient(name = "configurations")
+public interface ConfigurationClientRaw {
+  @GetMapping("/entries?query=(module==ORG and configName==localeSettings)")
+  public abstract String getLocaleSettings();
+}

--- a/src/main/java/org/folio/fqm/service/ResultSetService.java
+++ b/src/main/java/org/folio/fqm/service/ResultSetService.java
@@ -89,8 +89,7 @@ public class ResultSetService {
     for (String fieldName : dateFields) {
       contents.computeIfPresent(fieldName, (key, value) -> {
         if (value instanceof Timestamp ts) {
-        log.info("{} {} {}", ts, ts.toInstant(), ts.toLocalDateTime());
-        return adjustDate(ts.toInstant(), tenantTimezone);
+          return adjustDate(ts.toInstant(), tenantTimezone);
         } else if (value instanceof String s) {
           return parseAndAdjustDate(s, tenantTimezone);
         }

--- a/src/main/java/org/folio/fqm/service/ResultSetService.java
+++ b/src/main/java/org/folio/fqm/service/ResultSetService.java
@@ -1,9 +1,5 @@
 package org.folio.fqm.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import feign.FeignException;
 import lombok.extern.log4j.Log4j2;
 import org.folio.fqm.client.ConfigurationClient;
 import org.folio.fqm.repository.ResultSetRepository;
@@ -15,11 +11,11 @@ import org.springframework.stereotype.Service;
 import lombok.RequiredArgsConstructor;
 
 import java.sql.Timestamp;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -34,10 +30,11 @@ import java.util.stream.Collectors;
 @Log4j2
 public class ResultSetService {
 
-  private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
-  private static final DateTimeFormatter DATE_TIME_OFFSET_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'+00:00'");
-  private static final String DATE_TIME_REGEX = "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z$";
-  private static final String DATE_TIME_OFFSET_REGEX = "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}[+-]\\d{2}:\\d{2}$";
+  private static final DateTimeFormatter DATE_TIME_FORMATTER = new DateTimeFormatterBuilder()
+    .append(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+    .optionalStart().appendOffsetId() // optional Z/timezone at end
+    .toFormatter().withZone(ZoneOffset.UTC); // force interpretation as UTC
+  private static final String DATE_TIME_REGEX = "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}([+-]\\d{2}:\\d{2}(:\\d{2})?|Z|)$";
   private final ResultSetRepository resultSetRepository;
   private final EntityTypeFlatteningService entityTypeFlatteningService;
   private final ConfigurationClient configurationClient;
@@ -64,7 +61,7 @@ public class ResultSetService {
       );
 
     List<String> dateFields = localize ? EntityTypeUtils.getDateFields(entityType) : List.of();
-    ZoneOffset zoneOffset = localize ? getZoneOffset() : null;
+    ZoneId tenantTimezone = localize ? configurationClient.getTenantTimezone() : null;
 
     return contentIds
       .stream()
@@ -81,57 +78,37 @@ public class ResultSetService {
 
         Map<String, Object> copiedContents = new HashMap<>(contents);
         if (localize) {
-          localizeContent(copiedContents, dateFields, zoneOffset);
+          localizeContent(copiedContents, dateFields, tenantTimezone);
         }
         return copiedContents;
       })
       .toList();
   }
 
-  private void localizeContent(Map<String, Object> contents, List<String> dateFields, ZoneOffset zoneOffset) {
+  private void localizeContent(Map<String, Object> contents, List<String> dateFields, ZoneId tenantTimezone) {
     for (String fieldName : dateFields) {
       contents.computeIfPresent(fieldName, (key, value) -> {
         if (value instanceof Timestamp ts) {
-          return adjustDate(ts.toLocalDateTime(), zoneOffset);
+        log.info("{} {} {}", ts, ts.toInstant(), ts.toLocalDateTime());
+        return adjustDate(ts.toInstant(), tenantTimezone);
         } else if (value instanceof String s) {
-          return parseAndAdjustDate(s, zoneOffset);
+          return parseAndAdjustDate(s, tenantTimezone);
         }
         return value;
       });
     }
   }
 
-  private static String adjustDate(LocalDateTime dateTime, ZoneOffset zoneOffset) {
-    return dateTime.plusSeconds(zoneOffset.getTotalSeconds()).toLocalDate().toString();
+  private static String adjustDate(Instant instant, ZoneId tenantTimezone) {
+    return instant.atZone(tenantTimezone).toLocalDate().toString();
   }
 
-  private static String parseAndAdjustDate(String contentItem, ZoneOffset zoneOffset) {
-    LocalDateTime dateTime = null;
-    if (contentItem.matches(DATE_TIME_REGEX)) {
-      dateTime = LocalDateTime.parse(contentItem, DATE_TIME_FORMATTER);
-    } else if (contentItem.matches(DATE_TIME_OFFSET_REGEX)) {
-      dateTime = LocalDateTime.parse(contentItem, DATE_TIME_OFFSET_FORMATTER);
+  private static String parseAndAdjustDate(String value, ZoneId tenantTimezone) {
+    if (value.matches(DATE_TIME_REGEX)) {
+      return adjustDate(Instant.from(DATE_TIME_FORMATTER.parse(value)), tenantTimezone);
     }
-    return dateTime != null ? adjustDate(dateTime, zoneOffset) : contentItem;
-  }
 
-  private ZoneOffset getZoneOffset() {
-    try {
-      ObjectMapper objectMapper = new ObjectMapper();
-      String localeSettingsResponse = configurationClient.getLocaleSettings();
-      JsonNode localeSettingsNode = objectMapper.readTree(localeSettingsResponse);
-      String valueString = localeSettingsNode
-        .path("configs")
-        .get(0)
-        .path("value")
-        .asText();
-      JsonNode valueNode = objectMapper.readTree(valueString);
-      ZoneId zoneId = ZoneId.of(valueNode.path("timezone").asText());
-      ZonedDateTime zonedDateTime = ZonedDateTime.now(zoneId);
-      return zonedDateTime.getOffset();
-    } catch (JsonProcessingException | FeignException.Unauthorized | FeignException.NotFound | NullPointerException e) {
-      log.error("Failed to retrieve locale information from mod-configuration. Defaulting to UTC.");
-      return ZoneOffset.UTC;
-    }
+    log.warn("Database date value is in an unrecognized format: \"{}\"", value);
+    return value;
   }
 }

--- a/src/test/java/org/folio/fqm/client/ConfigurationClientTest.java
+++ b/src/test/java/org/folio/fqm/client/ConfigurationClientTest.java
@@ -1,0 +1,77 @@
+package org.folio.fqm.client;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import feign.FeignException;
+import java.time.ZoneId;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ConfigurationClientTest {
+
+  private static final String UTC_MINUS_THREE_LOCALE =
+    """
+    {
+      "configs": [
+        {
+           "id":"2a132a01-623b-4d3a-9d9a-2feb777665c2",
+           "module":"ORG",
+           "configName":"localeSettings",
+           "enabled":true,
+           "value":"{\\"locale\\":\\"en-US\\",\\"timezone\\":\\"America/Montevideo\\",\\"currency\\":\\"USD\\"}","metadata":{"createdDate":"2024-03-25T17:37:22.309+00:00","createdByUserId":"db760bf8-e05a-4a5d-a4c3-8d49dc0d4e48"}
+        }
+      ],
+      "totalRecords": 1,
+      "resultInfo": {"totalRecords":1,"facets":[],"diagnostics":[]}
+    }
+    """;
+
+  private static final String EMPTY_LOCALE_JSON =
+    """
+    {
+      "configs": [],
+      "totalRecords": 0,
+      "resultInfo": {"totalRecords":1,"facets":[],"diagnostics":[]}
+    }
+    """;
+
+  @InjectMocks
+  private ConfigurationClient configurationClient;
+
+  @Mock
+  private ConfigurationClientRaw underlyingClient;
+
+  @Spy // lazy way to make it inject into ConfigurationClient
+  private ObjectMapper objectMapper = new ObjectMapper();
+
+  @Test
+  void testTenantTimezoneWhenPresent() {
+    when(underlyingClient.getLocaleSettings()).thenReturn(UTC_MINUS_THREE_LOCALE);
+
+    assertThat(configurationClient.getTenantTimezone(), is(ZoneId.of("America/Montevideo")));
+  }
+
+  @Test
+  void testTenantTimezoneWhenNonePresent() {
+    when(underlyingClient.getLocaleSettings()).thenReturn(EMPTY_LOCALE_JSON);
+
+    assertThat(configurationClient.getTenantTimezone(), is(ZoneId.of("UTC")));
+  }
+
+  @Test
+  void testHandlesException() {
+    when(underlyingClient.getLocaleSettings())
+      .thenThrow(new FeignException.Unauthorized("", mock(feign.Request.class), null, null));
+
+    assertThat(configurationClient.getTenantTimezone(), is(ZoneId.of("UTC")));
+  }
+}

--- a/src/test/java/org/folio/fqm/service/ResultSetServiceTest.java
+++ b/src/test/java/org/folio/fqm/service/ResultSetServiceTest.java
@@ -179,16 +179,22 @@ class ResultSetServiceTest {
     UUID entityTypeId = UUID.fromString(DATE_ENTITY_TYPE.getId());
     UUID contentId = UUID.fromString("bb0e294a-bd66-5878-a597-a2a3ac035d8e");
 
+    Object extraordinarilyInvalidDate = new Object() {
+      public String toString() { return "extraordinarily invalid date"; }
+    };
+
     List<Map<String, Object>> repositoryResponse = List.of(
       Map.of(
         "id", contentId,
-        "dateField", "invalid date"
+        "dateField", "invalid date",
+        "offsetDateField", extraordinarilyInvalidDate
       )
     );
     List<Map<String, Object>> expectedResult = List.of(
       Map.of(
         "id", contentId,
-        "dateField", "invalid date"
+        "dateField", "invalid date",
+        "offsetDateField", extraordinarilyInvalidDate
       )
     );
     List<String> fields = List.of("id", "dateField");

--- a/src/test/java/org/folio/fqm/service/ResultSetServiceTest.java
+++ b/src/test/java/org/folio/fqm/service/ResultSetServiceTest.java
@@ -157,13 +157,47 @@ class ResultSetServiceTest {
     );
     List<String> fields = List.of("id", "dateField", "timestampField", "offsetDateField");
     List<String> tenantIds = List.of("tenant_01");
-    List<List<String>> listIds = List.of(
-      List.of(contentId.toString())
-    );
+    List<List<String>> listIds = List.of(List.of(contentId.toString()));
 
     when(entityTypeFlatteningService.getFlattenedEntityType(entityTypeId, null)).thenReturn(DATE_ENTITY_TYPE);
     when(entityTypeFlatteningService.getFlattenedEntityType(entityTypeId, "tenant_01")).thenReturn(DATE_ENTITY_TYPE);
     when(configurationClient.getTenantTimezone()).thenReturn(timezone);
+    when(resultSetRepository.getResultSet(entityTypeId, fields, listIds, tenantIds)).thenReturn(repositoryResponse);
+
+    List<Map<String, Object>> actualResult = service.getResultSet(
+      entityTypeId,
+      fields,
+      listIds,
+      tenantIds,
+      true
+    );
+    assertEquals(expectedResult, actualResult);
+  }
+
+  @Test
+  void testInvalidDateHandling() {
+    UUID entityTypeId = UUID.fromString(DATE_ENTITY_TYPE.getId());
+    UUID contentId = UUID.fromString("bb0e294a-bd66-5878-a597-a2a3ac035d8e");
+
+    List<Map<String, Object>> repositoryResponse = List.of(
+      Map.of(
+        "id", contentId,
+        "dateField", "invalid date"
+      )
+    );
+    List<Map<String, Object>> expectedResult = List.of(
+      Map.of(
+        "id", contentId,
+        "dateField", "invalid date"
+      )
+    );
+    List<String> fields = List.of("id", "dateField");
+    List<String> tenantIds = List.of("tenant_01");
+    List<List<String>> listIds = List.of(List.of(contentId.toString()));
+
+    when(entityTypeFlatteningService.getFlattenedEntityType(entityTypeId, null)).thenReturn(DATE_ENTITY_TYPE);
+    when(entityTypeFlatteningService.getFlattenedEntityType(entityTypeId, "tenant_01")).thenReturn(DATE_ENTITY_TYPE);
+    when(configurationClient.getTenantTimezone()).thenReturn(ZoneId.of("UTC"));
     when(resultSetRepository.getResultSet(entityTypeId, fields, listIds, tenantIds)).thenReturn(repositoryResponse);
 
     List<Map<String, Object>> actualResult = service.getResultSet(

--- a/src/test/java/org/folio/fqm/service/ResultSetServiceTest.java
+++ b/src/test/java/org/folio/fqm/service/ResultSetServiceTest.java
@@ -186,8 +186,8 @@ class ResultSetServiceTest {
     List<Map<String, Object>> repositoryResponse = List.of(
       Map.of(
         "id", contentId,
-        "dateField", "invalid date",
-        "offsetDateField", extraordinarilyInvalidDate
+        "dateField", "invalid date", // verify strings are attempted to be parsed and handled gracefully
+        "offsetDateField", extraordinarilyInvalidDate // verify non-strings are handled gracefully
       )
     );
     List<Map<String, Object>> expectedResult = List.of(

--- a/src/test/java/org/folio/fqm/service/ResultSetServiceTest.java
+++ b/src/test/java/org/folio/fqm/service/ResultSetServiceTest.java
@@ -12,7 +12,6 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.util.*;
 
-import feign.FeignException;
 import org.folio.fqm.client.ConfigurationClient;
 import org.folio.fqm.repository.ResultSetRepository;
 import org.folio.fqm.testutil.TestDataFixture;


### PR DESCRIPTION
## Why did this happen?

The backend was using the current date to determine the UTC offset, which resulted in either four or five hours (in America/New_York), depending on the date that the server handled the request. This could cause some discrepancies and for queries to return different values when entering/leaving daylight savings/summer time.
