### PR TITLE
[MODFQMMGR-758] Make 'Item - Former IDs' field non-queryable

### DIFF
--- a/src/main/resources/entity-types/inventory/simple_item.json5
+++ b/src/main/resources/entity-types/inventory/simple_item.json5
@@ -324,7 +324,7 @@
         },
       },
       isIdColumn: false,
-      queryable: true,
+      queryable: false,
       visibleByDefault: false,
       essential: true,
       valueGetter: "(\


### PR DESCRIPTION
## Purpose
[MODFQMMGR-758](https://folio-org.atlassian.net/browse/MODFQMMGR-758): Make 'Item - Former IDs' field non-queryable