### PR TITLE
MODFQMMGR-570 Downgrade the permissions MD dependency to 5.7

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -409,7 +409,7 @@
     },
     {
       "id": "permissions",
-      "version": "5.8"
+      "version": "5.7"
     },
     {
       "id": "permissions-users",


### PR DESCRIPTION
We don't actually need 5.8, and it's making life difficuly, so let's just use 5.7 ¯\_(ツ)_/¯