### PR TITLE
[MODFQMMGR-695] Fix entity type cache bug in ECS environments

### DIFF
--- a/src/main/java/org/folio/fqm/aspect/EntityTypePermissionsAspect.java
+++ b/src/main/java/org/folio/fqm/aspect/EntityTypePermissionsAspect.java
@@ -13,6 +13,7 @@ import org.folio.fqm.service.PermissionsService;
 import org.folio.querytool.domain.dto.ContentsRequest;
 import org.folio.querytool.domain.dto.EntityType;
 import org.folio.querytool.domain.dto.SubmitQuery;
+import org.folio.spring.FolioExecutionContext;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -30,6 +31,7 @@ public class EntityTypePermissionsAspect {
   private final EntityTypeRepository entityTypeRepository;
   private final QueryRepository queryRepository;
   private final PermissionsService permissionsService;
+  private final FolioExecutionContext executionContext;
 
   private final Map<MethodSignature, Integer> indexCache = new ConcurrentHashMap<>();
 
@@ -81,7 +83,7 @@ public class EntityTypePermissionsAspect {
   }
 
   private EntityType getEntityTypeFromId(UUID entityTypeId) {
-    return entityTypeRepository.getEntityTypeDefinition(entityTypeId, null)
+    return entityTypeRepository.getEntityTypeDefinition(entityTypeId, executionContext.getTenantId())
       .orElseThrow(() -> new EntityTypeNotFoundException(entityTypeId));
   }
 

--- a/src/main/java/org/folio/fqm/repository/EntityTypeRepository.java
+++ b/src/main/java/org/folio/fqm/repository/EntityTypeRepository.java
@@ -104,8 +104,7 @@ public class EntityTypeRepository {
 
   public Stream<EntityType> getEntityTypeDefinitions(Collection<UUID> entityTypeIds, String tenantId) {
     log.info("Getting definitions name for entity type ID: {}", entityTypeIds);
-
-    Map<UUID, EntityType> entityTypes = entityTypeCache.get(tenantId != null ? tenantId : executionContext.getTenantId(), tenantIdKey -> {
+    Map<UUID, EntityType> entityTypes = entityTypeCache.get(tenantId, tenantIdKey -> {
         String tableName = "".equals(tenantIdKey) ? TABLE_NAME : tenantIdKey + "_mod_fqm_manager." + TABLE_NAME;
         Field<String> definitionField = field(DEFINITION_FIELD_NAME, String.class);
         Map<String, EntityType> rawEntityTypes = readerJooqContext

--- a/src/main/java/org/folio/fqm/repository/ResultSetRepository.java
+++ b/src/main/java/org/folio/fqm/repository/ResultSetRepository.java
@@ -58,7 +58,7 @@ public class ResultSetRepository {
       return List.of();
     }
 
-    EntityType baseEntityType = getEntityType(null, entityTypeId);
+    EntityType baseEntityType = getEntityType(executionContext.getTenantId(), entityTypeId);
     List<String> idColumnNames = EntityTypeUtils.getIdColumnNames(baseEntityType);
 
     SelectConditionStep<Record> query = null;
@@ -117,7 +117,7 @@ public class ResultSetRepository {
       return List.of();
     }
 
-    EntityType baseEntityType = getEntityType(null, entityTypeId);
+    EntityType baseEntityType = getEntityType(executionContext.getTenantId(), entityTypeId);
     Field<String[]> idValueGetter = EntityTypeUtils.getResultIdValueGetter(baseEntityType);
     var sortCriteria = EntityTypeUtils.getSortFields(baseEntityType, true);
     Condition afterIdCondition;
@@ -136,7 +136,7 @@ public class ResultSetRepository {
       // Below is a very hackish way to get around valueGetter issues in FqlToSqlConverterServiceIT
       // (due to the fact the that integration test does not select from an actual table, and instead creates a subquery
       // on the fly. Once the value getter for that test is handled better, then the ternary condition below can be removed
-      String tenantId = tenantsToQuery.size() > 1 ? tenantsToQuery.get(i) : null;
+      String tenantId = tenantsToQuery.size() > 1 ? tenantsToQuery.get(i) : executionContext.getTenantId();
       EntityType entityTypeDefinition = tenantId != null && tenantId.equals(executionContext.getTenantId()) ? baseEntityType : getEntityType(tenantId, entityTypeId);
       List<String> idColumnValueGetters = EntityTypeUtils.getIdColumnValueGetters(entityTypeDefinition);
       log.debug("idColumnValueGetters: {}", idColumnValueGetters);

--- a/src/main/java/org/folio/fqm/service/EntityTypeFlatteningService.java
+++ b/src/main/java/org/folio/fqm/service/EntityTypeFlatteningService.java
@@ -4,6 +4,7 @@ import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
+
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -18,6 +19,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
+
 import lombok.extern.log4j.Log4j2;
 import org.folio.fqm.exception.EntityTypeNotFoundException;
 import org.folio.fqm.repository.EntityTypeRepository;
@@ -50,7 +52,7 @@ public class EntityTypeFlatteningService {
   private static final Comparator<EntityTypeColumn> columnComparator =
     nullsLast(
       comparing(entityTypeColumn ->
-        requireNonNullElse(entityTypeColumn.getLabelAlias(), ""),
+          requireNonNullElse(entityTypeColumn.getLabelAlias(), ""),
         String.CASE_INSENSITIVE_ORDER));
 
   @Autowired
@@ -73,10 +75,10 @@ public class EntityTypeFlatteningService {
   /**
    * Gets a flattened entity type definition, fully localized.
    *
-   * @param entityTypeId The ID of the entity type to flatten
-   * @param tenantId The tenant ID to use for fetching the entity type definition
+   * @param entityTypeId       The ID of the entity type to flatten
+   * @param tenantId           The tenant ID to use for fetching the entity type definition
    * @param preserveAllColumns If true, all columns will be preserved, even if they are marked as non-essential and should be filtered out.
-   *                             This is primary for use by methods which build the from clause, since some join-related columns aren't exposed to users.
+   *                           This is primary for use by methods which build the from clause, since some join-related columns aren't exposed to users.
    * @return The flattened entity type definition, fully localized
    */
   public EntityType getFlattenedEntityType(UUID entityTypeId, String tenantId, boolean preserveAllColumns) {
@@ -169,11 +171,11 @@ public class EntityTypeFlatteningService {
 
         // Add a prefix to each column's name and idColumnName, then add 'em to the flattened entity type
         childColumns.addAll(
-            columns.stream()
+          columns.stream()
             .filter(col ->
               preserveAllColumns ||
-              !Boolean.TRUE.equals(sourceEt.getEssentialOnly()) ||
-              Boolean.TRUE.equals(col.getEssential())
+                !Boolean.TRUE.equals(sourceEt.getEssentialOnly()) ||
+                Boolean.TRUE.equals(col.getEssential())
             )
             // Don't use aliasPrefix here, since the prefix is already appropriately baked into the source alias in flattenedSourceDefinition
             .map(col ->
@@ -249,5 +251,11 @@ public class EntityTypeFlatteningService {
     UUID entityTypeId,
     List<Locale> locales,
     boolean preserveAllColumns
-  ) {}
+  ) {
+    EntityTypeCacheKey {
+      if (tenantId == null) {
+        throw new IllegalArgumentException("tenantId cannot be null");
+      }
+    }
+  }
 }

--- a/src/main/java/org/folio/fqm/service/PermissionsRegularService.java
+++ b/src/main/java/org/folio/fqm/service/PermissionsRegularService.java
@@ -59,7 +59,7 @@ public class PermissionsRegularService implements PermissionsService {
   }
 
   public Set<String> getRequiredPermissions(EntityType entityType) {
-    EntityType flattenedEntityType = entityTypeFlatteningService.getFlattenedEntityType(UUID.fromString(entityType.getId()), null, false);
+    EntityType flattenedEntityType = entityTypeFlatteningService.getFlattenedEntityType(UUID.fromString(entityType.getId()), context.getTenantId(), false);
     return new HashSet<>(flattenedEntityType.getRequiredPermissions());
   }
 

--- a/src/main/java/org/folio/fqm/service/ResultSetService.java
+++ b/src/main/java/org/folio/fqm/service/ResultSetService.java
@@ -5,6 +5,7 @@ import org.folio.fqm.client.ConfigurationClient;
 import org.folio.fqm.repository.ResultSetRepository;
 import org.folio.fqm.utils.EntityTypeUtils;
 import org.folio.querytool.domain.dto.EntityType;
+import org.folio.spring.FolioExecutionContext;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -38,6 +39,7 @@ public class ResultSetService {
   private final ResultSetRepository resultSetRepository;
   private final EntityTypeFlatteningService entityTypeFlatteningService;
   private final ConfigurationClient configurationClient;
+  private final FolioExecutionContext executionContext;
 
   public List<Map<String, Object>> getResultSet(UUID entityTypeId,
                                                 List<String> fields,
@@ -49,7 +51,7 @@ public class ResultSetService {
   }
 
   private List<Map<String, Object>> getSortedContents(UUID entityTypeId, List<List<String>> contentIds, List<Map<String, Object>> unsortedResults, boolean localize) {
-    EntityType entityType = entityTypeFlatteningService.getFlattenedEntityType(entityTypeId, null, true);
+    EntityType entityType = entityTypeFlatteningService.getFlattenedEntityType(entityTypeId, executionContext.getTenantId(), true);
     List<String> idColumnNames = EntityTypeUtils.getIdColumnNames(entityType);
     Map<List<String>, Map<String, Object>> contentsMap = unsortedResults.stream()
       .collect(Collectors.toMap(content -> {

--- a/src/test/java/org/folio/fqm/aspect/EntityTypePermissionsAspectTest.java
+++ b/src/test/java/org/folio/fqm/aspect/EntityTypePermissionsAspectTest.java
@@ -11,6 +11,7 @@ import org.folio.fqm.service.PermissionsService;
 import org.folio.querytool.domain.dto.ContentsRequest;
 import org.folio.querytool.domain.dto.EntityType;
 import org.folio.querytool.domain.dto.SubmitQuery;
+import org.folio.spring.FolioExecutionContext;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
@@ -28,6 +29,7 @@ class EntityTypePermissionsAspectTest {
   private final EntityTypeRepository entityTypeRepository = mock(EntityTypeRepository.class);
   private final QueryRepository queryRepository = mock(QueryRepository.class);
   private final PermissionsService permissionsService = mock(PermissionsService.class);
+  private final FolioExecutionContext executionContext = mock(FolioExecutionContext.class);
 
   @Test
   void testUuidsCanBeHandled() {
@@ -101,7 +103,7 @@ class EntityTypePermissionsAspectTest {
   void testMethodSignatureCanBeHandled(AspectMethodHandler methodHandler, String methodName, Function<EntityType, Object[]> paramsConverter, Class<?>... paramTypes) {
     // Create a mock ProceedingJoinPoint for a dummy method, and use it to call the aspect
     // No permission checking is performed, so we can just verify that the permission check would hav happened and that the aspect calls proceed()
-    EntityTypePermissionsAspect aspect = new EntityTypePermissionsAspect(entityTypeRepository, queryRepository, permissionsService);
+    EntityTypePermissionsAspect aspect = new EntityTypePermissionsAspect(entityTypeRepository, queryRepository, permissionsService, executionContext);
     EntityType entityType = new EntityType(UUID.randomUUID().toString(), "name", true, false);
     when(entityTypeRepository.getEntityTypeDefinition(any(UUID.class), any(String.class))).thenReturn(Optional.of(entityType));
     when(entityTypeRepository.getEntityTypeDefinition(any(UUID.class), eq(null))).thenReturn(Optional.of(entityType));

--- a/src/test/java/org/folio/fqm/service/FqlToSqlConverterServiceIT.java
+++ b/src/test/java/org/folio/fqm/service/FqlToSqlConverterServiceIT.java
@@ -9,6 +9,7 @@ import org.folio.querytool.domain.dto.EntityTypeSourceDatabase;
 import org.folio.querytool.domain.dto.RangedUUIDType;
 import org.folio.querytool.domain.dto.StringType;
 import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -52,13 +53,7 @@ class FqlToSqlConverterServiceIT extends IntegrationTestBase {
           .sourceAlias("t")
       )).sources(List.of(
         new EntityTypeSourceDatabase("db", "t")
-          .target("""
-              (select id, some_column, unused_column
-              from (values
-                     ('2af997b6-2655-459e-bdca-decbf54795ae'::uuid, 'AbCdEfGhIjKlMnOpQrStUvWxYz', 456),
-                     ('e0e4233e-fea0-4834-96ac-78739a1856d3'::uuid, 'blah blah blah', 789)
-                   ) as t (id, some_column, unused_column)
-              )"""))
+          .target("dummy_table"))
       );
 
     var json = new ObjectMapper().writeValueAsString(entityType);
@@ -68,8 +63,33 @@ class FqlToSqlConverterServiceIT extends IntegrationTestBase {
         (:id, :definition::json)
       """.formatted(TENANT_ID);
 
-    NamedParameterJdbcTemplate jdbcTemplate = new NamedParameterJdbcTemplate(getDataSource());
-    jdbcTemplate.update(sql, Map.of("id", UUID.fromString(entityType.getId()), "definition", json));
+    NamedParameterJdbcTemplate namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(getDataSource());
+    JdbcTemplate jdbcTemplate = new JdbcTemplate(getDataSource());
+    namedParameterJdbcTemplate.update(sql, Map.of("id", UUID.fromString(entityType.getId()), "definition", json));
+
+    String createTableSql = """
+          CREATE TABLE %s_mod_fqm_manager.dummy_table (
+              id UUID PRIMARY KEY,
+              some_column TEXT,
+              unused_column INT
+          );
+      """.formatted(TENANT_ID);
+    jdbcTemplate.execute(createTableSql);
+
+    String insertSql = """
+          INSERT INTO beeuni_mod_fqm_manager.dummy_table (id, some_column, unused_column)
+          VALUES (:id, :some_column, :unused_column);
+      """;
+    namedParameterJdbcTemplate.update(insertSql, Map.of(
+      "id", UUID.fromString("2af997b6-2655-459e-bdca-decbf54795ae"),
+      "some_column", "AbCdEfGhIjKlMnOpQrStUvWxYz",
+      "unused_column", 456
+    ));
+    namedParameterJdbcTemplate.update(insertSql, Map.of(
+      "id", UUID.fromString("e0e4233e-fea0-4834-96ac-78739a1856d3"),
+      "some_column", "blah blah blah",
+      "unused_column", 789
+    ));
 
     // When we query for a value that only actually matches the mock data when it gets run through the valueFunction
     // and is compared against the value produced by the filterValueGetter

--- a/src/test/java/org/folio/fqm/service/PermissionsRegularServiceTest.java
+++ b/src/test/java/org/folio/fqm/service/PermissionsRegularServiceTest.java
@@ -49,7 +49,7 @@ class PermissionsRegularServiceTest {
   private EntityType getTestEntityType() {
     EntityType entityType = new EntityType(UUID.randomUUID().toString(), "entity type name", true, false)
       .sources(List.of(new EntityTypeSource("db", "source_alias")));
-    when(entityTypeFlatteningService.getFlattenedEntityType(any(UUID.class), eq(null), eq(false))).thenReturn(entityType);
+    when(entityTypeFlatteningService.getFlattenedEntityType(any(UUID.class), eq(TENANT_ID), eq(false))).thenReturn(entityType);
     return entityType;
   }
 

--- a/src/test/java/org/folio/fqm/service/ResultSetServiceTest.java
+++ b/src/test/java/org/folio/fqm/service/ResultSetServiceTest.java
@@ -19,6 +19,7 @@ import org.folio.querytool.domain.dto.DateType;
 import org.folio.querytool.domain.dto.EntityType;
 import org.folio.querytool.domain.dto.EntityTypeColumn;
 import org.folio.querytool.domain.dto.EntityTypeSourceDatabase;
+import org.folio.spring.FolioExecutionContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -51,13 +52,15 @@ class ResultSetServiceTest {
   private EntityTypeFlatteningService entityTypeFlatteningService;
   private ConfigurationClient configurationClient;
   private ResultSetService service;
+  private FolioExecutionContext executionContext;
 
   @BeforeEach
   void setUp() {
     this.resultSetRepository = mock(ResultSetRepository.class);
     this.entityTypeFlatteningService = mock(EntityTypeFlatteningService.class);
     this.configurationClient = mock(ConfigurationClient.class);
-    this.service = new ResultSetService(resultSetRepository, entityTypeFlatteningService, configurationClient);
+    this.executionContext = mock(FolioExecutionContext.class);
+    this.service = new ResultSetService(resultSetRepository, entityTypeFlatteningService, configurationClient, executionContext);
   }
 
   @Test


### PR DESCRIPTION
## Purpose
[MODFQMMGR-695](https://folio-org.atlassian.net/browse/MODFQMMGR-695): Fix entity type cache bug in ECS environments

The core of this fix is to never allow EntityTypeCacheKey's tenantId to be null