### PR TITLE
Set DB_HOST_READER to "" in the MD

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -436,7 +436,7 @@
         "value": "postgres"
       },
       { "name": "DB_HOST_READER",
-        "value": "postgres"
+        "value": ""
       },
       { "name": "DB_PORT",
         "value": "5432"


### PR DESCRIPTION
This commit sets the DB_HOST_READER to "" in the module descriptor, so that the env var is still listed there, but we still maintain the defauly reader fallback behavior when someone uses the values from the MD