### PR TITLE
Fix contributor_name_type ET

### DIFF
--- a/src/main/resources/entity-types/inventory/simple_contributor_name_type.json5
+++ b/src/main/resources/entity-types/inventory/simple_contributor_name_type.json5
@@ -37,7 +37,7 @@
     },
     {
       name: 'ordering',
-      sourceAlias: 'contributor_type',
+      sourceAlias: 'contributor_name_type',
       dataType: {
         dataType: 'stringType',
       },


### PR DESCRIPTION
## Purpose
Fix a bug I noticed in simple_contributor_name_type when testing the /entity-types?includeAll param for edge-fqm