### PR TITLE
MODFQMMGR-543 Refactor column sorting within ET sources

### DIFF
--- a/src/main/java/org/folio/fqm/service/LocalizationService.java
+++ b/src/main/java/org/folio/fqm/service/LocalizationService.java
@@ -32,7 +32,7 @@ public class LocalizationService {
   // refers to a possessive version of the entity type, for custom fields, e.g. "User's {customField}"
   private static final String ENTITY_TYPE_CUSTOM_FIELD_POSSESSIVE_TRANSLATION_TEMPLATE =
     "mod-fqm-manager.entityType.%s._custom_field_possessive";
-  
+
   // provides locale-specific way of joining `Source name — Field name`, to account for different separators or RTL
   // see MODFQMMGR-409 for more details
   private static final String ENTITY_TYPE_SOURCE_PREFIX_JOINER = "mod-fqm-manager.entityType._sourceLabelJoiner";
@@ -52,30 +52,34 @@ public class LocalizationService {
   public EntityType localizeEntityType(EntityType entityType) {
     entityType.setLabelAlias(getEntityTypeLabel(entityType.getName()));
 
-    entityType.getColumns().forEach(column -> localizeEntityTypeColumn(entityType, column));
+    var localizedColumns = entityType.getColumns().stream()
+      .map(column -> localizeEntityTypeColumn(entityType, column))
+      .toList();
 
-    return entityType;
+    return entityType.columns(localizedColumns);
   }
 
-  void localizeEntityTypeColumn(EntityType entityType, EntityTypeColumn column) {
-    if (column.getLabelAlias() == null) {
+  public EntityTypeColumn localizeEntityTypeColumn(EntityType entityType, EntityTypeColumn column) {
+    var newColumn = column.toBuilder().build();
+    if (newColumn.getLabelAlias() == null) {
       // Custom field names are already localized as they are user-defined, so they require special handling
-      if (Boolean.TRUE.equals(column.getIsCustomField())) {
-        column.setLabelAlias(getEntityTypeCustomFieldLabel(entityType.getName(), column.getName()));
-        return;
+      if (Boolean.TRUE.equals(newColumn.getIsCustomField())) {
+        newColumn.setLabelAlias(getEntityTypeCustomFieldLabel(entityType.getName(), newColumn.getName()));
+        return newColumn;
       }
 
-      column.setLabelAlias(getEntityTypeColumnLabel(entityType.getName(), column.getName()));
-      if (column.getDataType() instanceof ObjectType objectColumn) {
-        localizeObjectColumn(entityType, column, objectColumn);
-      } else if (column.getDataType() instanceof ArrayType arrayColumn) {
-        localizeArrayColumn(entityType, column, arrayColumn);
+      newColumn.setLabelAlias(getEntityTypeColumnLabel(entityType.getName(), newColumn.getName()));
+      if (newColumn.getDataType() instanceof ObjectType objectColumn) {
+        localizeObjectColumn(entityType, newColumn, objectColumn);
+      } else if (newColumn.getDataType() instanceof ArrayType arrayColumn) {
+        localizeArrayColumn(entityType, newColumn, arrayColumn);
       }
     } else {
       // column has been previously translated, so just append source translations to it
-      String sourceTranslation = getTranslationWithSourcePrefix(entityType, column.getName(), column.getLabelAlias());
-      column.setLabelAlias(sourceTranslation);
+      String sourceTranslation = getTranslationWithSourcePrefix(entityType, newColumn.getName(), newColumn.getLabelAlias());
+      newColumn.setLabelAlias(sourceTranslation);
     }
+    return newColumn;
   }
 
   private String getTranslationWithSourcePrefix(EntityType entityType, String columnName, String fieldLabel) {

--- a/src/main/java/org/folio/fqm/utils/flattening/SourceUtils.java
+++ b/src/main/java/org/folio/fqm/utils/flattening/SourceUtils.java
@@ -8,7 +8,6 @@ import lombok.experimental.UtilityClass;
 import lombok.extern.log4j.Log4j2;
 import org.folio.fqm.utils.EntityTypeUtils;
 import org.folio.querytool.domain.dto.ArrayType;
-import org.folio.querytool.domain.dto.EntityType;
 import org.folio.querytool.domain.dto.EntityTypeColumn;
 import org.folio.querytool.domain.dto.EntityTypeSource;
 import org.folio.querytool.domain.dto.EntityTypeSourceDatabase;
@@ -147,12 +146,10 @@ public class SourceUtils {
 
   public static Stream<EntityTypeColumn> copyColumns(
     EntityTypeSourceEntityType sourceFromParent,
-    EntityType originalEntityType,
+    Stream<EntityTypeColumn> columns,
     Map<String, String> renamedAliases
   ) {
-    return originalEntityType
-      .getColumns()
-      .stream()
+    return columns
       .map(column -> {
         EntityTypeColumn newColumn = copyColumn(column);
         // Only treat newColumn as idColumn if outer source specifies to do so

--- a/src/test/java/org/folio/fqm/service/EntityTypeFlatteningServiceTest.java
+++ b/src/test/java/org/folio/fqm/service/EntityTypeFlatteningServiceTest.java
@@ -392,6 +392,9 @@ class EntityTypeFlatteningServiceTest {
     lenient()
       .when(localizationService.localizeEntityType(any(EntityType.class)))
       .thenAnswer(invocation -> invocation.getArgument(0));
+    lenient()
+      .when(localizationService.localizeEntityTypeColumn(any(EntityType.class), any(EntityTypeColumn.class)))
+      .then(invocation -> invocation.getArgument(1));
     lenient().when(executionContext.getTenantId()).thenReturn("tenant_01");
   }
 

--- a/src/test/java/org/folio/fqm/service/LocalizationServiceTest.java
+++ b/src/test/java/org/folio/fqm/service/LocalizationServiceTest.java
@@ -124,9 +124,9 @@ class LocalizationServiceTest {
     when(translationService.format(expectedTranslationKey, "customField", "Custom Field"))
       .thenReturn("Test's Custom Field");
 
-    localizationService.localizeEntityTypeColumn(entityType, entityType.getColumns().get(0));
+    var localizedColumn = localizationService.localizeEntityTypeColumn(entityType, entityType.getColumns().get(0));
 
-    assertEquals(expectedTranslation, entityType.getColumns().get(0).getLabelAlias());
+    assertEquals(expectedTranslation, localizedColumn.getLabelAlias());
 
     verify(translationService, times(1)).format(expectedTranslationKey, "customField", "Custom Field");
     verifyNoMoreInteractions(translationService);
@@ -156,9 +156,9 @@ class LocalizationServiceTest {
     when(translationService.format(expectedInnerTranslationKey)).thenReturn(expectedInnerTranslation);
     when(translationService.format(expectedInnerQualifiedTranslationKey)).thenReturn(expectedInnerQualifiedTranslation);
 
-    localizationService.localizeEntityTypeColumn(entityType, entityType.getColumns().get(0));
+    var localizedColumn = localizationService.localizeEntityTypeColumn(entityType, entityType.getColumns().get(0));
 
-    assertEquals(expectedOuterTranslation, entityType.getColumns().get(0).getLabelAlias());
+    assertEquals(expectedOuterTranslation, localizedColumn.getLabelAlias());
     assertEquals(
       expectedInnerTranslation,
       ((ObjectType) entityType.getColumns().get(0).getDataType()).getProperties().get(0).getLabelAlias()
@@ -211,9 +211,9 @@ class LocalizationServiceTest {
     when(translationService.format(expectedInnerQualifiedTranslationKey)).thenReturn(expectedInnerQualifiedTranslation);
     when(translationService.format(expectedInnermostQualifiedTranslationKey)).thenReturn(expectedInnermostQualifiedTranslation);
 
-    localizationService.localizeEntityTypeColumn(entityType, entityType.getColumns().get(0));
+    var localizedColumn = localizationService.localizeEntityTypeColumn(entityType, entityType.getColumns().get(0));
 
-    assertEquals(expectedOuterTranslation, entityType.getColumns().get(0).getLabelAlias());
+    assertEquals(expectedOuterTranslation, localizedColumn.getLabelAlias());
     assertEquals(expectedInnerTranslation, inner.getLabelAlias());
     assertEquals(expectedInnermostTranslation, innermost.getLabelAlias());
     assertEquals(expectedInnerQualifiedTranslation, inner.getLabelAliasFullyQualified());

--- a/src/test/java/org/folio/fqm/utils/flattening/SourceUtilsCopyTest.java
+++ b/src/test/java/org/folio/fqm/utils/flattening/SourceUtilsCopyTest.java
@@ -8,6 +8,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
+
 import org.folio.querytool.domain.dto.EntityType;
 import org.folio.querytool.domain.dto.EntityTypeColumn;
 import org.folio.querytool.domain.dto.EntityTypeSource;
@@ -42,7 +44,7 @@ class SourceUtilsCopyTest {
     EntityTypeColumn result = SourceUtils
       .copyColumns(
         parent,
-        new EntityType().addColumnsItem(new EntityTypeColumn().isIdColumn(isIdColumn).valueGetter("")),
+        Stream.of(new EntityTypeColumn().isIdColumn(isIdColumn).valueGetter("")),
         Map.of()
       )
       .findAny()


### PR DESCRIPTION
This change makes it so all columns are sorted in a group within whatever entity type they are defined in. This way, columns within simples are always sorted (vs before, when they were only sorted when imported into a composite), and any columns defined directly in a composite are also sorted as a group that appears before any imported columns