### PR TITLE
[MODORDERS-1269] Updated orders interface version

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -387,7 +387,7 @@
     },
     {
       "id": "orders",
-      "version": "12.0"
+      "version": "13.0"
     },
     {
       "id": "organizations.organizations",


### PR DESCRIPTION
## Purpose
[MODORDERS-1269](https://folio-org.atlassian.net/browse/MODORDERS-1269) - Remove alerts and reporting codes from order lines, use a single order line schema

## Approach
Updated orders interface version

[Related PRs](https://github.com/folio-org/mod-orders-storage/pull/477)

## Pre-Merge Checklist

If you are adding entity type(s), have you:
- [ ] Added the JSON5 definition to the `src/main/resources/entity-types` directory?
- [ ] Ensured that GETing the entity type at `/entity-types/{id}` works as expected?
- [ ] Added translations for all fields, per the [translation guidelines](/translations/README.md)? (Check this by ensuring `GET /entity-types/{id}` does not have `mod-fqm-manager.entityType.` in the response)
- [ ] Added views to liquibase, as applicable?
- [ ] Added required interfaces to the module descriptor?
- [ ] Checked that querying fields works correctly and all SQL is valid?

If you are changing/removing entity type(s), have you:
- [ ] Added migration code for any changes?