### PR TITLE
MODFQMMGR-784: Remove IS_EUREKA environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ mvn clean install
 | DB_USERNAME                                       | postgres      | Postgres username                                                                              |
 | DB_PASSWORD                                       | postgres      | Postgres password                                                                              |
 | DB_DATABASE                                       | postgres      | Postgres database name                                                                         |
-| IS_EUREKA                                         | false         | Specifies if environment is configured for EUREKA                                              |
 | MAX_QUERY_SIZE                                    | 1250000       | max result count per query                                                                     |
 | mod-fqm-manager.permissions-cache-timeout-seconds | 60            | Cache duration for user permissions                                                            |
 | mod-fqm-manager.entity-type-cache-timeout-seconds | 300           | Cache duration for entity type definitions                                                     |

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -569,9 +569,6 @@
       },
       { "name": "mod-fqm-manager.entity-type-cache-timeout-seconds",
         "value": "300"
-      },
-      { "name": "IS_EUREKA",
-        "value": "false"
       }
     ]
   }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -79,7 +79,6 @@ coffee-boots:
       queryCache: maximumSize=500,expireAfterWrite=1m
       userTenantCache: maximumSize=100,expireAfterWrite=30s
 folio:
-  is-eureka: ${IS_EUREKA:false}
   tenant:
     validation:
       enabled: true

