### PR TITLE
MODFQMMGR-518 Handle zombie queries 🧟

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,24 +37,25 @@ By utilizing the combination of source views, computed views, and other relevant
 mvn clean install
 ```
 ## Environment Variables
-| Name                                              | Default Value | Description                                       |
-|---------------------------------------------------|---------------|---------------------------------------------------|
-| DB_HOST                                           | localhost     | Postgres hostname                                 |
-| DB_PORT                                           | 5432          | Postgres port                                     |
-| DB_HOST_READER                                    | localhost     | Postgres hostname                                 |
-| DB_PORT_READER                                    | 5432          | Postgres port                                     |
-| DB_USERNAME                                       | postgres      | Postgres username                                 |
-| DB_PASSWORD                                       | postgres      | Postgres password                                 |
-| DB_DATABASE                                       | postgres      | Postgres database name                            |
-| IS_EUREKA                                         | false         | Specifies if environment is configured for EUREKA |
-| MAX_QUERY_SIZE                                    | 1250000       | max result count per query                        |
-| mod-fqm-manager.permissions-cache-timeout-seconds | 60            | Cache duration for user permissions               |
-| mod-fqm-manager.entity-type-cache-timeout-seconds | 300           | Cache duration for entity type definitions        |
-| server.port                                       | 8081          | Server port                                       |
-| QUERY_RETENTION_DURATION                          | 3h            | Older queries get deleted                         |
-| task.execution.pool.core-size                     | 9             | Core number of concurrent async tasks             |
-| task.execution.pool.max-size                      | 10            | Max number of concurrent async tasks              |
-| task.execution.pool.queue-capacity                | 1000          | Size of the task queue                            |
+| Name                                              | Default Value | Description                                                                                    |
+|---------------------------------------------------|---------------|------------------------------------------------------------------------------------------------|
+| DB_HOST                                           | localhost     | Postgres hostname                                                                              |
+| DB_PORT                                           | 5432          | Postgres port                                                                                  |
+| DB_HOST_READER                                    | localhost     | Postgres hostname                                                                              |
+| DB_PORT_READER                                    | 5432          | Postgres port                                                                                  |
+| DB_USERNAME                                       | postgres      | Postgres username                                                                              |
+| DB_PASSWORD                                       | postgres      | Postgres password                                                                              |
+| DB_DATABASE                                       | postgres      | Postgres database name                                                                         |
+| IS_EUREKA                                         | false         | Specifies if environment is configured for EUREKA                                              |
+| MAX_QUERY_SIZE                                    | 1250000       | max result count per query                                                                     |
+| mod-fqm-manager.permissions-cache-timeout-seconds | 60            | Cache duration for user permissions                                                            |
+| mod-fqm-manager.entity-type-cache-timeout-seconds | 300           | Cache duration for entity type definitions                                                     |
+| mod-fqm-manager.zombie-query-max-wait-seconds     | 300           | Maximum wait time before assuming an in-progress query without a backing SQL query is a zombie |
+| server.port                                       | 8081          | Server port                                                                                    |
+| QUERY_RETENTION_DURATION                          | 3h            | Older queries get deleted                                                                      |
+| task.execution.pool.core-size                     | 9             | Core number of concurrent async tasks                                                          |
+| task.execution.pool.max-size                      | 10            | Max number of concurrent async tasks                                                           |
+| task.execution.pool.queue-capacity                | 1000          | Size of the task queue                                                                         |
 
 > **Note regarding `mod-fqm-manager.entity-type-cache-timeout-seconds`:** The default value defined in the project's
 > module descriptor is `300`, as this value is more appropriate for development environments while still being reasonable

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
     <org.jooq.version>3.18.4</org.jooq.version>
     <org.apache.commons.version>4.4</org.apache.commons.version>
     <org.apache.commons-lang3.version>3.17.0</org.apache.commons-lang3.version>
+    <spring-retry.version>2.0.10</spring-retry.version>
 
     <!-- test dependencies -->
     <wiremock.version>3.2.0</wiremock.version>
@@ -170,6 +171,11 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.retry</groupId>
+      <artifactId>spring-retry</artifactId>
+      <version>${spring-retry.version}</version>
     </dependency>
     <dependency>
       <groupId>com.jayway.jsonpath</groupId>

--- a/src/main/java/org/folio/fqm/repository/IdStreamer.java
+++ b/src/main/java/org/folio/fqm/repository/IdStreamer.java
@@ -201,13 +201,7 @@ public class IdStreamer {
 
   void cancelQuery(UUID queryId) {
     log.info("Query {} has been marked as cancelled. Cancelling query in database.", queryId);
-    String querySearchText = "%Query ID: " + queryId + "%";
-    List<Integer> pids = jooqContext
-      .select(field("pid", Integer.class))
-      .from(table("pg_stat_activity"))
-      .where(field("state").eq("active"))
-      .and(field("query").like(querySearchText))
-      .fetchInto(Integer.class);
+    List<Integer> pids = queryRepository.getQueryPids(queryId);
     for (int pid : pids) {
       log.debug("PID for the executing query: {}", pid);
       jooqContext.execute("SELECT pg_cancel_backend(?)", pid);

--- a/src/main/java/org/folio/fqm/repository/IdStreamer.java
+++ b/src/main/java/org/folio/fqm/repository/IdStreamer.java
@@ -157,7 +157,7 @@ public class IdStreamer {
   }
 
   void handleBatch(UUID queryId, IdsWithCancelCallback idsWithCancelCallback, Integer maxQuerySize, AtomicInteger total) {
-    Query query = queryRepository.getQuery(queryId, true)
+    Query query = queryRepository.getQuery(queryId, false)
       .orElseThrow(() -> new QueryNotFoundException(queryId));
     if (query.status() == QueryStatus.CANCELLED) {
       log.info("Query {} has been cancelled, closing id stream", queryId);

--- a/src/main/java/org/folio/fqm/repository/QueryRepository.java
+++ b/src/main/java/org/folio/fqm/repository/QueryRepository.java
@@ -6,6 +6,7 @@ import org.folio.fqm.domain.Query;
 import org.folio.fqm.domain.QueryStatus;
 import org.folio.querytool.domain.dto.QueryIdentifier;
 import org.jooq.DSLContext;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Repository;
 
@@ -29,6 +30,8 @@ public class QueryRepository {
   private static final int MULTIPLE_FOR_STUCK_QUERIES = 3;
 
   private final DSLContext jooqContext;
+  @Qualifier("readerJooqContext")
+  private final DSLContext readerJooqContext;
 
   public QueryIdentifier saveQuery(Query query) {
     jooqContext.insertInto(table(QUERY_DETAILS_TABLE))
@@ -52,12 +55,59 @@ public class QueryRepository {
       .execute();
   }
 
+  /**
+   * Retrieves a Query by its ID, with optional caching and status validation.
+   *
+   * This method performs the following steps:
+   * 1. Attempts to retrieve the query from the database.
+   * 2. If the query is found and its status is IN_PROGRESS, it checks for corresponding running SQL queries.
+   * 3. If no running SQL queries are found, it double-checks the query status to account for potential race conditions.
+   * 4. If the query is still IN_PROGRESS but no running SQL query is found, it updates the query status to FAILED.
+   *
+   * Note: This method contains business logic in the repository layer, which might not be ideal
+   * but is currently the most convenient place for this logic.
+   *
+   * @param queryId The UUID of the query to retrieve.
+   * @param useCache A boolean flag indicating whether to use caching for this query.
+   * @return An Optional containing the Query if found, or empty if not found.
+   */
   @Cacheable(value = "queryCache", condition = "#useCache==true")
   public Optional<Query> getQuery(UUID queryId, boolean useCache) {
+    return getQuery(queryId)
+      .flatMap(query -> {
+        // If the query is in progress, double-check in the DB to see if there's a running SQL query
+        if (query.status() == QueryStatus.IN_PROGRESS && getQueryPids(queryId).isEmpty()) {
+          // 😳! Oh, no.
+          // But wait! Don't panic yet! This could just be a race condition and the query completed before we checked the running queries.
+          log.warn("Query {} has an in-progress status, but no corresponding running SQL query was found. Double-checking...", queryId);
+          if (getQuery(queryId).filter(q2 -> q2.status() == QueryStatus.IN_PROGRESS).isPresent()) {
+            // Oh, no.
+            log.error("Query {} still has an in-progress status, but no corresponding running SQL query. Marking it as failed", queryId);
+            // This is business logic, so it probably doesn't belong in the repository layer, but there's not really another convenient place to put it
+            updateQuery(queryId, QueryStatus.FAILED, OffsetDateTime.now(), "No corresponding running SQL query was found.");
+            return getQuery(queryId);
+          }
+        }
+        return Optional.of(query);
+      });
+  }
+
+  // Package-private, to make this visible for tests
+  Optional<Query> getQuery(UUID queryId) {
     return Optional.ofNullable(jooqContext.select()
       .from(table(QUERY_DETAILS_TABLE))
       .where(field(QUERY_ID).eq(queryId))
       .fetchOneInto(Query.class));
+  }
+
+  public List<Integer> getQueryPids(UUID queryId) {
+    String querySearchText = "%Query ID: " + queryId + "%";
+    return readerJooqContext
+      .select(field("pid", Integer.class))
+      .from(table("pg_stat_activity"))
+      .where(field("state").eq("active"))
+      .and(field("query").like(querySearchText))
+      .fetchInto(Integer.class);
   }
 
   public List<UUID> getQueryIdsForDeletion(Duration retentionDuration) {

--- a/src/main/java/org/folio/fqm/repository/QueryRepository.java
+++ b/src/main/java/org/folio/fqm/repository/QueryRepository.java
@@ -1,13 +1,15 @@
 package org.folio.fqm.repository;
 
-import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.folio.fqm.domain.Query;
 import org.folio.fqm.domain.QueryStatus;
 import org.folio.querytool.domain.dto.QueryIdentifier;
 import org.jooq.DSLContext;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.retry.support.RetryTemplate;
 import org.springframework.stereotype.Repository;
 
 import java.time.Duration;
@@ -21,17 +23,33 @@ import static org.jooq.impl.DSL.table;
 
 
 @Repository
-@RequiredArgsConstructor
 @Log4j2
 public class QueryRepository {
-
   private static final String QUERY_DETAILS_TABLE = "query_details";
   private static final String QUERY_ID = "query_id";
   private static final int MULTIPLE_FOR_STUCK_QUERIES = 3;
 
   private final DSLContext jooqContext;
-  @Qualifier("readerJooqContext")
   private final DSLContext readerJooqContext;
+  private final RetryTemplate zombieQueryRetry;
+
+  @Autowired
+  public QueryRepository(DSLContext jooqContext,
+                         @Qualifier("readerJooqContext") DSLContext readerJooqContext,
+                         @Value("${mod-fqm-manager.zombie-query-max-wait-seconds:30}") int zombieQueryMaxWaitSeconds) {
+    this.jooqContext = jooqContext;
+    this.readerJooqContext = readerJooqContext;
+
+    var retryBuilder = RetryTemplate.builder()
+      .retryOn(ZombieQueryException.class);
+    if (zombieQueryMaxWaitSeconds != 0) {
+      retryBuilder = retryBuilder.exponentialBackoff(Duration.ofSeconds(1), 1.5, Duration.ofSeconds(zombieQueryMaxWaitSeconds))
+        .withTimeout(Duration.ofSeconds(zombieQueryMaxWaitSeconds));
+    } else { // The max wait == 0, so just disable retrying.
+      retryBuilder = retryBuilder.maxAttempts(1);
+    }
+    this.zombieQueryRetry = retryBuilder.build();
+  }
 
   public QueryIdentifier saveQuery(Query query) {
     jooqContext.insertInto(table(QUERY_DETAILS_TABLE))
@@ -57,47 +75,61 @@ public class QueryRepository {
 
   /**
    * Retrieves a Query by its ID, with optional caching and status validation.
-   *
+   * <p>
    * This method performs the following steps:
    * 1. Attempts to retrieve the query from the database.
    * 2. If the query is found and its status is IN_PROGRESS, it checks for corresponding running SQL queries.
    * 3. If no running SQL queries are found, it double-checks the query status to account for potential race conditions.
    * 4. If the query is still IN_PROGRESS but no running SQL query is found, it updates the query status to FAILED.
-   *
+   * <p>
    * Note: This method contains business logic in the repository layer, which might not be ideal
    * but is currently the most convenient place for this logic.
    *
    * @param queryId The UUID of the query to retrieve.
-   * @param useCache A boolean flag indicating whether to use caching for this query.
    * @return An Optional containing the Query if found, or empty if not found.
    */
+  public Optional<Query> getPotentialZombieQuery(UUID queryId) {
+
+    return zombieQueryRetry.execute(
+      context -> getAndValidateQuery(queryId),
+      context -> handleZombieQuery(queryId)
+    );
+  }
+
+  private Optional<Query> getAndValidateQuery(UUID queryId) {
+    Optional<Query> query = getQuery(queryId);
+    if (query.filter(q -> q.status() == QueryStatus.IN_PROGRESS).isPresent()
+        && getQueryPids(queryId).isEmpty()) {
+      log.warn("Query {} has an in-progress status, but no corresponding running SQL query was found. Retrying...", queryId);
+      throw new ZombieQueryException(); // This exception is the trigger to retry in the RetryTemplate
+    }
+    return query;
+  }
+
+  private Optional<Query> handleZombieQuery(UUID queryId) {
+    log.error("Query {} still has an in-progress status, but no corresponding running SQL query. Marking it as failed", queryId);
+    updateQuery(queryId, QueryStatus.FAILED, OffsetDateTime.now(), "No corresponding running SQL query was found.");
+    return getQuery(queryId);
+  }
+
+  private static class ZombieQueryException extends RuntimeException {
+    public ZombieQueryException() {
+      super("🧟");
+    }
+  }
+
   @Cacheable(value = "queryCache", condition = "#useCache==true")
   public Optional<Query> getQuery(UUID queryId, boolean useCache) {
-    return getQuery(queryId)
-      .flatMap(query -> {
-        // If the query is in progress, double-check in the DB to see if there's a running SQL query
-        if (query.status() == QueryStatus.IN_PROGRESS && getQueryPids(queryId).isEmpty()) {
-          // 😳! Oh, no.
-          // But wait! Don't panic yet! This could just be a race condition and the query completed before we checked the running queries.
-          log.warn("Query {} has an in-progress status, but no corresponding running SQL query was found. Double-checking...", queryId);
-          if (getQuery(queryId).filter(q2 -> q2.status() == QueryStatus.IN_PROGRESS).isPresent()) {
-            // Oh, no.
-            log.error("Query {} still has an in-progress status, but no corresponding running SQL query. Marking it as failed", queryId);
-            // This is business logic, so it probably doesn't belong in the repository layer, but there's not really another convenient place to put it
-            updateQuery(queryId, QueryStatus.FAILED, OffsetDateTime.now(), "No corresponding running SQL query was found.");
-            return getQuery(queryId);
-          }
-        }
-        return Optional.of(query);
-      });
+    return getQuery(queryId);
   }
 
   // Package-private, to make this visible for tests
   Optional<Query> getQuery(UUID queryId) {
-    return Optional.ofNullable(jooqContext.select()
+    Query query = jooqContext.select()
       .from(table(QUERY_DETAILS_TABLE))
       .where(field(QUERY_ID).eq(queryId))
-      .fetchOneInto(Query.class));
+      .fetchOneInto(Query.class);
+    return Optional.ofNullable(query);
   }
 
   public List<Integer> getQueryPids(UUID queryId) {

--- a/src/main/java/org/folio/fqm/service/QueryManagementService.java
+++ b/src/main/java/org/folio/fqm/service/QueryManagementService.java
@@ -123,7 +123,7 @@ public class QueryManagementService {
    * @return Details of the query
    */
   public Optional<QueryDetails> getQuery(UUID queryId, boolean includeResults, int offset, int limit) {
-    return queryRepository.getQuery(queryId, false)
+    return queryRepository.getPotentialZombieQuery(queryId)
       .map(query -> {
         QueryDetails details = new QueryDetails()
           .queryId(queryId)
@@ -179,7 +179,7 @@ public class QueryManagementService {
 
   @SuppressWarnings("java:S2201") // we just use orElseThrow to conveniently throw an exception, we don't want the value
   public List<List<String>> getSortedIds(UUID queryId, int offset, int limit) {
-    Query query = queryRepository.getQuery(queryId, false).orElseThrow(() -> new QueryNotFoundException(queryId));
+    Query query = queryRepository.getPotentialZombieQuery(queryId).orElseThrow(() -> new QueryNotFoundException(queryId));
 
     // ensures it exists
     entityTypeService.getEntityTypeDefinition(query.entityTypeId(), true);

--- a/src/main/java/org/folio/fqm/service/QueryProcessorService.java
+++ b/src/main/java/org/folio/fqm/service/QueryProcessorService.java
@@ -60,7 +60,7 @@ public class QueryProcessorService {
   }
 
   public void handleSuccess(Query query) {
-    Query savedQuery = queryRepository.getQuery(query.queryId(), true)
+    Query savedQuery = queryRepository.getQuery(query.queryId(), false)
       .orElseThrow(() -> new QueryNotFoundException(query.queryId()));
     if (savedQuery.status() == QueryStatus.CANCELLED) {
       log.info("Query {} has been cancelled, therefore not updating", query.queryId());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,7 @@ mod-fqm-manager:
   bypass-permissions: false # local development ONLY
   permissions-cache-timeout-seconds: 60
   entity-type-cache-timeout-seconds: 300
+  zombie-query-max-wait-seconds: 300
 server:
   port: 8081
 spring:

--- a/src/test/java/org/folio/fqm/repository/IdStreamerTest.java
+++ b/src/test/java/org/folio/fqm/repository/IdStreamerTest.java
@@ -114,7 +114,7 @@ class IdStreamerTest {
 
   @BeforeEach
   void setup() {
-    QueryRepository queryRepository = new QueryRepository(context, context, 0);
+    QueryRepository queryRepository = new QueryRepository(context, context);
     entityTypeFlatteningService = mock(EntityTypeFlatteningService.class);
     crossTenantQueryService = mock(CrossTenantQueryService.class);
     queryResultsRepository = mock(QueryResultsRepository.class);

--- a/src/test/java/org/folio/fqm/repository/IdStreamerTest.java
+++ b/src/test/java/org/folio/fqm/repository/IdStreamerTest.java
@@ -1,8 +1,6 @@
 package org.folio.fqm.repository;
 
 import static org.folio.fqm.utils.flattening.FromClauseUtils.getFromClause;
-import static org.jooq.impl.DSL.field;
-import static org.jooq.impl.DSL.table;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.*;
@@ -30,11 +28,7 @@ import org.folio.querytool.domain.dto.EntityTypeColumn;
 import org.folio.querytool.domain.dto.EntityTypeSource;
 import org.folio.querytool.domain.dto.RangedUUIDType;
 import org.folio.spring.FolioExecutionContext;
-import org.jooq.Condition;
 import org.jooq.DSLContext;
-import org.jooq.SelectConditionStep;
-import org.jooq.SelectJoinStep;
-import org.jooq.SelectSelectStep;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
@@ -120,7 +114,7 @@ class IdStreamerTest {
 
   @BeforeEach
   void setup() {
-    QueryRepository queryRepository = new QueryRepository(context, context);
+    QueryRepository queryRepository = new QueryRepository(context, context, 0);
     entityTypeFlatteningService = mock(EntityTypeFlatteningService.class);
     crossTenantQueryService = mock(CrossTenantQueryService.class);
     queryResultsRepository = mock(QueryResultsRepository.class);

--- a/src/test/java/org/folio/fqm/repository/IdStreamerTest.java
+++ b/src/test/java/org/folio/fqm/repository/IdStreamerTest.java
@@ -120,7 +120,7 @@ class IdStreamerTest {
 
   @BeforeEach
   void setup() {
-    QueryRepository queryRepository = new QueryRepository(context);
+    QueryRepository queryRepository = new QueryRepository(context, context);
     entityTypeFlatteningService = mock(EntityTypeFlatteningService.class);
     crossTenantQueryService = mock(CrossTenantQueryService.class);
     queryResultsRepository = mock(QueryResultsRepository.class);
@@ -251,20 +251,8 @@ class IdStreamerTest {
   void shouldCancelQuery() {
     // This test uses a mocked DSLContext because our test DSLContext doesn't behave nicely in separate threads
     DSLContext mockJooqContext = mock(DSLContext.class);
-    SelectSelectStep mockSelectStep = mock(SelectSelectStep.class);
-    SelectJoinStep mockJoinStep = mock(SelectJoinStep.class);
-    SelectConditionStep mockConditionStep = mock(SelectConditionStep.class);
-    SelectConditionStep mockConditionStep2 = mock(SelectConditionStep.class);
-    List<Integer> mockPids = List.of(123, 456);
-
-    when(mockJooqContext.select(field("pid", Integer.class))).thenReturn(mockSelectStep);
-    when(mockSelectStep.from(table("pg_stat_activity"))).thenReturn(mockJoinStep);
-    when(mockJoinStep.where(field("state").eq("active"))).thenReturn(mockConditionStep);
-    when(mockConditionStep.and(any(Condition.class))).thenReturn(mockConditionStep2);
-    when(mockConditionStep2.fetchInto(Integer.class)).thenReturn(mockPids);
-    when(mockJooqContext.execute(anyString(), anyInt())).thenReturn(1);
-
     QueryRepository mockQueryRepository = mock(QueryRepository.class);
+    when(mockQueryRepository.getQueryPids(any())).thenReturn(List.of(123, 456));
 
     IdStreamer newIdStreamer = new IdStreamer(
       mockJooqContext,

--- a/src/test/java/org/folio/fqm/repository/QueryRepositoryTest.java
+++ b/src/test/java/org/folio/fqm/repository/QueryRepositoryTest.java
@@ -3,6 +3,7 @@ package org.folio.fqm.repository;
 import org.folio.fqm.domain.Query;
 import org.folio.fqm.domain.QueryStatus;
 import org.folio.querytool.domain.dto.QueryIdentifier;
+import org.jooq.DSLContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -13,9 +14,13 @@ import org.springframework.test.context.ActiveProfiles;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 import static org.springframework.util.StringUtils.hasText;
 
 @ActiveProfiles("db-test")
@@ -23,13 +28,15 @@ import static org.springframework.util.StringUtils.hasText;
 class QueryRepositoryTest {
 
   @Autowired
-  private QueryRepository repo;
+  DSLContext jooqContext;
 
+  private QueryRepository repo;
   private UUID queryId;
 
   @BeforeEach
   public void setUp() {
     queryId = UUID.randomUUID();
+    repo = spy(new QueryRepository(jooqContext, jooqContext, 0));
   }
 
   @AfterEach
@@ -49,7 +56,7 @@ class QueryRepositoryTest {
     Query expectedQuery = new Query(queryId, entityTypeId, fqlQuery, fields,
       createdBy, OffsetDateTime.now(), null, QueryStatus.IN_PROGRESS, null);
     QueryIdentifier queryIdentifier = repo.saveQuery(expectedQuery);
-    Query actualQuery = repo.getQuery(queryIdentifier.getQueryId()).orElse(null);
+    Query actualQuery = repo.getQuery(queryIdentifier.getQueryId(), false).get();
     assertEquals(expectedQuery.queryId(), actualQuery.queryId());
     assertEquals(expectedQuery.entityTypeId(), actualQuery.entityTypeId());
     assertEquals(expectedQuery.createdBy(), actualQuery.createdBy());
@@ -116,9 +123,9 @@ class QueryRepositoryTest {
     Query query = new Query(queryId, UUID.randomUUID(), fqlQuery, fields,
       UUID.randomUUID(), OffsetDateTime.now(), null, QueryStatus.IN_PROGRESS, null);
     QueryIdentifier queryIdentifier = repo.saveQuery(query);
-    assertFalse(repo.getQuery(queryIdentifier.getQueryId(), false).isEmpty());
+    assertFalse(repo.getPotentialZombieQuery(queryIdentifier.getQueryId()).isEmpty());
     repo.deleteQueries(List.of(queryId));
-    assertTrue(repo.getQuery(queryIdentifier.getQueryId(), false).isEmpty());
+    assertTrue(repo.getPotentialZombieQuery(queryIdentifier.getQueryId()).isEmpty());
   }
 
   @Test
@@ -135,11 +142,11 @@ class QueryRepositoryTest {
     // Given a query which is saved with the in-progress status, but doesn't have an actual running SQL query backing it
     QueryIdentifier queryIdentifier = repo.saveQuery(expectedQuery);
     // When you retrieve it with getQuery(id, false)
-    Query actual = repo.getQuery(queryIdentifier.getQueryId(), false).orElseThrow(() -> new RuntimeException("Query not found"));
+    Query actual = repo.getPotentialZombieQuery(queryIdentifier.getQueryId()).orElseThrow(() -> new RuntimeException("Query not found"));
     // Then it should be marked as failed
     assertEquals(QueryStatus.FAILED, actual.status());
     // When you retrieve it again, with getQuery(id) (to circumvent the logic that marked it as failed),
-    actual = repo.getQuery(queryIdentifier.getQueryId(), false).orElseThrow(() -> new RuntimeException("Query not found"));
+    actual = repo.getPotentialZombieQuery(queryIdentifier.getQueryId()).orElseThrow(() -> new RuntimeException("Query not found"));
     // Then it should still be marked as failed, since the first getQuery() call changed its status
     assertEquals(QueryStatus.FAILED, actual.status());
   }
@@ -158,8 +165,50 @@ class QueryRepositoryTest {
     // Given a query which is saved with the in-progress status, but doesn't have an actual running SQL query backing it
     QueryIdentifier queryIdentifier = repo.saveQuery(expectedQuery);
     // When you retrieve it with getQuery(id, false)
-    Query actual = repo.getQuery(queryIdentifier.getQueryId(), false).orElseThrow(() -> new RuntimeException("Query not found"));
+    Query actual = repo.getPotentialZombieQuery(queryIdentifier.getQueryId()).orElseThrow(() -> new RuntimeException("Query not found"));
     // Then it should be returned as-is, without changing its status
+    assertEquals(QueryStatus.SUCCESS, actual.status());
+  }
+
+  @Test
+  void shouldNotFailQueriesThatAreStillRunning() {
+    UUID entityTypeId = UUID.randomUUID();
+    UUID createdBy = UUID.randomUUID();
+    String fqlQuery = """
+      {"field1": {"$in": ["value1", "value2", "value3", "value4", "value5" ] }}
+      """;
+    List<String> fields = List.of("id", "field1", "field2");
+
+    Query expectedQuery = new Query(queryId, entityTypeId, fqlQuery, fields,
+      createdBy, OffsetDateTime.now(), null, QueryStatus.IN_PROGRESS, null);
+    // Given a query which is saved with the in-progress status and has a running SQL query backing it
+    QueryIdentifier queryIdentifier = repo.saveQuery(expectedQuery);
+    when(repo.getQueryPids(eq(queryId))).thenReturn(List.of(123));
+    // When you retrieve it with getQuery(id, false)
+    Query actual = repo.getPotentialZombieQuery(queryIdentifier.getQueryId()).orElseThrow(() -> new RuntimeException("Query not found"));
+    // Then it should still be in-progress, since the getQuery() call didn't change its status'
+    assertEquals(QueryStatus.IN_PROGRESS, actual.status());
+  }
+
+  @Test
+  void shouldNotFailQueriesThatAreStillRunningIfTheStatusChanges() {
+    UUID entityTypeId = UUID.randomUUID();
+    UUID createdBy = UUID.randomUUID();
+    String fqlQuery = """
+      {"field1": {"$in": ["value1", "value2", "value3", "value4", "value5" ] }}
+      """;
+    List<String> fields = List.of("id", "field1", "field2");
+
+    Query inProgressQuery = new Query(queryId, entityTypeId, fqlQuery, fields,
+      createdBy, OffsetDateTime.now(), null, QueryStatus.IN_PROGRESS, null);
+    Query successQuery = new Query(queryId, entityTypeId, fqlQuery, fields,
+      createdBy, OffsetDateTime.now(), null, QueryStatus.SUCCESS, null);
+    // Given a query which is saved with the in-progress status and does not have a running SQL query backing it, but then switches to another status
+    when(repo.getQuery(eq(queryId))).thenReturn(Optional.of(inProgressQuery))
+      .thenReturn(Optional.of(successQuery));
+    // When you retrieve it with getQuery(id, false)
+    Query actual = repo.getPotentialZombieQuery(queryId).orElseThrow(() -> new RuntimeException("Query not found"));
+    // Then it should be successful, since it switched to success after retrying
     assertEquals(QueryStatus.SUCCESS, actual.status());
   }
 }

--- a/src/test/java/org/folio/fqm/repository/QueryRepositoryTest.java
+++ b/src/test/java/org/folio/fqm/repository/QueryRepositoryTest.java
@@ -88,7 +88,7 @@ class QueryRepositoryTest {
       UUID.randomUUID(), OffsetDateTime.now(), null, QueryStatus.IN_PROGRESS, null);
     repo.saveQuery(queryToDelete);
     Query updatedQuery = new Query(queryId, UUID.randomUUID(), fqlQuery, fields,
-      UUID.randomUUID(), null, OffsetDateTime.now(), QueryStatus.SUCCESS, null);
+      UUID.randomUUID(), null, OffsetDateTime.now().minusHours(1), QueryStatus.SUCCESS, null);
 
     UUID queryId2 = UUID.randomUUID();
     Query queryToNotDelete = new Query(queryId2, UUID.randomUUID(), fqlQuery, fields,

--- a/src/test/java/org/folio/fqm/repository/QueryRepositoryTest.java
+++ b/src/test/java/org/folio/fqm/repository/QueryRepositoryTest.java
@@ -3,7 +3,6 @@ package org.folio.fqm.repository;
 import org.folio.fqm.domain.Query;
 import org.folio.fqm.domain.QueryStatus;
 import org.folio.querytool.domain.dto.QueryIdentifier;
-import org.jooq.DSLContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -14,13 +13,9 @@ import org.springframework.test.context.ActiveProfiles;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
 import static org.springframework.util.StringUtils.hasText;
 
 @ActiveProfiles("db-test")
@@ -28,15 +23,12 @@ import static org.springframework.util.StringUtils.hasText;
 class QueryRepositoryTest {
 
   @Autowired
-  DSLContext jooqContext;
-
   private QueryRepository repo;
   private UUID queryId;
 
   @BeforeEach
   public void setUp() {
     queryId = UUID.randomUUID();
-    repo = spy(new QueryRepository(jooqContext, jooqContext, 0));
   }
 
   @AfterEach
@@ -123,92 +115,8 @@ class QueryRepositoryTest {
     Query query = new Query(queryId, UUID.randomUUID(), fqlQuery, fields,
       UUID.randomUUID(), OffsetDateTime.now(), null, QueryStatus.IN_PROGRESS, null);
     QueryIdentifier queryIdentifier = repo.saveQuery(query);
-    assertFalse(repo.getPotentialZombieQuery(queryIdentifier.getQueryId()).isEmpty());
+    assertFalse(repo.getQuery(queryIdentifier.getQueryId()).isEmpty());
     repo.deleteQueries(List.of(queryId));
-    assertTrue(repo.getPotentialZombieQuery(queryIdentifier.getQueryId()).isEmpty());
-  }
-
-  @Test
-  void shouldFailQueriesThatArentActuallyRunning() {
-    UUID entityTypeId = UUID.randomUUID();
-    UUID createdBy = UUID.randomUUID();
-    String fqlQuery = """
-      {"field1": {"$in": ["value1", "value2", "value3", "value4", "value5" ] }}
-      """;
-    List<String> fields = List.of("id", "field1", "field2");
-
-    Query expectedQuery = new Query(queryId, entityTypeId, fqlQuery, fields,
-      createdBy, OffsetDateTime.now(), null, QueryStatus.IN_PROGRESS, null);
-    // Given a query which is saved with the in-progress status, but doesn't have an actual running SQL query backing it
-    QueryIdentifier queryIdentifier = repo.saveQuery(expectedQuery);
-    // When you retrieve it with getQuery(id, false)
-    Query actual = repo.getPotentialZombieQuery(queryIdentifier.getQueryId()).orElseThrow(() -> new RuntimeException("Query not found"));
-    // Then it should be marked as failed
-    assertEquals(QueryStatus.FAILED, actual.status());
-    // When you retrieve it again, with getQuery(id) (to circumvent the logic that marked it as failed),
-    actual = repo.getPotentialZombieQuery(queryIdentifier.getQueryId()).orElseThrow(() -> new RuntimeException("Query not found"));
-    // Then it should still be marked as failed, since the first getQuery() call changed its status
-    assertEquals(QueryStatus.FAILED, actual.status());
-  }
-
-  @Test
-  void shouldNotFailNonInProgressQueriesThatArentActuallyRunning() {
-    UUID entityTypeId = UUID.randomUUID();
-    UUID createdBy = UUID.randomUUID();
-    String fqlQuery = """
-      {"field1": {"$in": ["value1", "value2", "value3", "value4", "value5" ] }}
-      """;
-    List<String> fields = List.of("id", "field1", "field2");
-
-    Query expectedQuery = new Query(queryId, entityTypeId, fqlQuery, fields,
-      createdBy, OffsetDateTime.now(), null, QueryStatus.SUCCESS, null);
-    // Given a query which is saved with the in-progress status, but doesn't have an actual running SQL query backing it
-    QueryIdentifier queryIdentifier = repo.saveQuery(expectedQuery);
-    // When you retrieve it with getQuery(id, false)
-    Query actual = repo.getPotentialZombieQuery(queryIdentifier.getQueryId()).orElseThrow(() -> new RuntimeException("Query not found"));
-    // Then it should be returned as-is, without changing its status
-    assertEquals(QueryStatus.SUCCESS, actual.status());
-  }
-
-  @Test
-  void shouldNotFailQueriesThatAreStillRunning() {
-    UUID entityTypeId = UUID.randomUUID();
-    UUID createdBy = UUID.randomUUID();
-    String fqlQuery = """
-      {"field1": {"$in": ["value1", "value2", "value3", "value4", "value5" ] }}
-      """;
-    List<String> fields = List.of("id", "field1", "field2");
-
-    Query expectedQuery = new Query(queryId, entityTypeId, fqlQuery, fields,
-      createdBy, OffsetDateTime.now(), null, QueryStatus.IN_PROGRESS, null);
-    // Given a query which is saved with the in-progress status and has a running SQL query backing it
-    QueryIdentifier queryIdentifier = repo.saveQuery(expectedQuery);
-    when(repo.getQueryPids(eq(queryId))).thenReturn(List.of(123));
-    // When you retrieve it with getQuery(id, false)
-    Query actual = repo.getPotentialZombieQuery(queryIdentifier.getQueryId()).orElseThrow(() -> new RuntimeException("Query not found"));
-    // Then it should still be in-progress, since the getQuery() call didn't change its status'
-    assertEquals(QueryStatus.IN_PROGRESS, actual.status());
-  }
-
-  @Test
-  void shouldNotFailQueriesThatAreStillRunningIfTheStatusChanges() {
-    UUID entityTypeId = UUID.randomUUID();
-    UUID createdBy = UUID.randomUUID();
-    String fqlQuery = """
-      {"field1": {"$in": ["value1", "value2", "value3", "value4", "value5" ] }}
-      """;
-    List<String> fields = List.of("id", "field1", "field2");
-
-    Query inProgressQuery = new Query(queryId, entityTypeId, fqlQuery, fields,
-      createdBy, OffsetDateTime.now(), null, QueryStatus.IN_PROGRESS, null);
-    Query successQuery = new Query(queryId, entityTypeId, fqlQuery, fields,
-      createdBy, OffsetDateTime.now(), null, QueryStatus.SUCCESS, null);
-    // Given a query which is saved with the in-progress status and does not have a running SQL query backing it, but then switches to another status
-    when(repo.getQuery(eq(queryId))).thenReturn(Optional.of(inProgressQuery))
-      .thenReturn(Optional.of(successQuery));
-    // When you retrieve it with getQuery(id, false)
-    Query actual = repo.getPotentialZombieQuery(queryId).orElseThrow(() -> new RuntimeException("Query not found"));
-    // Then it should be successful, since it switched to success after retrying
-    assertEquals(QueryStatus.SUCCESS, actual.status());
+    assertTrue(repo.getQuery(queryIdentifier.getQueryId()).isEmpty());
   }
 }

--- a/src/test/java/org/folio/fqm/service/QueryManagementServiceTest.java
+++ b/src/test/java/org/folio/fqm/service/QueryManagementServiceTest.java
@@ -206,7 +206,7 @@ class QueryManagementServiceTest {
       .startDate(offsetDateTimeAsDate(expectedQuery.startDate()))
       .totalRecords(5)
       .content(List.of()));
-    when(queryRepository.getQuery(expectedQuery.queryId(), false)).thenReturn(Optional.of(expectedQuery));
+    when(queryRepository.getPotentialZombieQuery(expectedQuery.queryId())).thenReturn(Optional.of(expectedQuery));
     when(queryResultsRepository.getQueryResultsCount(expectedQuery.queryId())).thenReturn(5);
     Optional<QueryDetails> actualDetails = queryManagementService.getQuery(expectedQuery.queryId(), includeResults, offset, limit);
     assertEquals(expectedDetails, actualDetails);
@@ -236,7 +236,7 @@ class QueryManagementServiceTest {
       .startDate(offsetDateTimeAsDate(expectedQuery.startDate()))
       .totalRecords(2)
       .content(contents));
-    when(queryRepository.getQuery(expectedQuery.queryId(), false)).thenReturn(Optional.of(expectedQuery));
+    when(queryRepository.getPotentialZombieQuery(expectedQuery.queryId())).thenReturn(Optional.of(expectedQuery));
     when(queryResultsRepository.getQueryResultsCount(expectedQuery.queryId())).thenReturn(2);
     when(queryResultsRepository.getQueryResultIds(expectedQuery.queryId(), offset, limit)).thenReturn(resultIds);
     when(crossTenantQueryService.getTenantsToQuery(any())).thenReturn(tenantIds);
@@ -414,7 +414,7 @@ class QueryManagementServiceTest {
       List.of(UUID.randomUUID().toString())
     );
 
-    when(queryRepository.getQuery(query.queryId(), false)).thenReturn(Optional.of(query));
+    when(queryRepository.getPotentialZombieQuery(query.queryId())).thenReturn(Optional.of(query));
     when(entityTypeService.getEntityTypeDefinition(query.entityTypeId(), true)).thenReturn(new EntityType());
     when(queryResultsSorterService.getSortedIds(query.queryId(), offset, limit)).thenReturn(expectedIds);
 
@@ -441,7 +441,7 @@ class QueryManagementServiceTest {
     UUID queryId = query.queryId();
     int offset = 0;
     int limit = 0;
-    when(queryRepository.getQuery(query.queryId(), false)).thenThrow(new QueryNotFoundException(query.queryId()));
+    when(queryRepository.getPotentialZombieQuery(query.queryId())).thenThrow(new QueryNotFoundException(query.queryId()));
     assertThrows(QueryNotFoundException.class, () -> queryManagementService.getSortedIds(queryId, offset, limit));
   }
 

--- a/src/test/java/org/folio/fqm/service/QueryManagementServiceTest.java
+++ b/src/test/java/org/folio/fqm/service/QueryManagementServiceTest.java
@@ -22,13 +22,12 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -38,13 +37,12 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class QueryManagementServiceTest {
@@ -81,11 +79,11 @@ class QueryManagementServiceTest {
 
   private final int maxConfiguredQuerySize = 1000;
 
-  @InjectMocks
   private QueryManagementService queryManagementService;
 
   @BeforeEach
   void setup() {
+    queryManagementService = new QueryManagementService(entityTypeService, executionContext, queryRepository, queryResultsRepository, queryExecutionService, queryProcessorService, queryResultsSorterService, resultSetService, fqlValidationService, crossTenantQueryService, 0);
     queryManagementService.setMaxConfiguredQuerySize(maxConfiguredQuerySize);
   }
 
@@ -206,7 +204,7 @@ class QueryManagementServiceTest {
       .startDate(offsetDateTimeAsDate(expectedQuery.startDate()))
       .totalRecords(5)
       .content(List.of()));
-    when(queryRepository.getPotentialZombieQuery(expectedQuery.queryId())).thenReturn(Optional.of(expectedQuery));
+    when(queryRepository.getQuery(expectedQuery.queryId(), false)).thenReturn(Optional.of(expectedQuery));
     when(queryResultsRepository.getQueryResultsCount(expectedQuery.queryId())).thenReturn(5);
     Optional<QueryDetails> actualDetails = queryManagementService.getQuery(expectedQuery.queryId(), includeResults, offset, limit);
     assertEquals(expectedDetails, actualDetails);
@@ -236,7 +234,7 @@ class QueryManagementServiceTest {
       .startDate(offsetDateTimeAsDate(expectedQuery.startDate()))
       .totalRecords(2)
       .content(contents));
-    when(queryRepository.getPotentialZombieQuery(expectedQuery.queryId())).thenReturn(Optional.of(expectedQuery));
+    when(queryRepository.getQuery(expectedQuery.queryId(), false)).thenReturn(Optional.of(expectedQuery));
     when(queryResultsRepository.getQueryResultsCount(expectedQuery.queryId())).thenReturn(2);
     when(queryResultsRepository.getQueryResultIds(expectedQuery.queryId(), offset, limit)).thenReturn(resultIds);
     when(crossTenantQueryService.getTenantsToQuery(any())).thenReturn(tenantIds);
@@ -414,7 +412,7 @@ class QueryManagementServiceTest {
       List.of(UUID.randomUUID().toString())
     );
 
-    when(queryRepository.getPotentialZombieQuery(query.queryId())).thenReturn(Optional.of(query));
+    when(queryRepository.getQuery(query.queryId(), false)).thenReturn(Optional.of(query));
     when(entityTypeService.getEntityTypeDefinition(query.entityTypeId(), true)).thenReturn(new EntityType());
     when(queryResultsSorterService.getSortedIds(query.queryId(), offset, limit)).thenReturn(expectedIds);
 
@@ -441,7 +439,7 @@ class QueryManagementServiceTest {
     UUID queryId = query.queryId();
     int offset = 0;
     int limit = 0;
-    when(queryRepository.getPotentialZombieQuery(query.queryId())).thenThrow(new QueryNotFoundException(query.queryId()));
+    when(queryRepository.getQuery(query.queryId(), false)).thenThrow(new QueryNotFoundException(query.queryId()));
     assertThrows(QueryNotFoundException.class, () -> queryManagementService.getSortedIds(queryId, offset, limit));
   }
 
@@ -519,6 +517,102 @@ class QueryManagementServiceTest {
     when(resultSetService.getResultSet(entityTypeId, fields, ids, tenantIds, false)).thenReturn(expectedContents);
     List<Map<String, Object>> actualContents = queryManagementService.getContents(entityTypeId, fields, ids, userId, false, true);
     assertEquals(expectedContents, actualContents);
+  }
+  @Test
+  void shouldFailQueriesThatArentActuallyRunning() {
+    UUID queryId = UUID.randomUUID();
+    UUID entityTypeId = UUID.randomUUID();
+    UUID createdBy = UUID.randomUUID();
+    String fqlQuery = """
+      {"field1": {"$in": ["value1", "value2", "value3", "value4", "value5" ] }}
+      """;
+    List<String> fields = List.of("id", "field1", "field2");
+
+    Query expectedQuery = new Query(queryId, entityTypeId, fqlQuery, fields,
+      createdBy, OffsetDateTime.now(), null, QueryStatus.IN_PROGRESS, null);
+    // Given a query which is saved with the in-progress status, but doesn't have an actual running SQL query backing it
+    when(queryRepository.getQuery(queryId, false)).thenReturn(Optional.of(expectedQuery));
+    when(queryRepository.getQueryPids(queryId)).thenReturn(Collections.emptyList());
+    // When you retrieve it with getPotentialZombieQuery()
+    queryManagementService.getPotentialZombieQuery(queryId).orElseThrow(() -> new RuntimeException("Query not found"));
+    // Then it should be marked as failed
+    verify(queryRepository, times(1)).updateQuery(eq(queryId), eq(QueryStatus.FAILED), any(OffsetDateTime.class), anyString());
+    Query failedQuery = new Query(queryId, entityTypeId, fqlQuery, fields,
+      createdBy, OffsetDateTime.now(), null, QueryStatus.FAILED, null);
+
+    // When you retrieve it again
+    reset(queryRepository);
+    when(queryRepository.getQuery(queryId, false)).thenReturn(Optional.of(failedQuery));
+    queryManagementService.getPotentialZombieQuery(queryId).orElseThrow(() -> new RuntimeException("Query not found"));
+    // Then it should not be updated
+    verify(queryRepository, never()).updateQuery(eq(queryId), any(QueryStatus.class), any(OffsetDateTime.class), anyString());
+  }
+
+  @Test
+  void shouldNotFailNonInProgressQueriesThatArentActuallyRunning() {
+    UUID queryId = UUID.randomUUID();
+
+    UUID entityTypeId = UUID.randomUUID();
+    UUID createdBy = UUID.randomUUID();
+    String fqlQuery = """
+      {"field1": {"$in": ["value1", "value2", "value3", "value4", "value5" ] }}
+      """;
+    List<String> fields = List.of("id", "field1", "field2");
+
+    Query expectedQuery = new Query(queryId, entityTypeId, fqlQuery, fields,
+      createdBy, OffsetDateTime.now(), null, QueryStatus.SUCCESS, null);
+    // Given a query which is saved with the success status
+    when(queryRepository.getQuery(queryId, false)).thenReturn(Optional.of(expectedQuery));
+    // When you retrieve it with getPotentialZombieQuery()
+    queryManagementService.getPotentialZombieQuery(queryId).orElseThrow(() -> new RuntimeException("Query not found"));
+    // Then it should not update anything
+    verify(queryRepository, never()).updateQuery(eq(queryId), any(QueryStatus.class), any(OffsetDateTime.class), anyString());
+  }
+
+  @Test
+  void shouldNotFailQueriesThatAreStillRunning() {
+    UUID queryId = UUID.randomUUID();
+
+    UUID entityTypeId = UUID.randomUUID();
+    UUID createdBy = UUID.randomUUID();
+    String fqlQuery = """
+      {"field1": {"$in": ["value1", "value2", "value3", "value4", "value5" ] }}
+      """;
+    List<String> fields = List.of("id", "field1", "field2");
+
+    Query expectedQuery = new Query(queryId, entityTypeId, fqlQuery, fields,
+      createdBy, OffsetDateTime.now(), null, QueryStatus.IN_PROGRESS, null);
+    // Given a query which is saved with the in-progress status and has a running SQL query backing it
+    when(queryRepository.getQuery(queryId, false)).thenReturn(Optional.of(expectedQuery));
+    when(queryRepository.getQueryPids(eq(queryId))).thenReturn(List.of(123));
+    // When you retrieve it with getPotentialZombieQuery()
+    queryManagementService.getPotentialZombieQuery(queryId).orElseThrow(() -> new RuntimeException("Query not found"));
+    // Then it should not update anything
+    verify(queryRepository, never()).updateQuery(eq(queryId), any(QueryStatus.class), any(OffsetDateTime.class), anyString());
+  }
+
+  @Test
+  void shouldNotFailQueriesThatAreStillRunningIfTheStatusChanges() {
+    UUID queryId = UUID.randomUUID();
+
+    UUID entityTypeId = UUID.randomUUID();
+    UUID createdBy = UUID.randomUUID();
+    String fqlQuery = """
+      {"field1": {"$in": ["value1", "value2", "value3", "value4", "value5" ] }}
+      """;
+    List<String> fields = List.of("id", "field1", "field2");
+
+    Query inProgressQuery = new Query(queryId, entityTypeId, fqlQuery, fields,
+      createdBy, OffsetDateTime.now(), null, QueryStatus.IN_PROGRESS, null);
+    Query successQuery = new Query(queryId, entityTypeId, fqlQuery, fields,
+      createdBy, OffsetDateTime.now(), null, QueryStatus.SUCCESS, null);
+    // Given a query which is saved with the in-progress status and does not have a running SQL query backing it, but then switches to another status
+    when(queryRepository.getQuery(eq(queryId), anyBoolean())).thenReturn(Optional.of(inProgressQuery))
+      .thenReturn(Optional.of(successQuery));
+    // When you retrieve it with getPotentialZombieQuery()
+    queryManagementService.getPotentialZombieQuery(queryId).orElseThrow(() -> new RuntimeException("Query not found"));
+    // Then it should not try to update the status, since it eventually switched its status after retrying
+    verify(queryRepository, never()).updateQuery(eq(queryId), any(QueryStatus.class), any(OffsetDateTime.class), anyString());
   }
 
   private static Date offsetDateTimeAsDate(OffsetDateTime offsetDateTime) {

--- a/src/test/java/org/folio/fqm/service/QueryProcessorServiceTest.java
+++ b/src/test/java/org/folio/fqm/service/QueryProcessorServiceTest.java
@@ -95,7 +95,7 @@ class QueryProcessorServiceTest {
   @Test
   void shouldHandleSuccess() {
     Query query = TestDataFixture.getMockQuery();
-    when(queryRepository.getQuery(query.queryId(), true)).thenReturn(Optional.of(query));
+    when(queryRepository.getQuery(query.queryId(), false)).thenReturn(Optional.of(query));
     service.handleSuccess(query);
     verify(queryRepository, times(1)).updateQuery(eq(query.queryId()), eq(QueryStatus.SUCCESS), any(), eq(null));
   }
@@ -104,7 +104,7 @@ class QueryProcessorServiceTest {
   void successHandlerShouldHandleCancelledQuery() {
     Query query = new Query(UUID.randomUUID(), UUID.randomUUID(), "", List.of(), UUID.randomUUID(),
       OffsetDateTime.now(), null, QueryStatus.CANCELLED, null);
-    when(queryRepository.getQuery(query.queryId(), true)).thenReturn(Optional.of(query));
+    when(queryRepository.getQuery(query.queryId(), false)).thenReturn(Optional.of(query));
     service.handleSuccess(query);
     verify(queryRepository, times(0)).updateQuery(query.queryId(), query.status(), query.endDate(), query.failureReason());
   }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -3,6 +3,7 @@ server:
 mod-fqm-manager:
   permissions-cache-timeout-seconds: 60
   entity-type-cache-timeout-seconds: 3600
+  zombie-query-max-wait-seconds: 0
 spring:
   application:
     name: mod-fqm-manager


### PR DESCRIPTION
## Purpose
This PR is to handle situations where a query is still marked as in-progress when it's not actually running, due to something like a server crash.

## Approach
When retrieving the FQM query details, if the query is in the in-progress status, it will check running queries in the DB to find the corresponding DB query. If it's not found, it re-checks the FQM query status. If the query is still marked as in-progress, then FQM will update its status to failed, then return the failed query details.