### PR TITLE
[MODFQMMGR-709] Align Transaction - Source PO line display value with Orders app

### DIFF
--- a/src/main/resources/entity-types/finance/simple_transaction.json5
+++ b/src/main/resources/entity-types/finance/simple_transaction.json5
@@ -180,7 +180,11 @@
       queryable: true,
       visibleByDefault: true,
       essential: true,
-      valueGetter: ":transaction.jsonb ->> 'source'",
+      valueGetter: "SELECT \
+                      CASE \
+                        WHEN :transaction.jsonb ->> 'source' = 'PoLine' THEN 'PO line' \
+                        ELSE :transaction.jsonb ->> 'source' \
+                      END",
       values: [
         {
           label: 'Fiscal year',
@@ -191,8 +195,8 @@
           value: 'Invoice',
         },
         {
-          label: 'PoLine',
-          value: 'PoLine',
+          label: 'PO line',
+          value: 'PO line',
         },
         {
           label: 'User',


### PR DESCRIPTION
## Purpose
Part 2 of [MODFQMMGR-709](https://folio-org.atlassian.net/browse/MODFQMMGR-709)

Use label "PO line" instead of "PoLine" in order to better align with the Orders app

Edit: team decided this wasn't needed for now, so closing this PR