### PR TITLE
[MODORDSTOR-448] Change type of eresource.userLimit to string; udpated po-lines interface

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -335,7 +335,7 @@
     },
     {
       "id": "orders-storage.po-lines",
-      "version": "12.0"
+      "version": "13.0"
     },
     {
       "id": "orders-storage.purchase-orders",

--- a/src/main/resources/entity-types/orders/simple_purchase_order_line.json5
+++ b/src/main/resources/entity-types/orders/simple_purchase_order_line.json5
@@ -825,13 +825,12 @@
       name: 'eresource_user_limit',
       sourceAlias: 'pol',
       dataType: {
-        dataType: 'integerType',
+        dataType: 'stringType',
       },
       isIdColumn: false,
       queryable: true,
       visibleByDefault: false,
-      valueGetter: "(:sourceAlias.jsonb->'eresource'->>'userLimit')::integer",
-      valueFunction: '(:value)::integer',
+      valueGetter: ":sourceAlias.jsonb->'eresource'->>'userLimit'",
     },
     {
       name: 'eresource_access_provider',


### PR DESCRIPTION
## Purpose
[MODORDSTOR-448](https://folio-org.atlassian.net/browse/MODORDSTOR-448) - Make user limit as string field & apply migration

## Approach
- Updated the entity type to get `eresource.userLimit` as a string
- Updated `po-lines` interface version

## Related PRs
See [acq-models](https://github.com/folio-org/acq-models/pull/519) or [mod-orders-storage](https://github.com/folio-org/mod-orders-storage/pull/476) PRs (there are lots).

## Pre-Merge Checklist

If you are adding entity type(s), have you:
- [ ] Added the JSON5 definition to the `src/main/resources/entity-types` directory?
- [ ] Ensured that GETing the entity type at `/entity-types/{id}` works as expected?
- [ ] Added translations for all fields, per the [translation guidelines](/translations/README.md)? (Check this by ensuring `GET /entity-types/{id}` does not have `mod-fqm-manager.entityType.` in the response)
- [ ] Added views to liquibase, as applicable?
- [ ] Added required interfaces to the module descriptor?
- [ ] Checked that querying fields works correctly and all SQL is valid?

If you are changing/removing entity type(s), have you:
- [ ] Added migration code for any changes?