### PR TITLE
FOLIO-4237 Upgrade to Java 21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM folioci/alpine-jre-openjdk17:latest
+FROM folioci/alpine-jre-openjdk21:latest
 
 # Install latest patch versions of packages
 USER root

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ buildMvn {
   publishModDescriptor = true
   mvnDeploy = true
   doKubeDeploy = true
-  buildNode = 'jenkins-agent-java17'
+  buildNode = 'jenkins-agent-java21'
 
   doDocker = {
     buildJavaDocker {

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.2.3</version>
+    <version>3.4.3</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
   <groupId>org.folio</groupId>
@@ -23,7 +23,7 @@
 
   <properties>
     <!-- runtime dependencies -->
-    <folio-spring-base.version>8.2.1</folio-spring-base.version>
+    <folio-spring-base.version>9.0.0-SNAPSHOT</folio-spring-base.version>
     <folio-query-tool-metadata.version>3.1.0-SNAPSHOT</folio-query-tool-metadata.version>
     <mapstruct.version>1.5.2.Final</mapstruct.version>
     <lib-fqm-query-processor.version>3.1.0-SNAPSHOT</lib-fqm-query-processor.version>
@@ -45,7 +45,7 @@
     <lombok.version>1.18.30</lombok.version>
 
     <!-- other properties -->
-    <java.version>17</java.version>
+    <java.version>21</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <mod-fqm-manager.yaml.file>${project.basedir}/src/main/resources/swagger.api/mod-fqm-manager.yaml</mod-fqm-manager.yaml.file>

--- a/src/main/java/org/folio/fqm/config/PermissionsConfiguration.java
+++ b/src/main/java/org/folio/fqm/config/PermissionsConfiguration.java
@@ -1,6 +1,5 @@
 package org.folio.fqm.config;
 
-import javax.inject.Provider;
 import lombok.extern.log4j.Log4j2;
 import org.folio.fqm.service.PermissionsBypassService;
 import org.folio.fqm.service.PermissionsRegularService;
@@ -19,7 +18,7 @@ public class PermissionsConfiguration {
   private boolean bypassPermissionChecks;
 
   @Bean
-  @Autowired
+//  @Autowired
   public PermissionsService permissionsService(
     // lazy-loading here to avoid instantiation of the unused one
     ApplicationContext applicationContext

--- a/src/test/java/org/folio/fqm/context/DatasourceConnectionTest.java
+++ b/src/test/java/org/folio/fqm/context/DatasourceConnectionTest.java
@@ -22,10 +22,10 @@ import static java.lang.String.format;
 @SpringBootTest
 class DatasourceConnectionTest {
   @Container
-  public static PostgreSQLContainer<?> readerDbContainer = new PostgreSQLContainer<>("postgres:12-alpine");
+  public static PostgreSQLContainer<?> readerDbContainer = new PostgreSQLContainer<>("postgres:16-alpine");
 
   @Container
-  public static PostgreSQLContainer<?> writerDbContainer = new PostgreSQLContainer<>("postgres:12-alpine");
+  public static PostgreSQLContainer<?> writerDbContainer = new PostgreSQLContainer<>("postgres:16-alpine");
 
   @Autowired
   @Qualifier("readerDataSource")

--- a/src/test/java/org/folio/fqm/context/TestcontainerBeanFactoryPostProcessor.java
+++ b/src/test/java/org/folio/fqm/context/TestcontainerBeanFactoryPostProcessor.java
@@ -14,7 +14,7 @@ public class TestcontainerBeanFactoryPostProcessor implements BeanFactoryPostPro
   private static final int POSTGRES_PORT = 5432;
 
   @Container
-  public static PostgreSQLContainer<?> dbContainer = new PostgreSQLContainer<>("postgres:12-alpine");
+  public static PostgreSQLContainer<?> dbContainer = new PostgreSQLContainer<>("postgres:16-alpine");
 
   @Override
   public void postProcessBeanFactory(ConfigurableListableBeanFactory configurableListableBeanFactory) throws BeansException {

--- a/src/test/java/org/folio/fqm/controller/DataRefreshControllerTest.java
+++ b/src/test/java/org/folio/fqm/controller/DataRefreshControllerTest.java
@@ -8,7 +8,7 @@ import org.folio.spring.integration.XOkapiHeaders;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.RequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -25,9 +25,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class DataRefreshControllerTest {
   @Autowired
   private MockMvc mockMvc;
-  @MockBean
+  @MockitoBean
   private FolioExecutionContext executionContext;
-  @MockBean
+  @MockitoBean
   private DataRefreshService dataRefreshService;
 
   @Test

--- a/src/test/java/org/folio/fqm/controller/EntityTypeControllerTest.java
+++ b/src/test/java/org/folio/fqm/controller/EntityTypeControllerTest.java
@@ -25,8 +25,8 @@ import org.folio.spring.integration.XOkapiHeaders;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.RequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -39,13 +39,13 @@ class EntityTypeControllerTest {
   @Autowired
   private MockMvc mockMvc;
 
-  @MockBean
+  @MockitoBean
   private EntityTypeService entityTypeService;
 
-  @MockBean
+  @MockitoBean
   private MigrationService migrationService;
 
-  @MockBean
+  @MockitoBean
   private FolioExecutionContext folioExecutionContext;
 
   @Test

--- a/src/test/java/org/folio/fqm/controller/FqlQueryControllerTest.java
+++ b/src/test/java/org/folio/fqm/controller/FqlQueryControllerTest.java
@@ -17,8 +17,8 @@ import org.folio.spring.integration.XOkapiHeaders;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.RequestBuilder;
 
@@ -43,11 +43,11 @@ class FqlQueryControllerTest {
 
   @Autowired
   private MockMvc mockMvc;
-  @MockBean
+  @MockitoBean
   private QueryManagementService queryManagementService;
-  @MockBean
+  @MockitoBean
   private QueryProcessorService queryProcessorService;
-  @MockBean
+  @MockitoBean
   private FolioExecutionContext executionContext;
 
   @Test

--- a/src/test/java/org/folio/fqm/controller/MigrationControllerTest.java
+++ b/src/test/java/org/folio/fqm/controller/MigrationControllerTest.java
@@ -14,7 +14,7 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.RequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -37,13 +37,13 @@ class MigrationControllerTest {
   @Autowired
   private MockMvc mockMvc;
 
-  @MockBean
+  @MockitoBean
   private MigrationService migrationService;
 
-  @MockBean
+  @MockitoBean
   private FolioExecutionContext executionContext;
 
-  @MockBean
+  @MockitoBean
   private TranslationService translationService;
 
   @Test

--- a/src/test/java/org/folio/fqm/controller/PurgeQueryControllerTest.java
+++ b/src/test/java/org/folio/fqm/controller/PurgeQueryControllerTest.java
@@ -6,7 +6,7 @@ import org.folio.spring.integration.XOkapiHeaders;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.RequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -25,7 +25,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class PurgeQueryControllerTest {
   @Autowired
   private MockMvc mockMvc;
-  @MockBean
+  @MockitoBean
   private QueryManagementService queryManagementService;
 
   @Test

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -20,7 +20,7 @@ folio:
       enabled: false
 management:
   endpoints:
-    enabled-by-default: false
+    access.default: unrestricted
 logging:
   level:
     org.springframework.web: debug


### PR DESCRIPTION
This commit bumps the module from Java 17 to 21. It also updates to dependencies that are compatible with this upgrade and makes a few small test and config changes to account for these dependeny upgrades. Finally, it upgrades a few integration tests to use PostgreSQL 16 instead of 12 (this is unreleated to the Java upgrade, but is still important)
