### PR TITLE
MODFQMMGR-649 Mark ET fields as queryable and visibleByDefault

### DIFF
--- a/src/main/resources/entity-types/invoice/composite_voucher_line_totals_per_account.json5
+++ b/src/main/resources/entity-types/invoice/composite_voucher_line_totals_per_account.json5
@@ -71,6 +71,8 @@
       },
       isIdColumn: 'true',
       valueGetter: ':sourceAlias.id',
+      queryable: true,
+      visibleByDefault: true,
     },
     {
       name: 'ledger_name',
@@ -79,6 +81,8 @@
         dataType: 'stringType',
       },
       valueGetter: ":sourceAlias.jsonb->>'name'",
+      queryable: true,
+      visibleByDefault: true,
     },
     {
       name: 'external_account_number',
@@ -88,6 +92,8 @@
       },
       isIdColumn: true,
       valueGetter: ":sourceAlias.jsonb->>'externalAccountNo'",
+      queryable: true,
+      visibleByDefault: true,
     },
     {
       name: 'total_amount_spent_per_account_number',
@@ -96,7 +102,9 @@
         dataType: 'numberType',
       },
       valueGetter: "SUM((:sourceAlias.jsonb->'amount')::float)",
-      valueFunction: "(:value)::float"
+      valueFunction: "(:value)::float",
+      queryable: true,
+      visibleByDefault: true,
     },
     {
       name: 'voucher_date',
@@ -105,7 +113,9 @@
         dataType: 'dateType',
       },
       valueGetter: ":sourceAlias.jsonb->>'voucherDate'",
-      queryOnly: true
+      queryOnly: true,
+      queryable: true,
+      visibleByDefault: true,
     },
   ],
   groupByFields: [


### PR DESCRIPTION
This commit updates the composite_voucher_line_totals_per_account entity type's fields, to make the ET actually usable
