### PR TITLE
[MODFQMMGR-642] Use custom field UUIDs for BE custom field names

### DIFF
--- a/src/main/java/org/folio/fqm/config/MigrationConfiguration.java
+++ b/src/main/java/org/folio/fqm/config/MigrationConfiguration.java
@@ -9,7 +9,7 @@ public class MigrationConfiguration {
   public static final String VERSION_KEY = "_version";
   public static final UUID REMOVED_ENTITY_TYPE_ID = UUID.fromString("deadbeef-dead-dead-dead-deaddeadbeef");
 
-  private static final String CURRENT_VERSION = "13";
+  private static final String CURRENT_VERSION = "14";
   // TODO: replace this with current version in the future?
   private static final String DEFAULT_VERSION = "0";
 

--- a/src/main/java/org/folio/fqm/migration/MigrationStrategyRepository.java
+++ b/src/main/java/org/folio/fqm/migration/MigrationStrategyRepository.java
@@ -11,6 +11,7 @@ import org.folio.fqm.migration.strategies.V0POCMigration;
 import org.folio.fqm.migration.strategies.V10OrganizationStatusValueChange;
 import org.folio.fqm.migration.strategies.V11OrganizationNameCodeOperatorChange;
 import org.folio.fqm.migration.strategies.V12PurchaseOrderIdFieldRemoval;
+import org.folio.fqm.migration.strategies.V13CustomFieldRename;
 import org.folio.fqm.migration.strategies.V1ModeOfIssuanceConsolidation;
 import org.folio.fqm.migration.strategies.V2ResourceTypeConsolidation;
 import org.folio.fqm.migration.strategies.V3RamsonsFieldCleanup;
@@ -20,6 +21,8 @@ import org.folio.fqm.migration.strategies.V6ModeOfIssuanceValueChange;
 import org.folio.fqm.migration.strategies.V7PatronGroupsValueChange;
 import org.folio.fqm.migration.strategies.V8LocationValueChange;
 import org.folio.fqm.migration.strategies.V9LocLibraryValueChange;
+import org.folio.spring.FolioExecutionContext;
+import org.jooq.DSLContext;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -33,7 +36,9 @@ public class MigrationStrategyRepository {
     LocationUnitsClient locationUnitsClient,
     ModesOfIssuanceClient modesOfIssuanceClient,
     OrganizationsClient organizationsClient,
-    PatronGroupsClient patronGroupsClient
+    PatronGroupsClient patronGroupsClient,
+    DSLContext jooqContext,
+    FolioExecutionContext executionContext
   ) {
     this.migrationStrategies =
       List.of(
@@ -49,7 +54,8 @@ public class MigrationStrategyRepository {
         new V9LocLibraryValueChange(locationUnitsClient),
         new V10OrganizationStatusValueChange(),
         new V11OrganizationNameCodeOperatorChange(organizationsClient),
-        new V12PurchaseOrderIdFieldRemoval()
+        new V12PurchaseOrderIdFieldRemoval(),
+        new V13CustomFieldRename(executionContext, jooqContext)
         // adding a strategy? be sure to update the `CURRENT_VERSION` in MigrationConfiguration!
       );
   }

--- a/src/main/java/org/folio/fqm/migration/strategies/V13CustomFieldRename.java
+++ b/src/main/java/org/folio/fqm/migration/strategies/V13CustomFieldRename.java
@@ -1,0 +1,126 @@
+package org.folio.fqm.migration.strategies;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.apache.commons.lang3.tuple.Pair;
+import org.folio.fql.service.FqlService;
+import org.folio.fqm.migration.MigratableQueryInformation;
+import org.folio.fqm.migration.MigrationStrategy;
+import org.folio.fqm.migration.MigrationUtils;
+import org.folio.fqm.migration.warnings.Warning;
+import org.folio.spring.FolioExecutionContext;
+import org.jooq.DSLContext;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.folio.fqm.repository.EntityTypeRepository.CUSTOM_FIELD_NAME;
+import static org.folio.fqm.repository.EntityTypeRepository.CUSTOM_FIELD_PREPENDER;
+import static org.folio.fqm.repository.EntityTypeRepository.CUSTOM_FIELD_TYPE;
+import static org.folio.fqm.repository.EntityTypeRepository.SUPPORTED_CUSTOM_FIELD_TYPES;
+import static org.jooq.impl.DSL.field;
+
+/**
+ * Version 13 -> 14, handles custom field renaming.
+ *
+ * The custom field naming scheme was changed in MODFQMMGR-376. This migration handles updating custom field names to match the new scheme.
+ *
+ * @see https://folio-org.atlassian.net/browse/MODFQMMGR-642 for the addition of this migration
+ */
+@Log4j2
+@RequiredArgsConstructor
+public class V13CustomFieldRename implements MigrationStrategy {
+
+  public static final String SOURCE_VERSION = "13";
+  public static final String TARGET_VERSION = "14";
+
+  static final UUID USERS_ENTITY_TYPE_ID = UUID.fromString("ddc93926-d15a-4a45-9d9c-93eadc3d9bbf");
+  static final String CUSTOM_FIELD_SOURCE_VIEW = "src_user_custom_fields"; // Only user entity type currently supports custom fields
+
+  private final FolioExecutionContext executionContext;
+  private final DSLContext jooqContext;
+
+  private final Map<String, List<Pair<String, String>>> tenantCustomFieldNamePairs = new ConcurrentHashMap<>();
+
+  @Override
+  public String getLabel() {
+    return "V13 -> V14 Custom field renaming (MODFQMMGR-642)";
+  }
+
+  @Override
+  public boolean applies(String version) {
+    return SOURCE_VERSION.equals(version);
+  }
+
+  @Override
+  public MigratableQueryInformation apply(FqlService fqlService, MigratableQueryInformation query) {
+    List<Warning> warnings = new ArrayList<>(query.warnings());
+
+    return query
+      .withFqlQuery(
+        MigrationUtils.migrateFql(
+          query.fqlQuery(),
+          originalVersion -> TARGET_VERSION,
+          (result, key, value) -> {
+            if (!USERS_ENTITY_TYPE_ID.equals(query.entityTypeId())) {
+              result.set(key, value); // no-op
+              return;
+            }
+
+            Optional<Pair<String, String>> namePair = getNamePairs(executionContext.getTenantId())
+              .stream()
+              .filter(pair -> pair.getLeft().equals(key))
+              .findFirst();
+            String resultKey = namePair.map(Pair::getRight).orElse(key);
+            result.set(resultKey, value);
+          }
+        )
+      )
+      .withFields(query
+        .fields()
+        .stream()
+        .map(oldName -> getNamePairs(executionContext.getTenantId())
+          .stream()
+          .filter(pair -> pair.getLeft().equals(oldName))
+          .map(Pair::getRight)
+          .findFirst()
+          .orElse(oldName)
+        ).toList()
+      )
+      .withWarnings(warnings);
+  }
+
+  private synchronized List<Pair<String, String>> getNamePairs(String tenantId) {
+    return tenantCustomFieldNamePairs.computeIfAbsent(tenantId, id -> {
+      try {
+        return jooqContext
+          .select(field("id"), field(CUSTOM_FIELD_NAME))
+          .from(CUSTOM_FIELD_SOURCE_VIEW)
+          .where(field(CUSTOM_FIELD_TYPE).in(SUPPORTED_CUSTOM_FIELD_TYPES))
+          .fetch()
+          .stream()
+          .map(row -> {
+            String name = "";
+            try {
+              String idValue = row.get("id", String.class);
+              name = row.get(CUSTOM_FIELD_NAME, String.class);
+              return Pair.of(name, CUSTOM_FIELD_PREPENDER + idValue);
+            } catch (Exception e) {
+              log.error("Error processing custom field {} for tenant ID: {}", name, tenantId, e);
+              return null;
+            }
+          })
+          .filter(Objects::nonNull)
+          .toList();
+      } catch (Exception e) {
+        log.error("Failed to fetch custom fields for tenant ID: {}", tenantId, e);
+        return List.of();
+      }
+    });
+  }
+}

--- a/src/test/java/org/folio/fqm/IntegrationTestBase.java
+++ b/src/test/java/org/folio/fqm/IntegrationTestBase.java
@@ -138,7 +138,7 @@ public class IntegrationTestBase {
   private static void createDummyViews() {
     JdbcTemplate jdbcTemplate = new JdbcTemplate(getDataSource());
     // Create a src_user_custom_fields view, since the Users entity type depends on it for custom fields. Without this, the smoke test will fail.
-    jdbcTemplate.execute("CREATE VIEW src_user_custom_fields AS SELECT '{}'::jsonb AS jsonb LIMIT 1");
+    jdbcTemplate.execute("CREATE VIEW src_user_custom_fields AS SELECT NULL::uuid AS id, '{}'::jsonb AS jsonb LIMIT 1");
   }
 
   private static void smokeTest() {

--- a/src/test/java/org/folio/fqm/migration/MigrationStrategyRepositoryTest.java
+++ b/src/test/java/org/folio/fqm/migration/MigrationStrategyRepositoryTest.java
@@ -32,6 +32,8 @@ class MigrationStrategyRepositoryTest {
     null,
     null,
     null,
+    null,
+    null,
     null
   );
   MigrationService migrationService = new MigrationService(

--- a/src/test/java/org/folio/fqm/migration/strategies/V13CustomFieldRenameTest.java
+++ b/src/test/java/org/folio/fqm/migration/strategies/V13CustomFieldRenameTest.java
@@ -1,0 +1,167 @@
+package org.folio.fqm.migration.strategies;
+
+import org.folio.fqm.migration.MigratableQueryInformation;
+import org.folio.fqm.migration.MigrationStrategy;
+import org.folio.spring.FolioExecutionContext;
+import org.jooq.DSLContext;
+import org.jooq.Field;
+import org.jooq.Record2;
+import org.jooq.Result;
+import org.jooq.SelectConditionStep;
+import org.jooq.SelectJoinStep;
+import org.jooq.SelectSelectStep;
+import org.jooq.impl.DSL;
+import org.jooq.impl.DefaultConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.folio.fqm.migration.strategies.V13CustomFieldRename.CUSTOM_FIELD_SOURCE_VIEW;
+import static org.folio.fqm.repository.EntityTypeRepository.CUSTOM_FIELD_NAME;
+import static org.folio.fqm.repository.EntityTypeRepository.CUSTOM_FIELD_TYPE;
+import static org.folio.fqm.repository.EntityTypeRepository.SUPPORTED_CUSTOM_FIELD_TYPES;
+import static org.jooq.impl.DSL.field;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class V13CustomFieldRenameTest extends TestTemplate {
+
+  private static final String CUSTOM_FIELD_ID_1 = "97ebe38d-4733-4631-b264-5d29f4f50b07";
+  private static final String CUSTOM_FIELD_ID_2 = "48e035c3-d2fe-4575-b387-e7fdc07dde58";
+  private static final String CUSTOM_FIELD_NAME_1 = "a_custom_field";
+  private static final String CUSTOM_FIELD_NAME_2 = "another_custom_field";
+  private static final Field<Object> ID_FIELD = field("id", Object.class);
+  private static final Field<Object> NAME_FIELD = field(CUSTOM_FIELD_NAME, Object.class);
+
+  @Mock
+  DSLContext jooqContext;
+
+  @Mock
+  FolioExecutionContext executionContext;
+
+  @BeforeEach
+  public void setup() {
+    DSLContext creator = DSL.using(new DefaultConfiguration()); // for creating results
+
+    Result<Record2<Object, Object>> result = creator.newResult(
+      ID_FIELD,
+      NAME_FIELD
+    );
+    result.add(creator
+      .newRecord(ID_FIELD, NAME_FIELD)
+      .values(CUSTOM_FIELD_ID_1, CUSTOM_FIELD_NAME_1)
+    );
+    result.add(creator
+      .newRecord(ID_FIELD, NAME_FIELD)
+      .values(CUSTOM_FIELD_ID_2, CUSTOM_FIELD_NAME_2)
+    );
+
+    lenient().when(executionContext.getTenantId()).thenReturn("tenant_01");
+    SelectSelectStep<Record2<Object, Object>> mockSelect = mock(SelectSelectStep.class);
+    lenient().when(jooqContext.select(ID_FIELD, field(CUSTOM_FIELD_NAME))).thenReturn(mockSelect);
+
+    SelectJoinStep<Record2<Object, Object>> selectJoinStep = mock(SelectJoinStep.class);
+    lenient().when(mockSelect.from(CUSTOM_FIELD_SOURCE_VIEW)).thenReturn(selectJoinStep);
+
+    SelectConditionStep<Record2<Object, Object>> selectConditionStep = mock(SelectConditionStep.class);
+    lenient().when(selectJoinStep.where(field(CUSTOM_FIELD_TYPE).in(SUPPORTED_CUSTOM_FIELD_TYPES))).thenReturn(selectConditionStep);
+
+    lenient().when(selectConditionStep.fetch()).thenReturn(result);
+  }
+
+  @Override
+  public MigrationStrategy getStrategy() {
+    return new V13CustomFieldRename(executionContext, jooqContext);
+  }
+
+  @Override
+  public List<Arguments> getExpectedTransformations() {
+    return List.of(
+      Arguments.of(
+        "Query with non-matching entity type",
+        MigratableQueryInformation
+          .builder()
+          .entityTypeId(UUID.fromString("a9112682-958f-576c-b46c-d851abc62cd1"))
+          .fqlQuery("{\"code\": {\"$ne\": \"active\"}}")
+          .fields(List.of())
+          .build(),
+        MigratableQueryInformation
+          .builder()
+          .entityTypeId(UUID.fromString("a9112682-958f-576c-b46c-d851abc62cd1"))
+          .fqlQuery("{\"code\": {\"$ne\": \"active\"}, \"_version\":\"14\"}")
+          .fields(List.of())
+          .build()
+      ),
+
+      Arguments.of(
+        "$eq query with custom field",
+        MigratableQueryInformation
+          .builder()
+          .entityTypeId(UUID.fromString("ddc93926-d15a-4a45-9d9c-93eadc3d9bbf"))
+          .fqlQuery("{\"a_custom_field\": {\"$ne\": \"active\"}}")
+          .fields(List.of())
+          .build(),
+        MigratableQueryInformation
+          .builder()
+          .entityTypeId(UUID.fromString("ddc93926-d15a-4a45-9d9c-93eadc3d9bbf"))
+          .fqlQuery("{\"_custom_field_97ebe38d-4733-4631-b264-5d29f4f50b07\": {\"$ne\": \"active\"}, \"_version\":\"14\"}")
+          .fields(List.of())
+          .build()
+      ),
+
+      Arguments.of(
+        "$in query with custom field",
+        MigratableQueryInformation
+          .builder()
+          .entityTypeId(UUID.fromString("ddc93926-d15a-4a45-9d9c-93eadc3d9bbf"))
+          .fqlQuery("{\"a_custom_field\": {\"$in\": [\"active\", \"inactive\"]}}")
+          .fields(List.of())
+          .build(),
+        MigratableQueryInformation
+          .builder()
+          .entityTypeId(UUID.fromString("ddc93926-d15a-4a45-9d9c-93eadc3d9bbf"))
+          .fqlQuery("{\"_custom_field_97ebe38d-4733-4631-b264-5d29f4f50b07\": {\"$in\": [\"active\", \"inactive\"]}, \"_version\":\"14\"}")
+          .fields(List.of())
+          .build()
+      ),
+
+      Arguments.of(
+        "$and query with custom field",
+        MigratableQueryInformation
+          .builder()
+          .entityTypeId(UUID.fromString("ddc93926-d15a-4a45-9d9c-93eadc3d9bbf"))
+          .fqlQuery("{\"$and\": [{\"a_custom_field\": {\"$ne\": \"val1\"}}, {\"not_a_custom_field\": {\"$ne\": \"val2\"}}, {\"another_custom_field\": {\"$eq\": \"val3\"}}]}")
+          .fields(List.of())
+          .build(),
+        MigratableQueryInformation
+          .builder()
+          .entityTypeId(UUID.fromString("ddc93926-d15a-4a45-9d9c-93eadc3d9bbf"))
+          .fqlQuery("{\"$and\": [{\"_custom_field_97ebe38d-4733-4631-b264-5d29f4f50b07\": {\"$ne\": \"val1\"}}, {\"not_a_custom_field\": {\"$ne\": \"val2\"}}, {\"_custom_field_48e035c3-d2fe-4575-b387-e7fdc07dde58\": {\"$eq\": \"val3\"}}], \"_version\":\"14\"}")
+          .fields(List.of())
+          .build()
+      ),
+
+      Arguments.of(
+        "query with custom fields in field array",
+        MigratableQueryInformation
+          .builder()
+          .entityTypeId(UUID.fromString("ddc93926-d15a-4a45-9d9c-93eadc3d9bbf"))
+          .fqlQuery("{\"not_a_custom_field\": {\"$in\": [\"active\", \"inactive\"]}}")
+          .fields(List.of("not_a_custom_field", "a_custom_field", "another_custom_field"))
+          .build(),
+        MigratableQueryInformation
+          .builder()
+          .entityTypeId(UUID.fromString("ddc93926-d15a-4a45-9d9c-93eadc3d9bbf"))
+          .fqlQuery("{\"not_a_custom_field\": {\"$in\": [\"active\", \"inactive\"]}, \"_version\":\"14\"}")
+          .fields(List.of("not_a_custom_field", "_custom_field_97ebe38d-4733-4631-b264-5d29f4f50b07", "_custom_field_48e035c3-d2fe-4575-b387-e7fdc07dde58"))
+          .build()
+      )
+    );
+  }
+}

--- a/src/test/java/org/folio/fqm/repository/EntityTypeRepositoryTest.java
+++ b/src/test/java/org/folio/fqm/repository/EntityTypeRepositoryTest.java
@@ -19,6 +19,7 @@ import org.springframework.test.context.ActiveProfiles;
 import java.util.*;
 
 import static org.folio.fqm.repository.EntityTypeRepository.CUSTOM_FIELD_BOOLEAN_VALUES;
+import static org.folio.fqm.repository.EntityTypeRepository.CUSTOM_FIELD_PREPENDER;
 import static org.folio.fqm.repository.EntityTypeRepository.CUSTOM_FIELD_VALUE_GETTER;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -78,7 +79,7 @@ class EntityTypeRepositoryTest {
         .labelAlias("Column 2")
         .visibleByDefault(true),
       new EntityTypeColumn()
-        .name("custom_column_1")
+        .name(CUSTOM_FIELD_PREPENDER + "2c4e9797-422f-4962-a302-174af09b23f8")
         .dataType(new BooleanType().dataType("booleanType"))
         .valueGetter(String.format(genericValueGetter, refId1))
         .labelAlias("custom_column_1")
@@ -87,7 +88,7 @@ class EntityTypeRepositoryTest {
         .queryable(true)
         .isCustomField(true),
       new EntityTypeColumn()
-        .name("custom_column_2")
+        .name(CUSTOM_FIELD_PREPENDER + "2c4e9797-422f-4962-a302-174af09b23f9")
         .dataType(new StringType().dataType("stringType"))
         .valueGetter(valueGetter2)
         .filterValueGetter(String.format(genericValueGetter, refId2))
@@ -97,7 +98,7 @@ class EntityTypeRepositoryTest {
         .queryable(true)
         .isCustomField(true),
       new EntityTypeColumn()
-        .name("custom_column_3")
+        .name(CUSTOM_FIELD_PREPENDER + "2c4e9797-422f-4962-a302-174af09b23fa")
         .dataType(new StringType().dataType("stringType"))
         .valueGetter(valueGetter3)
         .filterValueGetter(String.format(genericValueGetter, refId3))
@@ -107,7 +108,7 @@ class EntityTypeRepositoryTest {
         .queryable(true)
         .isCustomField(true),
       new EntityTypeColumn()
-        .name("custom_column_4")
+        .name(CUSTOM_FIELD_PREPENDER + "2c4e9797-422f-4962-a302-174af09b23fb")
         .dataType(new StringType().dataType("stringType"))
         .valueGetter(String.format(genericValueGetter, refId4))
         .labelAlias("custom_column_4")
@@ -115,7 +116,7 @@ class EntityTypeRepositoryTest {
         .queryable(true)
         .isCustomField(true),
       new EntityTypeColumn()
-        .name("custom_column_5")
+        .name(CUSTOM_FIELD_PREPENDER + "2c4e9797-422f-4962-a302-174af09b23fc")
         .dataType(new StringType().dataType("stringType"))
         .valueGetter(String.format(genericValueGetter, refId5))
         .labelAlias("custom_column_5")


### PR DESCRIPTION
## Purpose
[MODFQMMGR-642](https://folio-org.atlassian.net/browse/MODFQMMGR-642): Use custom field UUIDs for BE custom field names. This will make it possible to track changes to custom field names 

+  Add migration script for updated custom field names