### PR TITLE
Set Hikari max pool size to 12

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -465,8 +465,8 @@
       { "name": "QUERY_RETENTION_DURATION",
         "value": "3h"
       },
-      { "name": "task.execution.pool.max-size",
-        "value": "10"
+      { "name": "spring.task.execution.pool.max-size",
+        "value": "12"
       },
       { "name": "MAX_QUERY_SIZE",
         "value": "1250000"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,6 +23,7 @@ spring:
       initialization-fail-timeout: 1800000
       data-source-properties:
         reWriteBatchedInserts: true
+      maximum-pool-size: 12
   sql:
     init:
       # to boot up application despite of any DB connection issues


### PR DESCRIPTION
If we have 12 application threads, we need a hikari pool size of 12 too.

Also fix module descriptor