### PR TITLE
[MODFQMMGR-728] Ensure tenant_id column is last component of result_id

### DIFF
--- a/src/test/java/org/folio/fqm/utils/EntityTypeUtilsTest.java
+++ b/src/test/java/org/folio/fqm/utils/EntityTypeUtilsTest.java
@@ -99,4 +99,16 @@ class EntityTypeUtilsTest {
     List<String> actualDateFields = EntityTypeUtils.getDateFields(entityType);
     assertEquals(expectedDateFields, actualDateFields);
   }
+
+  @Test
+  void shouldOrderResultIdColumns() {
+    EntityType entityType = new EntityType()
+      .columns(List.of(
+        new EntityTypeColumn().name("tenant_id").isIdColumn(true),
+        new EntityTypeColumn().name("field2").isIdColumn(true)
+      ));
+    List<String> expectedIdColumnNames = List.of("field2", "tenant_id");
+    List<String> actualIdColumnNames = EntityTypeUtils.getIdColumnNames(entityType);
+    assertEquals(expectedIdColumnNames, actualIdColumnNames);
+  }
 }


### PR DESCRIPTION
## Purpose
[MODFQMMGR-728](https://folio-org.atlassian.net/browse/MODFQMMGR-728) Ensure tenant_id column is last component of result_id

Now that we're ordering ET columns by their localized names, there's a chance that the `tenant_id` field can come before the rest of the result_id (e.g. instance_id for instances, holdings_id for holdings, etc.). While this is fine for FQM and lists, this breaks bulk-edit, because it assumes that the tenant_id will always come last in the response from the `/sortedIds` endpoint. In practice, the only ET that this actually affected was Holdings, because tenant_id naturally comes last for the other ETs when ordering columns alphabetically (in English, at least). 

This PR introduces a kind of silly feeling change: now when we get the result ids for an ET, we do a quick check to make sure tenant_id comes last, and move it to the back of the list if necessary. Now bulk-edit is happy again!

NOTE: this will break contents retrieval for cross-tenant Holdings lists that were created between the merging of https://github.com/folio-org/mod-fqm-manager/pull/639 and the merging of this PR. Imo this isn't a huge deal, given that the change has never been released to production, only affects a single ET and only in ECS environments, and there's a simple fix: just refresh the list.