### PR TITLE
[MODFQMMGR-623] Resolve query failures against loan policy field

### DIFF
--- a/src/main/resources/entity-types/inventory/simple_instance.json5
+++ b/src/main/resources/entity-types/inventory/simple_instance.json5
@@ -803,8 +803,8 @@
       idColumnName: 'instance_format_ids',
       queryable: true,
       visibleByDefault: false,
-      valueGetter: "( SELECT array_agg(format.jsonb ->> 'name'::text) FROM jsonb_array_elements_text(:sourceAlias.jsonb -> 'instanceFormatIds'::text) record(value) JOIN src_inventory_instance_format format ON record.value::text = format.id::text)",
-      filterValueGetter: "( SELECT array_agg(lower(format.jsonb ->> 'name'::text)) FROM jsonb_array_elements_text(:sourceAlias.jsonb -> 'instanceFormatIds'::text) record(value) JOIN src_inventory_instance_format format ON record.value::text = format.id::text)",
+      valueGetter: "( SELECT array_agg(format.jsonb ->> 'name'::text) FROM jsonb_array_elements_text(:inst.jsonb -> 'instanceFormatIds'::text) record(value) JOIN src_inventory_instance_format format ON record.value::text = format.id::text)",
+      filterValueGetter: "( SELECT array_agg(lower(format.jsonb ->> 'name'::text)) FROM jsonb_array_elements_text(:inst.jsonb -> 'instanceFormatIds'::text) record(value) JOIN src_inventory_instance_format format ON record.value::text = format.id::text)",
       source: {
         entityTypeId: '8fc4a9d2-7ccf-4233-afb8-796911839862',
         columnName: 'format_names',


### PR DESCRIPTION
The error in `Loan policy — Name` traced back to the instance `format_names` field, where an unqualified `:sourceAlias` resulted in postgres attempting to find the table `null`:

```
select "loans.loan".id as "loans.id", "loans.loan".creation_date as "loans.created_at", "loans.loan".jsonb->>'userId' as "loans.user_id", "loans.loan".jsonb->>'proxyUserId' as "loans.proxy_user_id", "loans.loan".jsonb->>'itemId' as "loans.item_id", "loans.loan".jsonb->'status'->>'name' as "loans.status_name", "loans.loan".jsonb->>'loanDate' as "loans.checkout_date", "loans.loan".jsonb->>'dueDate' as "loans.due_date", "loans.loan".jsonb->>'returnDate' as "loans.return_date", "loans.loan".jsonb->>'action' as "loans.action", "loans.loan".jsonb->>'itemStatus' as "loans.item_status", "loans.loan".jsonb->>'renewalCount' as "loans.renewal_count", "loans.loan".jsonb->>'loanPolicyId' as "loans.loan_policy_id", "loans.loan".jsonb->>'checkoutServicePointId' as "loans.checkout_service_point_id", "loans.loan".jsonb->>'checkinServicePointId' as "loans.checkin_service_point_id", "loans.loan".jsonb->>'dueDateChangedByRecall' as "loans.due_date_changed_by_recall", "loans.loan".jsonb->>'declaredLostDate' as "loans.declared_lost_date", "loans.loan".jsonb->>'claimedReturnedDate' as "loans.claimed_returned_date", "lpolicy.lp".id as "lpolicy.id", "lpolicy.lp".jsonb->>'name' as "lpolicy.name", "lpolicy.lp".jsonb->>'loanable' as "lpolicy.loanable", "lpolicy.lp".jsonb->'loansPolicy'->>'profileId' as "lpolicy.loan_profile", "lpolicy.lp".jsonb->>'renewable' as "lpolicy.renewable", "lpolicy.lp".jsonb::text as "lpolicy.jsonb", "cospi.service_point".id as "cospi.id", "cospi.service_point".jsonb->>'code' as "cospi.code", "cospi.service_point".jsonb->>'name' as "cospi.name", "cospi.service_point".jsonb->>'discoveryDisplayName' as "cospi.discovery_display_name", "cospi.service_point".jsonb::text as "cospi.jsonb", "cispi.service_point".id as "cispi.id", "cispi.service_point".jsonb->>'code' as "cispi.code", "c
ispi.service_point".jsonb->>'name' as "cispi.name", "cispi.service_point".jsonb->>'discoveryDisplayName' as "cispi.discovery_display_name", "cispi.service_point".jsonb::text as "cispi.jsonb", "items.item".id as "items.id", "items.item".jsonb ->> 'hrid' as "items.hrid", "items.item".jsonb->>'notes' as "items.notes", "items.item".jsonb->'status'->>'name' as "items.status_name", "items.item".jsonb->>'barcode' as "items.barcode", ("items.item".jsonb->>'_version')::integer as "items.version", "items.item".jsonb->'metadata'->>'createdDate' as "items.created_date", "items.item".jsonb->'metadata'->>'updatedDate' as "items.updated_date", "items.item".jsonb->>'copyNumber' as "items.copy_number", "items.item".materialtypeid as "items.material_type_id", "items.item".jsonb->>'circulationNotes' as "items.circulation_notes", "items.item".jsonb->>'electronicAccess' as "items.electronic_access", "items.item".holdingsrecordid as "items.holdings_record_id", ("items.item".jsonb -> 'statisticalCodeIds'::text) as "items.statistical_code_ids", ( SELECT array_agg(statcode.statistical_code) FROM jsonb_array_elements_text("items.item".jsonb -> 'statisticalCodeIds'::text) record(value) JOIN drv_inventory_statistical_codes_full statcode ON record.value::text = statcode.id::text) as "items.statistical_code_names", (
2025-01-03T17:56:47.432025543Z         SELECT
2025-01-03T17:56:47.432035623Z           array_agg(elems.value::text)
2025-01-03T17:56:47.432041703Z         FROM
2025-01-03T17:56:47.432049134Z           jsonb_array_elements_text("items.item".jsonb->'administrativeNotes') AS elems
      ) as "items.administrative_notes", "items.item".effectivelocationid as "items.effective_location_id", "items.item".jsonb->>'permanentLoanTypeId' as "items.permanent_loan_type_id", "items.item".jsonb->>'itemLevelCallNumberTypeId' as "items.item_level_call_number_type_id", concat_ws(', '::text, NULLIF(("items.item".jsonb -> 'effectiveCallNumberComponents'::text) ->> 'prefix'::text, ''::text), NULLIF(("items.item".jsonb -> 'effectiveCallNumberComponents'::text) ->> 'callNumber'::text, ''::text), NULLIF(("items.item".jsonb -> 'effectiveCallNumberComponents'::text) ->> 'suffix'::text, ''::text), NULLIF("items.item".jsonb ->> 'copyNumber'::text, ''::text)) as "items.effective_call_number", "items.item".jsonb->>'enumeration' as "items.enumeration", "items.item".jsonb->>'effectiveShelvingOrder' as "items.effective_shelving_order", "items.item".jsonb->>'itemLevelCallNumber' as "items.item_level_call_number", "items.item".permanentlocationid as "items.permanent_location_id", "items.item".jsonb->'lastCheckIn'->>'dateTime' as "items.last_check_in_date_time", "items.item".jsonb->'lastCheckIn'->>'staffMemberId' as "items.last_check_in_staff_member_id", "items.item".jsonb->'lastCheckIn'->>'servicePointId' as "items.last_check_in_service_point_id", "items.item".jsonb->>'numberOfPieces' as "items.number_of_pieces", "items.item".jsonb->>'descriptionOfPieces' as "items.description_of_pieces", (
2025-01-03T17:56:47.432073964Z         SELECT
2025-01-03T17:56:47.432079924Z           array_agg(elems.value::text)
        FROM
          jsonb_array_elements_text("items.item".jsonb->'tags'->'tagList') AS elems
2025-01-03T17:56:47.432100595Z       ) as "items.tags_tag_list", "items.item".jsonb->>'chronology' as "items.chronology", "items.item".jsonb->>'discoverySuppress' as "items.discovery_suppress", "items.item".jsonb->>'accessionNumber' as "items.accession_number", "items.item".jsonb->>'numberOfMissingPieces' as "items.number_of_missing_pieces", "items.item".jsonb->>'purchaseOrderLineIdentifier' as "items.purchase_order_line_identifier", "items.item".jsonb::text as "items.jsonb", "mtypes.material_type".id as "mtypes.id", "mtypes.material_type".jsonb->>'name' as "mtypes.name", "mtypes.material_type".jsonb->>'source' as "mtypes.source", "mtypes.material_type".jsonb::text as "mtypes.jsonb", "users.user".id as "users.id", "users.user".jsonb->>'active' as "users.active", concat_ws(', '::text, NULLIF(("users.user".jsonb -> 'personal'::text) ->> 'lastName', ''::text), NULLIF(("users.user".jsonb -> 'personal'::text) ->> 'firstName', ''::text)) as "users.last_name_first_name", "users.user".jsonb->>'expirationDate' as "users.expiration_date", "users.user".jsonb->>'barcode' as "users.barcode", "groups.groups".jsonb->>'group' as "groups.group", "groups.groups".id as "groups.id", "groups.groups".jsonb::text as "groups.jsonb", "holdings.hrd".id as "holdings.id", "holdings.hrd".created_by as "holdings.created_by", "holdings.hrd".creation_date as "holdings.created_at", "holdings.hrd".jsonb->'metadata'->>'updatedByUserId' as "holdings.updated_by", "holdings.hrd".jsonb->'metadata'->>'updatedDate' as "holdings.updated_at", "holdings.hrd".jsonb->>'_version' as "holdings.version", "holdings.hrd".jsonb->>'hrid' as "holdings.hrid", "holdings.hrd".effectivelocationid as "holdings.effective_location_id", "holdings.hrd".holdingstypeid as "holdings.holdings_type_id", "holdings.hrd".instanceid as "holdings.instance_id", "holdings.hrd".permanentlocationid as "holdings.permanent_location_id", "holdings.hrd".temporarylocationid as "ho
ldings.temporary_location_id", "holdings.hrd".sourceid as "holdings.source_id", "holdings.hrd".jsonb->>'callNumber' as "holdings.call_number", (
2025-01-03T17:56:47.432107464Z         SELECT
2025-01-03T17:56:47.432113994Z           array_agg(el::text)
2025-01-03T17:56:47.432120145Z         FROM
          jsonb_array_elements_text("holdings.hrd".jsonb->'formerIds'::text) el (value)
      ) as "holdings.former_ids", "holdings.hrd".jsonb->>'callNumberPrefix' as "holdings.call_number_prefix", "holdings.hrd".jsonb->>'callNumberSuffix' as "holdings.call_number_suffix", "holdings.hrd".jsonb->>'discoverySuppress' as "holdings.discovery_suppress", ("holdings.hrd".jsonb -> 'statisticalCodeIds'::text) as "holdings.statistical_code_ids", ( SELECT array_agg(statcode.statistical_code) FROM jsonb_array_elements_text("holdings.hrd".jsonb -> 'statisticalCodeIds'::text) record(value) JOIN drv_inventory_statistical_codes_full statcode ON record.value::text = statcode.id::text) as "holdings.statistical_code_names", coalesce(
        (
2025-01-03T17:56:47.432151955Z           SELECT
2025-01-03T17:56:47.432158226Z             jsonb_agg(el::jsonb) FILTER (
2025-01-03T17:56:47.432164336Z               WHERE
2025-01-03T17:56:47.432169805Z                 el IS NOT NULL
            )
2025-01-03T17:56:47.432181255Z           FROM
2025-01-03T17:56:47.432192866Z             jsonb_array_elements_text("holdings.hrd".jsonb->'holdingsStatements') el (value)
        ),
2025-01-03T17:56:47.432204846Z         '[]'::jsonb
2025-01-03T17:56:47.432211237Z       )::text as "holdings.holdings_statements", coalesce(
2025-01-03T17:56:47.432217016Z         (
2025-01-03T17:56:47.432223106Z           SELECT
2025-01-03T17:56:47.432229026Z             jsonb_agg(el::jsonb) FILTER (
2025-01-03T17:56:47.432234637Z               WHERE
2025-01-03T17:56:47.432240847Z                 el IS NOT NULL
            )
2025-01-03T17:56:47.432252207Z           FROM
2025-01-03T17:56:47.432261187Z             jsonb_array_elements_text("holdings.hrd".jsonb->'holdingsStatementsForIndexes') el (value)
        ),
2025-01-03T17:56:47.432273128Z         '[]'::jsonb
2025-01-03T17:56:47.432279167Z       )::text as "holdings.holdings_statements_for_indexes", coalesce(
        (
2025-01-03T17:56:47.432290597Z           SELECT
2025-01-03T17:56:47.432296427Z             jsonb_agg(el::jsonb) FILTER (
2025-01-03T17:56:47.432302428Z               WHERE
2025-01-03T17:56:47.432308348Z                 el IS NOT NULL
2025-01-03T17:56:47.432314458Z             )
2025-01-03T17:56:47.432320278Z           FROM
2025-01-03T17:56:47.432326458Z             jsonb_array_elements_text("holdings.hrd".jsonb->'holdingsStatementsForSupplements') el (value)
        ),
2025-01-03T17:56:47.432338248Z         '[]'::jsonb
2025-01-03T17:56:47.432345969Z       )::text as "holdings.holdings_statements_for_supplements", "holdings.hrd".jsonb->>'electronicAccess' as "holdings.electronic_access", "holdings.hrd".jsonb->>'shelvingTitle' as "holdings.shelving_title", "holdings.hrd".jsonb->>'acquisitionFormat' as "holdings.acquisition_format", "holdings.hrd".jsonb->>'acquisitionMethod' as "holdings.acquisition_method", "holdings.hrd".jsonb->>'receiptStatus' as "holdings.receipt_status", "holdings.hrd".jsonb->>'retentionPolicy' as "holdings.retention_policy", "holdings.hrd".jsonb->>'digitizationPolicy' as "holdings.digitization_policy", "holdings.hrd".jsonb->>'copyNumber' as "holdings.copy_number", ("holdings.hrd".jsonb->>'numberOfItems')::float as "holdings.number_of_items", (
        SELECT
2025-01-03T17:56:47.432357888Z           array_agg(elems.value::text)
2025-01-03T17:56:47.432363468Z         FROM
2025-01-03T17:56:47.432369579Z           jsonb_array_elements_text("holdings.hrd".jsonb->'administrativeNotes') AS elems
2025-01-03T17:56:47.432375549Z       ) as "holdings.administrative_notes", (
2025-01-03T17:56:47.432381439Z         SELECT
2025-01-03T17:56:47.432386759Z           array_agg(elems.value::text) FILTER (
            WHERE
2025-01-03T17:56:47.432399659Z               (elems.value::text) IS NOT NULL
2025-01-03T17:56:47.432406669Z           ) AS ARRAY_AGG
2025-01-03T17:56:47.432412810Z         FROM
          jsonb_array_elements_text("holdings.hrd".jsonb->'tags'->'tagList'::text) elems (value)
2025-01-03T17:56:47.432430499Z       ) as "holdings.tags", "holdings.hrd".jsonb->>'notes' as "holdings.notes", "holdings.hrd".jsonb::text as "holdings.jsonb", "instance.inst".id as "instance.id", "instance.inst".created_by as "instance.created_by", "instance.inst".creation_date as "instance.created_at", "instance.inst".jsonb->'metadata'->>'updatedByUserId' as "instance.updated_by", "instance.inst".jsonb->'metadata'->>'updatedDate' as "instance.updated_at", "instance.inst".instancetypeid as "instance.instance_type_id", "instance.instance_type".jsonb->>'name' as "instance.instance_type_name", "instance.inst".modeofissuanceid as "instance.mode_of_issuance_id", "instance.mode_of_issuance".jsonb->>'name' as "instance.mode_of_issuance_name", ("instance.inst".jsonb->>'_version')::integer as "instance.version", "instance.inst".jsonb->>'hrid' as "instance.hrid", "instance.inst".jsonb->>'source' as "instance.source", "instance.inst".jsonb->>'title' as "instance.title", "instance.inst".jsonb->>'indexTitle' as "instance.index_title", ( SELECT array_agg(elems.value->>'alternativeTitleTypeId') FROM jsonb_array_elements("instance.inst".jsonb->'alternativeTitles') AS elems) as "instance.alternative_titles_ids", ( SELECT array_agg(elems.value->>'alternativeTitle') FROM jsonb_array_elements("instance.inst".jsonb->'alternativeTitles') AS elems) as "instance.alternative_titles", (
2025-01-03T17:56:47.432442750Z         SELECT
2025-01-03T17:56:47.432448910Z           array_agg(elems.value::text)
2025-01-03T17:56:47.432454760Z         FROM
2025-01-03T17:56:47.432474260Z           jsonb_array_elements_text("instance.inst".jsonb->'editions') AS elems
      ) as "instance.editions", (
2025-01-03T17:56:47.432486981Z         SELECT
2025-01-03T17:56:47.432492611Z           array_agg(elems.value->>'value')
2025-01-03T17:56:47.432498030Z         FROM
2025-01-03T17:56:47.432504631Z           jsonb_array_elements("instance.inst".jsonb->'series') AS elems
2025-01-03T17:56:47.432510871Z       ) as "instance.series", "instance.inst".jsonb->>'identifiers' as "instance.identifiers", (SELECT jsonb_agg(record.value || 
                                  jsonb_build_object('contributorType', contributor_type.jsonb ->> 'name', 
2025-01-03T17:56:47.432526761Z                                                      'contributorNameType', contributor_name_type.jsonb ->> 'name') 
2025-01-03T17:56:47.432533452Z                    ORDER BY record.value ->> 'contributorTypeId', record.value ->> 'contributorNameTypeId') 
                 FROM jsonb_array_elements(("instance.inst".jsonb -> 'contributors')) record(value) 
2025-01-03T17:56:47.432545051Z                    LEFT JOIN src_inventory_contributor_type contributor_type 
2025-01-03T17:56:47.432550951Z                      ON (record.value ->> 'contributorTypeId') = contributor_type.id::text 
2025-01-03T17:56:47.432556902Z                    LEFT JOIN src_inventory_contributor_name_type contributor_name_type 
                     ON (record.value ->> 'contributorNameTypeId') = contributor_name_type.id::text)::text as "instance.contributors", jsonb_path_query_first("instance.inst".jsonb, '$."contributors"[*]?(@."primary" == true)."name"'::jsonpath) #>> '{}'::text[] as "instance.instance_primary_contributor", (
        SELECT
2025-01-03T17:56:47.432575413Z           array_agg(elems.value->>'value')
2025-01-03T17:56:47.432581302Z         FROM
2025-01-03T17:56:47.432587232Z           jsonb_array_elements("instance.inst".jsonb->'subjects') AS elems
2025-01-03T17:56:47.432593282Z       ) as "instance.subjects", (SELECT jsonb_agg(record.value || 
2025-01-03T17:56:47.432598942Z                                       jsonb_build_object('classificationType', class_type.jsonb ->> 'name') 
2025-01-03T17:56:47.432604713Z                        ORDER BY record.value ->> 'classificationTypeId') 
                     FROM jsonb_array_elements(("instance.inst".jsonb -> 'classifications')) record(value) 
2025-01-03T17:56:47.432616363Z                        LEFT JOIN src_inventory_classification_type class_type 
                         ON (record.value ->> 'classificationTypeId') = class_type.id::text)::text as "instance.classifications", "instance.inst".jsonb->>'publication' as "instance.publication", (
2025-01-03T17:56:47.432634643Z         SELECT
2025-01-03T17:56:47.432640713Z           array_agg(elems.value::text)
2025-01-03T17:56:47.432647624Z         FROM
          jsonb_array_elements("instance.inst".jsonb->'publicationFrequency') AS elems
2025-01-03T17:56:47.432659683Z       ) as "instance.publication_frequency", (
        SELECT
2025-01-03T17:56:47.432671504Z           array_agg(elems.value::text)
2025-01-03T17:56:47.432677234Z         FROM
          jsonb_array_elements_text("instance.inst".jsonb->'publicationRange') AS elems
      ) as "instance.publication_range", "instance.inst".jsonb->'dates'->>'date1' as "instance.instance_date_1", "instance.inst".jsonb->'dates'->>'date2' as "instance.instance_date_2", "instance.inst".jsonb->'date'->>'dateTypeId' as "instance.instance_date_type_id", "instance.inst".jsonb->>'electronicAccess' as "instance.electronic_access", ("instance.inst".jsonb -> 'instanceFormatIds'::text) as "instance.instance_format_ids", ( SELECT array_agg(format.jsonb ->> 'name'::text) FROM jsonb_array_elements_text("null".jsonb -> 'instanceFormatIds'::text) record(value) JOIN src_inventory_instance_format format ON record.value::text = format.id::text) as "instance.format_names", (
        SELECT
2025-01-03T17:56:47.432707044Z           array_agg(elems.value::text)
2025-01-03T17:56:47.432712364Z         FROM
2025-01-03T17:56:47.432718254Z           jsonb_array_elements_text("instance.inst".jsonb->'physicalDescriptions') AS elems
2025-01-03T17:56:47.432724735Z       ) as "instance.physical_descriptions", ("instance.inst".jsonb -> 'languages'::text) as "instance.languages", "instance.inst".jsonb->>'notes' as "instance.notes", (
        SELECT
2025-01-03T17:56:47.432736735Z           array_agg(elems.value::text)
2025-01-03T17:56:47.432741615Z         FROM
2025-01-03T17:56:47.432746485Z           jsonb_array_elements_text("instance.inst".jsonb->'administrativeNotes') AS elems
      ) as "instance.administrative_notes", "instance.inst".jsonb->>'catalogedDate' as "instance.cataloged_date", "instance.inst".jsonb->>'previouslyHeld' as "instance.previously_held", "instance.inst".jsonb->>'staffSuppress' as "instance.staff_suppress", "instance.inst".jsonb->>'discoverySuppress' as "instance.discovery_suppress", ("instance.inst".jsonb -> 'statisticalCodeIds'::text) as "instance.statistical_code_ids", ( SELECT array_agg(statcode.statistical_code) FROM jsonb_array_elements_text("instance.inst".jsonb -> 'statisticalCodeIds'::text) record(value) JOIN drv_inventory_statistical_codes_full statcode ON record.value::text = statcode.id::text) as "instance.statistical_code_names", (
2025-01-03T17:56:47.432758535Z         SELECT
2025-01-03T17:56:47.432764315Z           array_agg(elems.value::text) FILTER (
2025-01-03T17:56:47.432770175Z             WHERE
2025-01-03T17:56:47.432776205Z               (elems.value::text) IS NOT NULL
2025-01-03T17:56:47.432782166Z           ) AS ARRAY_AGG
2025-01-03T17:56:47.432787896Z         FROM
2025-01-03T17:56:47.432793796Z           jsonb_array_elements_text("instance.inst".jsonb->'tags'->'tagList'::text) elems (value)
2025-01-03T17:56:47.432799366Z       ) as "instance.tags", (
2025-01-03T17:56:47.432805206Z         SELECT
2025-01-03T17:56:47.432811146Z           array_agg(elems.value::text)
2025-01-03T17:56:47.432816266Z         FROM
2025-01-03T17:56:47.432823346Z           jsonb_array_elements("instance.inst".jsonb->'natureOfContentTermIds') AS elems
      ) as "instance.nature_of_content_term_ids", "instance.inst".jsonb::text as "instance.jsonb" from fs09000000_mod_fqm_manager.src_circulation_loan "loans.loan" left join fs09000000_mod_fqm_manager.src_circulation_loan_policy "lpolicy.lp" ON ("loans.loan".jsonb ->> 'loanPolicyId')::uuid = "lpolicy.lp".id left join fs09000000_mod_fqm_manager.src_inventory_service_point "cospi.service_point" ON ("loans.loan".jsonb ->> 'checkoutServicePointId')::uuid = "cospi.service_point".id left join fs09000000_mod_fqm_manager.src_inventory_service_point "cispi.service_point" ON ("loans.loan".jsonb ->> 'checkinServicePointId')::uuid = "cispi.service_point".id left join fs09000000_mod_fqm_manager.src_inventory_item "items.item" ON ("loans.loan".jsonb ->> 'itemId')::uuid = "items.item".id left join fs09000000_mod_fqm_manager.src_inventory_material_type "mtypes.material_type" ON ("items.item".jsonb ->> 'materialTypeId')::uuid = "mtypes.material_type".id left join fs09000000_mod_fqm_manager.src_users_users "users.user" ON ("loans.loan".jsonb ->> 'userId')::uuid = "users.user".id left join fs09000000_mod_fqm_manager.src_users_groups "groups.groups" ON ("users.user".jsonb ->> 'patronGroup')::uuid = "groups.groups".id left join fs09000000_mod_fqm_manager.src_inventory_holdings_record "holdings.hrd" ON ("items.item".jsonb ->> 'holdingsRecordId')::uuid = "holdings.hrd".id left join fs09000000_mod_fqm_manager.src_inventory_instance "instance.inst" ON ("holdings.hrd".jsonb ->> 'instanceId')::uuid = "instance.inst".id left join fs09000000_mod_fqm_manager.src_inventory_mode_of_issuance "instance.mode_of_issuance" ON "instance.mode_of_issuance".id = "instance.inst".modeOfIssuanceId left join fs09000000_mod_fqm_manager.src_inventory_instance_type "instance.instance_type" ON "instance.instance_type".id = "instance.inst".instanceTypeId where "loans.loan".id in (cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), c
ast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid), cast(? as uuid))];
```