### PR TITLE
The canned list "Missing items" is shared on the ECS env

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -400,12 +400,6 @@
     {
       "id": "search",
       "version": "1.2"
-    }
-  ],
-  "optional": [
-    {
-      "id": "consortia",
-      "version": "1.0"
     },
     {
       "id": "permissions",
@@ -415,6 +409,12 @@
       "id": "permissions-users",
       "version": "1.0"
     }
+  ],
+  "optional": [
+    {
+      "id": "consortia",
+      "version": "1.0"
+    },
   ],
   "launchDescriptor": {
     "dockerImage": "@artifactId@:@version@",


### PR DESCRIPTION
making permission required instead of optional in MD