### PR TITLE
[MODFQMMGR-695] Fix entity type cache bug in ECS environments

### DIFF
--- a/src/main/java/org/folio/fqm/aspect/EntityTypePermissionsAspect.java
+++ b/src/main/java/org/folio/fqm/aspect/EntityTypePermissionsAspect.java
@@ -13,6 +13,7 @@ import org.folio.fqm.service.PermissionsService;
 import org.folio.querytool.domain.dto.ContentsRequest;
 import org.folio.querytool.domain.dto.EntityType;
 import org.folio.querytool.domain.dto.SubmitQuery;
+import org.folio.spring.FolioExecutionContext;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -30,6 +31,7 @@ public class EntityTypePermissionsAspect {
   private final EntityTypeRepository entityTypeRepository;
   private final QueryRepository queryRepository;
   private final PermissionsService permissionsService;
+  private final FolioExecutionContext executionContext;
 
   private final Map<MethodSignature, Integer> indexCache = new ConcurrentHashMap<>();
 
@@ -81,7 +83,7 @@ public class EntityTypePermissionsAspect {
   }
 
   private EntityType getEntityTypeFromId(UUID entityTypeId) {
-    return entityTypeRepository.getEntityTypeDefinition(entityTypeId, null)
+    return entityTypeRepository.getEntityTypeDefinition(entityTypeId, executionContext.getTenantId())
       .orElseThrow(() -> new EntityTypeNotFoundException(entityTypeId));
   }
 

--- a/src/main/java/org/folio/fqm/repository/EntityTypeRepository.java
+++ b/src/main/java/org/folio/fqm/repository/EntityTypeRepository.java
@@ -105,7 +105,7 @@ public class EntityTypeRepository {
   public Stream<EntityType> getEntityTypeDefinitions(Collection<UUID> entityTypeIds, String tenantId) {
     log.info("Getting definitions name for entity type ID: {}", entityTypeIds);
 
-    Map<UUID, EntityType> entityTypes = entityTypeCache.get(tenantId, tenantIdKey -> {
+    Map<UUID, EntityType> entityTypes = entityTypeCache.get(tenantId != null ? tenantId : executionContext.getTenantId(), tenantIdKey -> {
         String tableName = "".equals(tenantIdKey) ? TABLE_NAME : tenantIdKey + "_mod_fqm_manager." + TABLE_NAME;
         Field<String> definitionField = field(DEFINITION_FIELD_NAME, String.class);
         Map<String, EntityType> rawEntityTypes = readerJooqContext

--- a/src/main/java/org/folio/fqm/repository/EntityTypeRepository.java
+++ b/src/main/java/org/folio/fqm/repository/EntityTypeRepository.java
@@ -105,7 +105,7 @@ public class EntityTypeRepository {
   public Stream<EntityType> getEntityTypeDefinitions(Collection<UUID> entityTypeIds, String tenantId) {
     log.info("Getting definitions name for entity type ID: {}", entityTypeIds);
 
-    Map<UUID, EntityType> entityTypes = entityTypeCache.get(tenantId != null ? tenantId : executionContext.getTenantId(), tenantIdKey -> {
+    Map<UUID, EntityType> entityTypes = entityTypeCache.get(tenantId, tenantIdKey -> {
         String tableName = "".equals(tenantIdKey) ? TABLE_NAME : tenantIdKey + "_mod_fqm_manager." + TABLE_NAME;
         Field<String> definitionField = field(DEFINITION_FIELD_NAME, String.class);
         Map<String, EntityType> rawEntityTypes = readerJooqContext

--- a/src/main/java/org/folio/fqm/service/EntityTypeService.java
+++ b/src/main/java/org/folio/fqm/service/EntityTypeService.java
@@ -28,6 +28,7 @@ import org.folio.querytool.domain.dto.Field;
 import org.folio.querytool.domain.dto.SourceColumn;
 import org.folio.querytool.domain.dto.ValueSourceApi;
 import org.folio.querytool.domain.dto.ValueWithLabel;
+import org.folio.spring.FolioExecutionContext;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 
@@ -64,6 +65,7 @@ public class EntityTypeService {
   private final PermissionsService permissionsService;
   private final CrossTenantQueryService crossTenantQueryService;
   private final LanguageClient languageClient;
+  private final FolioExecutionContext executionContext;
 
   /**
    * Returns the list of all entity types.
@@ -73,7 +75,7 @@ public class EntityTypeService {
   public List<EntityTypeSummary> getEntityTypeSummary(Set<UUID> entityTypeIds, boolean includeInaccessible, boolean includeAll) {
     Set<String> userPermissions = permissionsService.getUserPermissions();
     return entityTypeRepository
-      .getEntityTypeDefinitions(entityTypeIds, null)
+      .getEntityTypeDefinitions(entityTypeIds, executionContext.getTenantId())
       .filter(entityType -> includeAll || !Boolean.TRUE.equals(entityType.getPrivate()))
       .filter(entityType -> includeInaccessible || userPermissions.containsAll(permissionsService.getRequiredPermissions(entityType)))
       .map(entityType -> {
@@ -104,7 +106,7 @@ public class EntityTypeService {
    * @return the entity type definition if found, empty otherwise
    */
   public EntityType getEntityTypeDefinition(UUID entityTypeId, boolean includeHidden) {
-    EntityType entityType = entityTypeFlatteningService.getFlattenedEntityType(entityTypeId, null, false);
+    EntityType entityType = entityTypeFlatteningService.getFlattenedEntityType(entityTypeId, executionContext.getTenantId(), false);
     boolean crossTenantEnabled = Boolean.TRUE.equals(entityType.getCrossTenantQueriesEnabled())
       && crossTenantQueryService.isCentralTenant();
     List<EntityTypeColumn> columns = entityType
@@ -126,7 +128,7 @@ public class EntityTypeService {
    */
   public ColumnValues getFieldValues(UUID entityTypeId, String fieldName, @Nullable String searchText) {
     searchText = searchText == null ? "" : searchText;
-    EntityType entityType = entityTypeFlatteningService.getFlattenedEntityType(entityTypeId, null, false);
+    EntityType entityType = entityTypeFlatteningService.getFlattenedEntityType(entityTypeId, executionContext.getTenantId(), false);
 
     Field field = FqlValidationService
       .findFieldDefinition(new FqlField(fieldName), entityType)

--- a/src/test/java/org/folio/fqm/aspect/EntityTypePermissionsAspectTest.java
+++ b/src/test/java/org/folio/fqm/aspect/EntityTypePermissionsAspectTest.java
@@ -11,6 +11,7 @@ import org.folio.fqm.service.PermissionsService;
 import org.folio.querytool.domain.dto.ContentsRequest;
 import org.folio.querytool.domain.dto.EntityType;
 import org.folio.querytool.domain.dto.SubmitQuery;
+import org.folio.spring.FolioExecutionContext;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
@@ -28,6 +29,7 @@ class EntityTypePermissionsAspectTest {
   private final EntityTypeRepository entityTypeRepository = mock(EntityTypeRepository.class);
   private final QueryRepository queryRepository = mock(QueryRepository.class);
   private final PermissionsService permissionsService = mock(PermissionsService.class);
+  private final FolioExecutionContext executionContext = mock(FolioExecutionContext.class);
 
   @Test
   void testUuidsCanBeHandled() {
@@ -101,7 +103,7 @@ class EntityTypePermissionsAspectTest {
   void testMethodSignatureCanBeHandled(AspectMethodHandler methodHandler, String methodName, Function<EntityType, Object[]> paramsConverter, Class<?>... paramTypes) {
     // Create a mock ProceedingJoinPoint for a dummy method, and use it to call the aspect
     // No permission checking is performed, so we can just verify that the permission check would hav happened and that the aspect calls proceed()
-    EntityTypePermissionsAspect aspect = new EntityTypePermissionsAspect(entityTypeRepository, queryRepository, permissionsService);
+    EntityTypePermissionsAspect aspect = new EntityTypePermissionsAspect(entityTypeRepository, queryRepository, permissionsService, executionContext);
     EntityType entityType = new EntityType(UUID.randomUUID().toString(), "name", true, false);
     when(entityTypeRepository.getEntityTypeDefinition(any(UUID.class), any(String.class))).thenReturn(Optional.of(entityType));
     when(entityTypeRepository.getEntityTypeDefinition(any(UUID.class), eq(null))).thenReturn(Optional.of(entityType));


### PR DESCRIPTION
## Purpose
[MODFQMMGR-695](https://folio-org.atlassian.net/browse/MODFQMMGR-695): Fix entity type cache bug in ECS environments

Replacing null tenantIds with `executionContext.getTenantId()` since null tenantId causes problems with caching definitions