--- a/src/test/java/org/folio/fqm/IntegrationTestBase.java
+++ b/src/test/java/org/folio/fqm/IntegrationTestBase.java
@@ -165,19 +165,19 @@ public class IntegrationTestBase {
     @NotNull
     @Override
     public MockResponse dispatch(@NotNull RecordedRequest recordedRequest) {
-      if (recordedRequest.getPath().matches("/perms/users/[-0-9a-f]+/permissions\\?expanded=true&indexField=userId")) {
+      if (recordedRequest.getPath().matches("/permissions/users/.+")) {
         return new MockResponse().setBody("""
           {
-            "permissionNames": [ "organizations.organizations.collection.get",
-                                 "organizations-storage.organization-types.collection.get",
-                                 "acquisitions-units.units.collection.get"
-            ],
-            "totalRecords": 3
+            "permissions": [ "organizations.organizations.collection.get",
+                             "organizations-storage.organization-types.collection.get",
+                             "acquisitions-units.units.collection.get"
+            ]
           }
           """).setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
       }
       if (recordedRequest.getPath().matches("/user-tenants.*")) {
-        return new MockResponse().setBody("{\"userTenants\": [], \"totalRecords\": 0}").setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+        return new MockResponse().setBody("{\"userTenants\": [], \"totalRecords\": 0}")
+            .setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
       }
       throw new RuntimeException("Unexpected request: " + recordedRequest.getPath());
     }

--- a/src/test/java/org/folio/fqm/service/PermissionsRegularServiceTest.java
+++ b/src/test/java/org/folio/fqm/service/PermissionsRegularServiceTest.java
@@ -7,24 +7,20 @@ import static org.mockito.Mockito.*;
 
 import java.util.*;
 
-import org.folio.fqm.client.ModPermissionsClient;
 import org.folio.fqm.client.ModRolesKeycloakClient;
 import org.folio.fqm.exception.MissingPermissionsException;
 import org.folio.querytool.domain.dto.EntityType;
 import org.folio.querytool.domain.dto.EntityTypeSource;
 import org.folio.spring.FolioExecutionContext;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 
 class PermissionsRegularServiceTest {
 
   private final FolioExecutionContext context = mock(FolioExecutionContext.class);
-  private final ModPermissionsClient modPermissionsClient = mock(ModPermissionsClient.class);
   private final ModRolesKeycloakClient modRolesKeycloakClient = mock(ModRolesKeycloakClient.class);
   private final EntityTypeFlatteningService entityTypeFlatteningService = mock(EntityTypeFlatteningService.class);
   private final PermissionsRegularService permissionsService = new PermissionsRegularService(
     context,
-    modPermissionsClient,
     modRolesKeycloakClient,
     entityTypeFlatteningService
   );
@@ -32,17 +28,10 @@ class PermissionsRegularServiceTest {
   private static final UUID USER_ID = UUID.randomUUID();
 
   void setUpMocks(String... permissions) {
-
     when(context.getUserId()).thenReturn(USER_ID);
     when(context.getTenantId()).thenReturn(TENANT_ID);
-
-    if (permissionsService.isEureka) {
-      when(modRolesKeycloakClient.getPermissionsUser(TENANT_ID, USER_ID))
-        .thenReturn(new ModRolesKeycloakClient.UserPermissions(List.of(permissions), USER_ID));
-    } else {
-      when(modPermissionsClient.getPermissionsForUser(TENANT_ID, USER_ID.toString()))
-        .thenReturn(new ModPermissionsClient.UserPermissions(List.of(permissions), permissions.length));
-    }
+    when(modRolesKeycloakClient.getPermissionsUser(TENANT_ID, USER_ID))
+      .thenReturn(new ModRolesKeycloakClient.UserPermissions(List.of(permissions), USER_ID));
   }
 
 
@@ -142,31 +131,12 @@ class PermissionsRegularServiceTest {
   }
 
   @Test
-  void WhenEurekaIsTrue() {
-    permissionsService.isEureka = true;
+  void shouldCheckPermissionsUser() {
     setUpMocks("permission1", "permission2");
     Set<String> userPermissions = permissionsService.getUserPermissions();
 
-    ArgumentCaptor<UUID> userIdCaptor = ArgumentCaptor.forClass(UUID.class);
-    verify(modRolesKeycloakClient).getPermissionsUser(eq(TENANT_ID), userIdCaptor.capture());
+    verify(modRolesKeycloakClient).getPermissionsUser(TENANT_ID, USER_ID);
     assertEquals(2, userPermissions.size());
-
-    // Ensure no interactions with modPermissionsClient
-    verifyNoInteractions(modPermissionsClient);
-  }
-
-  @Test
-  void WhenEurekaIsFalse() {
-    permissionsService.isEureka = false;
-    setUpMocks("permission1", "permission2");
-    Set<String> userPermissions = permissionsService.getUserPermissions();
-
-    ArgumentCaptor<String> userIdCaptor = ArgumentCaptor.forClass(String.class);
-    verify(modPermissionsClient).getPermissionsForUser(eq(TENANT_ID), userIdCaptor.capture());
-    assertEquals(2, userPermissions.size());
-
-    // Ensure no interactions with modRolesKeyclockClient
-    verifyNoInteractions(modRolesKeycloakClient);
   }
 
 }


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODFQMMGR-784

## Purpose
From Sunflower on FOLIO supports only Eureka based installations: https://folio-org.atlassian.net/wiki/spaces/TC/pages/860061701/DR-000041+-+Eureka+Adoption

## Approach
Remove the mod-fqm-manager environment variable IS_EUREKA defaulting to false.

Remove non-Eureka functionality.

Use Eureka functionality by default.

## Learning
Don't require sysops to configure something that should be the default.

## Pre-Merge Checklist

If you are adding entity type(s), have you:
- n/a Added the JSON5 definition to the `src/main/resources/entity-types` directory?
- n/a Ensured that GETing the entity type at `/entity-types/{id}` works as expected?
- n/a Added translations for all fields, per the [translation guidelines](/translations/README.md)? (Check this by ensuring `GET /entity-types/{id}` does not have `mod-fqm-manager.entityType.` in the response)
- n/a Added views to liquibase, as applicable?
- n/a Added required interfaces to the module descriptor?
- n/a Checked that querying fields works correctly and all SQL is valid?

If you are changing/removing entity type(s), have you:
- n/a Added migration code for any changes?