### PR TITLE
[MODFQMMGR-618] Organizations migration id/name/code fixes

### DIFF
--- a/src/main/java/org/folio/fqm/client/OrganizationsClient.java
+++ b/src/main/java/org/folio/fqm/client/OrganizationsClient.java
@@ -13,5 +13,5 @@ public interface OrganizationsClient {
 
   public record OrganizationsResponse(List<Organization> organizations) {}
 
-  public record Organization(String id, String code) {}
+  public record Organization(String id, String code, String name) {}
 }

--- a/src/main/java/org/folio/fqm/migration/MigrationStrategyRepository.java
+++ b/src/main/java/org/folio/fqm/migration/MigrationStrategyRepository.java
@@ -9,7 +9,7 @@ import org.folio.fqm.client.OrganizationsClient;
 import org.folio.fqm.client.PatronGroupsClient;
 import org.folio.fqm.migration.strategies.V0POCMigration;
 import org.folio.fqm.migration.strategies.V10OrganizationStatusValueChange;
-import org.folio.fqm.migration.strategies.V11OrganizationCodeOperatorChange;
+import org.folio.fqm.migration.strategies.V11OrganizationNameCodeOperatorChange;
 import org.folio.fqm.migration.strategies.V12PurchaseOrderIdFieldRemoval;
 import org.folio.fqm.migration.strategies.V1ModeOfIssuanceConsolidation;
 import org.folio.fqm.migration.strategies.V2ResourceTypeConsolidation;
@@ -48,7 +48,7 @@ public class MigrationStrategyRepository {
         new V8LocationValueChange(locationsClient),
         new V9LocLibraryValueChange(locationUnitsClient),
         new V10OrganizationStatusValueChange(),
-        new V11OrganizationCodeOperatorChange(organizationsClient),
+        new V11OrganizationNameCodeOperatorChange(organizationsClient),
         new V12PurchaseOrderIdFieldRemoval()
         // adding a strategy? be sure to update the `CURRENT_VERSION` in MigrationConfiguration!
       );

