### PR TITLE
MODFQMMGR-577 Fix typo in MD and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ mvn clean install
 | IS_EUREKA                                         | false         | Specifies if environment is configured for EUREKA |
 | MAX_QUERY_SIZE                                    | 1250000       | max result count per query                        |
 | mod-fqm-manager.permissions-cache-timeout-seconds | 60            | Cache duration for user permissions               |
-| mod-fqm-manager.entity-type-cache-timeout-seconds | 3600          | Cache duration for entity type definitions        |
+| mod-fqm-manager.entity-type-cache-timeout-seconds | 300           | Cache duration for entity type definitions        |
 | server.port                                       | 8081          | Server port                                       |
 | QUERY_RETENTION_DURATION                          | 3h            | Older queries get deleted                         |
 | task.execution.pool.core-size                     | 9             | Core number of concurrent async tasks             |

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -471,7 +471,7 @@
       { "name": "MAX_QUERY_SIZE",
         "value": "1250000"
       },
-      { "name": "mod.fqm-manager.entity-type-cache-timeout-seconds",
+      { "name": "mod-fqm-manager.entity-type-cache-timeout-seconds",
         "value": "300"
       },
       { "name": "IS_EUREKA",


### PR DESCRIPTION
This commit fixes a typo in the
"mod-fqm-manager.entity-type-cache-timeout-seconds" config setting. It also updates the README to reflect the new default value for this setting