--- a/src/main/java/org/folio/fqm/migration/strategies/V11OrganizationNameCodeOperatorChange.java
+++ b/src/main/java/org/folio/fqm/migration/strategies/V11OrganizationNameCodeOperatorChange.java
@@ -92,8 +92,11 @@ public class V11OrganizationNameCodeOperatorChange implements MigrationStrategy 
                       .get()
                       .stream()
                       .filter(org ->
-                        ("code".equals(key) && org.code().equalsIgnoreCase(entry.getValue().textValue())) ||
-                        ("name".equals(key) && org.name().equalsIgnoreCase(entry.getValue().textValue()))
+                        // our earlier condition ensures that the key is either "code" or "name",
+                        // so no need to check both here.
+                        "code".equals(key)
+                          ? org.code().equalsIgnoreCase(entry.getValue().textValue())
+                          : org.name().equalsIgnoreCase(entry.getValue().textValue())
                       )
                       .findAny()
                       .ifPresentOrElse(

--- a/src/main/java/org/folio/fqm/migration/strategies/V11OrganizationNameCodeOperatorChange.java
+++ b/src/main/java/org/folio/fqm/migration/strategies/V11OrganizationNameCodeOperatorChange.java
@@ -20,12 +20,12 @@ import org.folio.fqm.migration.warnings.ValueBreakingWarning;
 import org.folio.fqm.migration.warnings.Warning;
 
 /**
- * Version 11 -> 12, handles a change in operators for the organization code field.
+ * Version 11 -> 12, handles a change in operators for the organization code and name fields.
  *
- * Previously, organization codes were considered a plain text field, with $eq/$ne and $regex
+ * Previously, organization codes/names were considered a plain text field, with $eq/$ne and $regex
  * (backing "contains" and "starts with" functionality). In Ramsons, this was changed to have a
- * value source of the codes themselves, using a dropdown in the UI. The values used in the query
- * are now the UUIDs, too, rather than just the plain text.
+ * value source of the codes/names themselves, using a dropdown in the UI. The values used in the
+ * query are now the UUIDs, too, rather than just the plain text.
  *
  * Therefore, we need to (for $eq/$ne) update queries to use the corresponding UUIDs, and will
  * be removing $regex queries (the alternative was to pull all that matched these, but a query
@@ -35,20 +35,20 @@ import org.folio.fqm.migration.warnings.Warning;
  */
 @Log4j2
 @RequiredArgsConstructor
-public class V11OrganizationCodeOperatorChange implements MigrationStrategy {
+public class V11OrganizationNameCodeOperatorChange implements MigrationStrategy {
 
   public static final String SOURCE_VERSION = "11";
   public static final String TARGET_VERSION = "12";
 
   private static final UUID ORGANIZATIONS_ENTITY_TYPE_ID = UUID.fromString("b5ffa2e9-8080-471a-8003-a8c5a1274503");
-  private static final String FIELD_NAME = "code";
+  private static final List<String> FIELD_NAMES = List.of("code", "name");
 
   private final ObjectMapper objectMapper = new ObjectMapper();
   private final OrganizationsClient organizationsClient;
 
   @Override
   public String getLabel() {
-    return "V11 -> V12 Organizations code operator/value transformation (MODFQMMGR-606)";
+    return "V11 -> V12 Organizations name/code operator/value transformation (MODFQMMGR-606)";
   }
 
   @Override
@@ -68,7 +68,7 @@ public class V11OrganizationCodeOperatorChange implements MigrationStrategy {
           query.fqlQuery(),
           originalVersion -> TARGET_VERSION,
           (result, key, value) -> {
-            if (!ORGANIZATIONS_ENTITY_TYPE_ID.equals(query.entityTypeId()) || !FIELD_NAME.equals(key)) {
+            if (!ORGANIZATIONS_ENTITY_TYPE_ID.equals(query.entityTypeId()) || !FIELD_NAMES.contains(key)) {
               result.set(key, value); // no-op
               return;
             }
@@ -91,7 +91,10 @@ public class V11OrganizationCodeOperatorChange implements MigrationStrategy {
                     records
                       .get()
                       .stream()
-                      .filter(org -> org.code().equalsIgnoreCase(entry.getValue().textValue()))
+                      .filter(org ->
+                        ("code".equals(key) && org.code().equalsIgnoreCase(entry.getValue().textValue())) ||
+                        ("name".equals(key) && org.name().equalsIgnoreCase(entry.getValue().textValue()))
+                      )
                       .findAny()
                       .ifPresentOrElse(
                         org -> transformed.set(entry.getKey(), TextNode.valueOf(org.id())),
@@ -99,7 +102,7 @@ public class V11OrganizationCodeOperatorChange implements MigrationStrategy {
                           warnings.add(
                             ValueBreakingWarning
                               .builder()
-                              .field(FIELD_NAME)
+                              .field(key)
                               .value(entry.getValue().asText())
                               .fql(
                                 objectMapper.createObjectNode().set(entry.getKey(), entry.getValue()).toPrettyString()
@@ -111,7 +114,7 @@ public class V11OrganizationCodeOperatorChange implements MigrationStrategy {
                   case "$regex" -> warnings.add(
                     OperatorBreakingWarning
                       .builder()
-                      .field(FIELD_NAME)
+                      .field(key)
                       .operator(entry.getKey())
                       .fql(objectMapper.createObjectNode().set(entry.getKey(), entry.getValue()).toPrettyString())
                       .build()
@@ -119,9 +122,10 @@ public class V11OrganizationCodeOperatorChange implements MigrationStrategy {
                   case "$empty" -> transformed.set(entry.getKey(), entry.getValue());
                   default -> {
                     log.warn(
-                      "Unknown operator {}: {} found for organizations' code field, not migrating...",
+                      "Unknown operator {}: {} found for organizations' {} field, not migrating...",
                       entry.getKey(),
-                      entry.getValue()
+                      entry.getValue(),
+                      key
                     );
                     transformed.set(entry.getKey(), entry.getValue());
                   }

--- a/src/main/resources/entity-types/organizations/simple_organizations.json5
+++ b/src/main/resources/entity-types/organizations/simple_organizations.json5
@@ -23,8 +23,22 @@
       dataType: {
         dataType: 'rangedUUIDType',
       },
-      isIdColumn: true,
+      isIdColumn: false,
       queryable: true,
+      visibleByDefault: false,
+      essential: true,
+      valueGetter: ':sourceAlias.id',
+    },
+    // used as id columns for name/code
+    {
+      name: '_id',
+      sourceAlias: 'org',
+      dataType: {
+        dataType: 'rangedUUIDType',
+      },
+      isIdColumn: true,
+      queryable: false,
+      hidden: true,
       visibleByDefault: false,
       essential: true,
       valueGetter: ':sourceAlias.id',
@@ -89,7 +103,7 @@
       valueGetter: ":sourceAlias.jsonb->>'name'",
       filterValueGetter: "lower(${tenant_id}_mod_organizations_storage.f_unaccent(:sourceAlias.jsonb ->> 'name'::text))",
       valueFunction: 'lower(${tenant_id}_mod_organizations_storage.f_unaccent(:value))',
-      idColumnName: 'id',
+      idColumnName: '_id',
       source: {
         entityTypeId: 'b5ffa2e9-8080-471a-8003-a8c5a1274503',
         columnName: 'name',
@@ -113,7 +127,7 @@
       valueGetter: ":sourceAlias.jsonb->>'code'",
       filterValueGetter: "lower(${tenant_id}_mod_organizations_storage.f_unaccent(:sourceAlias.jsonb ->> 'code'::text))",
       valueFunction: 'lower(${tenant_id}_mod_organizations_storage.f_unaccent(:value))',
-      idColumnName: 'id',
+      idColumnName: '_id',
       source: {
         entityTypeId: 'b5ffa2e9-8080-471a-8003-a8c5a1274503',
         columnName: 'code',

--- a/src/test/java/org/folio/fqm/migration/strategies/V11OrganizationCodeOperatorChangeTest.java
+++ b/src/test/java/org/folio/fqm/migration/strategies/V11OrganizationCodeOperatorChangeTest.java
@@ -28,13 +28,15 @@ class V11OrganizationCodeOperatorChangeTest extends TestTemplate {
     lenient()
       .when(organizationsClient.getOrganizations())
       .thenReturn(
-        new OrganizationsResponse(List.of(new Organization("id1", "code1"), new Organization("id2", "code2")))
+        new OrganizationsResponse(
+          List.of(new Organization("id1", "code1", "name1"), new Organization("id2", "code2", "name2"))
+        )
       );
   }
 
   @Override
   public MigrationStrategy getStrategy() {
-    return new V11OrganizationCodeOperatorChange(organizationsClient);
+    return new V11OrganizationNameCodeOperatorChange(organizationsClient);
   }
 
   @Override
@@ -61,16 +63,18 @@ class V11OrganizationCodeOperatorChangeTest extends TestTemplate {
           .builder()
           .entityTypeId(UUID.fromString("b5ffa2e9-8080-471a-8003-a8c5a1274503"))
           .fqlQuery("""
-            { "code": { "$eq": "code1" } }
+            { "code": { "$eq": "code1" }, "name": { "$eq": "name1" } }
             """)
           .fields(List.of())
           .build(),
         MigratableQueryInformation
           .builder()
           .entityTypeId(UUID.fromString("b5ffa2e9-8080-471a-8003-a8c5a1274503"))
-          .fqlQuery("""
-            { "_version": "12", "code": { "$eq": "id1" } }
-            """)
+          .fqlQuery(
+            """
+            { "_version": "12", "code": { "$eq": "id1" }, "name": { "$eq": "id1" } }
+            """
+          )
           .fields(List.of())
           .build()
       ),

--- a/translations/mod-fqm-manager/en.json
+++ b/translations/mod-fqm-manager/en.json
@@ -965,6 +965,7 @@
   "entityType.simple_mode_of_issuance.id": "UUID",
   "entityType.simple_mode_of_issuance.name": "Name",
   "entityType.simple_organization": "Organizations",
+  "entityType.simple_organization._id": "UUID",
   "entityType.simple_organization.access_provider": "Access provider",
   "entityType.simple_organization.accounting_code": "Accounting code",
   "entityType.simple_organization.accounts": "Accounts",


### PR DESCRIPTION
- Restores `id` field for querying (by creating a new `_id` to use for `idColumnName`s, instead)
- Handles migration of `name` field similar to `code`