### PR TITLE
MODFQMMGR-412 Refactor how outdated queries are rejected

### DIFF
--- a/src/main/java/org/folio/fqm/migration/AbstractSimpleMigrationStrategy.java
+++ b/src/main/java/org/folio/fqm/migration/AbstractSimpleMigrationStrategy.java
@@ -1,46 +1,38 @@
 package org.folio.fqm.migration;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.UncheckedIOException;
+import lombok.extern.log4j.Log4j2;
+import org.folio.fql.service.FqlService;
+import org.folio.fqm.config.MigrationConfiguration;
+import org.folio.fqm.migration.warnings.*;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiFunction;
 import java.util.function.Function;
-import lombok.extern.log4j.Log4j2;
-import org.folio.fql.service.FqlService;
-import org.folio.fqm.config.MigrationConfiguration;
-import org.folio.fqm.migration.warnings.EntityTypeWarning;
-import org.folio.fqm.migration.warnings.FieldWarning;
-import org.folio.fqm.migration.warnings.QueryBreakingWarning;
-import org.folio.fqm.migration.warnings.RemovedEntityWarning;
-import org.folio.fqm.migration.warnings.RemovedFieldWarning;
-import org.folio.fqm.migration.warnings.Warning;
 
 @Log4j2
 public abstract class AbstractSimpleMigrationStrategy implements MigrationStrategy {
 
   protected final ObjectMapper objectMapper = new ObjectMapper();
 
-  /** The version migrating FROM */
-  public abstract String getSourceVersion();
-
-  /** The version migrating TO */
-  public abstract String getTargetVersion();
-
-  /** The entity types that got a new UUID */
+  /**
+   * The entity types that got a new UUID
+   */
   public Map<UUID, UUID> getEntityTypeChanges() {
     return Map.of();
   }
 
   /**
    * The fields that were renamed. Keys should use their OLD entity type ID, if applicable.
-   *
+   * <p>
    * The special key "*" on the field map can be used to apply a template to all fields. This value
    * should be a string with a %s placeholder, which will be filled in with the original field name.
    */
@@ -57,10 +49,10 @@ public abstract class AbstractSimpleMigrationStrategy implements MigrationStrate
 
   /**
    * The fields that were deprecated, removed, etc.
-   *
+   * <p>
    * ET keys should use their OLD entity type ID, if applicable.
    * Fields should use their OLD names, if applicable.
-   *
+   * <p>
    * The function will be given the field's name and FQL (if applicable), as a string
    */
   public Map<UUID, Map<String, BiFunction<String, String, FieldWarning>>> getFieldWarnings() {
@@ -68,95 +60,89 @@ public abstract class AbstractSimpleMigrationStrategy implements MigrationStrate
   }
 
   @Override
-  public boolean applies(String version) {
-    return this.getSourceVersion().equals(version);
-  }
-
-  @Override
   public MigratableQueryInformation apply(FqlService fqlService, MigratableQueryInformation src) {
-    try {
-      MigratableQueryInformation result = src;
-      Set<Warning> warnings = new HashSet<>(src.warnings());
+    MigratableQueryInformation result = src;
+    Set<Warning> warnings = new HashSet<>(src.warnings());
 
-      Optional<EntityTypeWarning> entityTypeWarning = Optional
-        .ofNullable(getEntityTypeWarnings().get(src.entityTypeId()))
-        .map(f -> f.apply(src.fqlQuery()));
-      if (entityTypeWarning.isPresent() && entityTypeWarning.get() instanceof RemovedEntityWarning) {
-        return MigratableQueryInformation
-          .builder()
-          .entityTypeId(MigrationConfiguration.REMOVED_ENTITY_TYPE_ID)
-          .fqlQuery(
-            objectMapper.writeValueAsString(Map.of(MigrationConfiguration.VERSION_KEY, this.getTargetVersion()))
-          )
-          .fields(List.of())
-          .warning(getEntityTypeWarnings().get(src.entityTypeId()).apply(src.fqlQuery()))
-          .build();
-      } else if (entityTypeWarning.isPresent()) {
-        warnings.add(entityTypeWarning.get());
-      }
-
-      if (src.fqlQuery() == null) {
-        result =
-          result.withFqlQuery(
-            objectMapper.writeValueAsString(Map.of(MigrationConfiguration.VERSION_KEY, this.getTargetVersion()))
-          );
-      }
-
-      result =
-        result.withEntityTypeId(this.getEntityTypeChanges().getOrDefault(src.entityTypeId(), src.entityTypeId()));
-
-      Map<String, String> fieldChanges = this.getFieldChanges().getOrDefault(src.entityTypeId(), Map.of());
-      Map<String, BiFunction<String, String, FieldWarning>> fieldWarnings =
-        this.getFieldWarnings().getOrDefault(src.entityTypeId(), Map.of());
-
-      String newFql = MigrationUtils.migrateFql(
-        result.fqlQuery(),
-        originalVersion -> this.getTargetVersion(),
-        (fql, key, value) -> {
-          if (fieldWarnings.containsKey(key)) {
-            FieldWarning warning = fieldWarnings.get(key).apply(key, value.toPrettyString());
-
-            warnings.add(warning);
-            if (warning instanceof RemovedFieldWarning || warning instanceof QueryBreakingWarning) {
-              return;
-            }
-          }
-          fql.set(getNewFieldName(fieldChanges, key), value);
-        }
-      );
-
-      if (!fieldChanges.isEmpty() || !fieldWarnings.isEmpty()) {
-        // map fields list
-        result =
-          result.withFields(
-            src
-              .fields()
-              .stream()
-              .map(f -> {
-                if (fieldWarnings.containsKey(f)) {
-                  Warning warning = fieldWarnings.get(f).apply(f, null);
-                  if (!(warning instanceof QueryBreakingWarning)) {
-                    warnings.add(warning);
-                  }
-                  if (warning instanceof RemovedFieldWarning) {
-                    return null;
-                  }
-                }
-                return getNewFieldName(fieldChanges, f);
-              })
-              .filter(f -> f != null)
-              .distinct()
-              .toList()
-          );
-      }
-
-      result = result.withFqlQuery(newFql);
-
-      return result.withWarnings(new ArrayList<>(warnings));
-    } catch (JsonProcessingException e) {
-      log.error("Failed to serialize FQL query", e);
-      throw new UncheckedIOException(e);
+    Optional<EntityTypeWarning> entityTypeWarning = Optional
+      .ofNullable(getEntityTypeWarnings().get(src.entityTypeId()))
+      .map(f -> f.apply(src.fqlQuery()));
+    if (entityTypeWarning.isPresent() && entityTypeWarning.get() instanceof RemovedEntityWarning) {
+      return MigratableQueryInformation
+        .builder()
+        .entityTypeId(MigrationConfiguration.REMOVED_ENTITY_TYPE_ID)
+        .fqlQuery("")
+        .fields(List.of())
+        .warning(getEntityTypeWarnings().get(src.entityTypeId()).apply(src.fqlQuery()))
+        .hadBreakingChanges(true)
+        .build();
+    } else if (entityTypeWarning.isPresent()) {
+      warnings.add(entityTypeWarning.get());
     }
+    if (this.getEntityTypeChanges().containsKey(src.entityTypeId())) {
+      result = result
+        .withEntityTypeId(this.getEntityTypeChanges().getOrDefault(src.entityTypeId(), src.entityTypeId()))
+        .withHadBreakingChanges(true);
+    }
+
+    Map<String, String> fieldChanges = this.getFieldChanges().getOrDefault(src.entityTypeId(), Map.of());
+    Map<String, BiFunction<String, String, FieldWarning>> fieldWarnings =
+      this.getFieldWarnings().getOrDefault(src.entityTypeId(), Map.of());
+
+    AtomicBoolean hadBreakingChanges = new AtomicBoolean(false);
+    String newFql = MigrationUtils.migrateFql(
+      result.fqlQuery(),
+      (fql, key, value) -> {
+        if (fieldWarnings.containsKey(key)) {
+          FieldWarning warning = fieldWarnings.get(key).apply(key, value.toPrettyString());
+
+          warnings.add(warning);
+          if (warning instanceof RemovedFieldWarning || warning instanceof QueryBreakingWarning) {
+            hadBreakingChanges.set(true);
+            return;
+          }
+        }
+        fql.set(getNewFieldName(fieldChanges, key), value);
+      }
+    );
+
+    if (!fieldChanges.isEmpty() || !fieldWarnings.isEmpty()) {
+      // map fields list
+      result =
+        result.withFields(
+          src
+            .fields()
+            .stream()
+            .map(f -> {
+              if (fieldWarnings.containsKey(f)) {
+                Warning warning = fieldWarnings.get(f).apply(f, null);
+                if (!(warning instanceof QueryBreakingWarning)) {
+                  warnings.add(warning);
+                  hadBreakingChanges.set(true);
+                }
+                if (warning instanceof RemovedFieldWarning) {
+                  return null;
+                }
+              }
+              String newFieldName = getNewFieldName(fieldChanges, f);
+              if (!f.equals(newFieldName)) {
+                hadBreakingChanges.set(true);
+              }
+              return newFieldName;
+            })
+            .filter(Objects::nonNull)
+            .distinct()
+            .toList()
+        );
+    }
+
+    if (hadBreakingChanges.get()) {
+      result = result.withHadBreakingChanges(true);
+    }
+
+    result = result.withFqlQuery(newFql);
+
+    return result.withWarnings(new ArrayList<>(warnings));
   }
 
   protected static String getNewFieldName(Map<String, String> fieldChanges, String oldFieldName) {

--- a/src/main/java/org/folio/fqm/migration/MigratableQueryInformation.java
+++ b/src/main/java/org/folio/fqm/migration/MigratableQueryInformation.java
@@ -14,9 +14,11 @@ public record MigratableQueryInformation(
   UUID entityTypeId,
   @CheckForNull String fqlQuery,
   List<String> fields,
-  @Singular List<Warning> warnings
+  @Singular List<Warning> warnings,
+  String version,
+  boolean hadBreakingChanges
 ) {
   public MigratableQueryInformation(UUID entityTypeId, String fqlQuery, List<String> fields) {
-    this(entityTypeId, fqlQuery, fields, List.of());
+    this(entityTypeId, fqlQuery, fields, List.of(), null, false);
   }
 }

--- a/src/main/java/org/folio/fqm/migration/MigrationStrategy.java
+++ b/src/main/java/org/folio/fqm/migration/MigrationStrategy.java
@@ -9,15 +9,22 @@ public interface MigrationStrategy
   /** For logging purposes */
   String getLabel();
 
+  /** Get the version after which this migration doesn't apply.
+   * If the current version &gt; this value, then the migration can be skipped
+   */
+  String getMaximumApplicableVersion();
+
   /**
    * Determine if a query should be migrated by this strategy (if this strategy "applies" to a query)
    */
-  boolean applies(@Nonnull String version);
+  default boolean applies(@Nonnull MigratableQueryInformation migratableQueryInformation) {
+    return true;
+  }
 
   /**
-   * Migrate the query. This method will be called iff {@link #applies(FqlService, MigratableQueryInformation)} returns true.
+   * Migrate the query. This method will be called iff {@link #applies(MigratableQueryInformation)} returns true.
    *
-   * After this method is called, {@link #applies(FqlService, MigratableQueryInformation)} MUST return false. Otherwise, an infinite
+   * After this method is called, {@link #applies(MigratableQueryInformation)} MUST return false. Otherwise, an infinite
    * loop will occur.
    */
   @Override // respecified to add docblock

--- a/src/main/java/org/folio/fqm/migration/MigrationUtils.java
+++ b/src/main/java/org/folio/fqm/migration/MigrationUtils.java
@@ -9,10 +9,12 @@ import com.fasterxml.jackson.databind.node.TextNode;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
+import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
+import java.util.regex.Pattern;
+
 import lombok.experimental.UtilityClass;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.function.TriConsumer;
@@ -30,28 +32,15 @@ public class MigrationUtils {
    * details on the field transformation function.
    *
    * @param fqlQuery The root query to migrate
-   * @param versionTransformer A function that takes the current (potentially null) version and
-   *                           returns the new one to be persisted in the query
-   * @param handler something that takes the result node, the field name, and the field's query object,
-   *                applies some transformation, and stores the results back in result
+   * @param handler  something that takes the result node, the field name, and the field's query object,
+   *                 applies some transformation, and stores the results back in result
    */
   public static String migrateFql(
     String fqlQuery,
-    UnaryOperator<String> versionTransformer,
     TriConsumer<ObjectNode, String, JsonNode> handler
   ) {
     try {
       ObjectNode fql = (ObjectNode) objectMapper.readTree(fqlQuery);
-
-      fql.set(
-        MigrationConfiguration.VERSION_KEY,
-        objectMapper.valueToTree(
-          versionTransformer.apply(
-            Optional.ofNullable(fql.get(MigrationConfiguration.VERSION_KEY)).map(JsonNode::asText).orElse(null)
-          )
-        )
-      );
-
       fql = migrateFqlTree(fql, handler);
 
       return objectMapper.writeValueAsString(fql);
@@ -65,12 +54,12 @@ public class MigrationUtils {
    * Call `handler` for each field in the FQL query tree, returning a new tree.
    * Note that `handler` is responsible for inserting what should be left in the tree, if anything;
    * if the function is a no-op, an empty FQL tree will be returned.
-   *
+   * <p>
    * A true "no-op" here would look like (result, key, value) -> result.set(key, value).
-   *
+   * <p>
    * This conveniently handles `$and`s, allowing logic to be handled on fields only.
    *
-   * @param fql the fql node
+   * @param fql     the fql node
    * @param handler something that takes the result node, the field name, and the field's query object,
    *                applies some transformation, and stores the results back in result
    * @return
@@ -108,14 +97,12 @@ public class MigrationUtils {
    * Helper function to transform values in an FQL query. This changes a version to a new one, and
    * runs a given function on each value in the query. Returning `null` from the transformation
    * function will result in the value being removed from the query.
-   *
-   * This is similar to {@link #migrateFql(String, UnaryOperator, TriConsumer)}, but operates on
+   * <p>
+   * This is similar to {@link #migrateFql(String, TriConsumer)}, but operates on
    * each value, and provides additional convenience to handle cases of array values, etc.
    *
-   * @param fqlQuery The root query to migrate
-   * @param versionTransformer A function that takes the current (potentially null) version and
-   *                           returns the new one to be persisted in the query
-   * @param applies If the valueTransformer should be applied to the field (for optimization)
+   * @param fqlQuery         The root query to migrate
+   * @param applies          If the valueTransformer should be applied to the field (for optimization)
    * @param valueTransformer Something that takes an incoming field name, value, and a supplier
    *                         (to get the original fql for warnings), returning either the
    *                         transformed value, or `null` if it should be removed (the transformer
@@ -123,13 +110,11 @@ public class MigrationUtils {
    */
   public static String migrateFqlValues(
     String fqlQuery,
-    UnaryOperator<String> versionTransformer,
     Predicate<String> applies,
     ValueTransformer valueTransformer
   ) {
     return migrateFql(
       fqlQuery,
-      versionTransformer,
       (result, key, value) -> {
         if (!applies.test(key)) {
           result.set(key, value); // no-op
@@ -211,5 +196,53 @@ public class MigrationUtils {
   @FunctionalInterface
   public interface ValueTransformer {
     String apply(String key, String value, Supplier<String> fql);
+  }
+
+  // Formatting note: This object is down here instead of at the top of the class because it is only used in
+  // compareVersions() and is a static field only because Patterns are expensive to construct.
+  private static final Pattern NUMBER_PATTERN = Pattern.compile("^\\d+$");
+
+  /**
+   * Compare two version strings, following the standard compareTo() semantics.
+   *
+   * <p/>A version can be separated into pieces by dots ("."), which are handled independently.
+   * If the same part in both versions is an integer, they are compared numerically.
+   * If at least one of them is not an integer, they are compared lexicographically as strings.
+   *
+   * <p/>Null versions or version pieces are treated as "0"
+   * This means "1" and "1.0" are considered equal versions.
+   *
+   * <p/>Examples:
+   * <ul>
+   *   <li>1 < 2</li>
+   *   <li>1.1 > 1</li>
+   *   <li>1.0.0 == 1</li>
+   *   <li>1.000 = 1</li>
+   *   <li>2.0 > 1.9.9.9</li>
+   *   <li>alpha < beta</li>
+   *   <li>1.something > 1.0</li>
+   * </ul>
+   */
+  public static int compareVersions(String version1, String version2) {
+    // Basic algorithm:
+    // 1. Base case: Versions are equal, so return immediately
+    // 2. Otherwise, look at the first version piece and compare them
+    // 3. If they are different, return immediately
+    // 4. Otherwise, recurse with the remaining portion of the versions
+    version1 = Objects.requireNonNullElse(version1, "0");
+    version2 = Objects.requireNonNullElse(version2, "0");
+    if (version1.equals(version2)) {
+      return 0;
+    }
+    String[] version1Parts = version1.split("\\.", 2);
+    String[] version2Parts = version2.split("\\.", 2);
+    int result = NUMBER_PATTERN.matcher(version1Parts[0]).matches() && NUMBER_PATTERN.matcher(version2Parts[0]).matches() // Are both of these ints?
+      ? Integer.compare(Integer.parseInt(version1Parts[0]), Integer.parseInt(version2Parts[0])) // Yep - compare as ints
+      : version1Parts[0].compareTo(version2Parts[0]); // Nope - compare as strings
+    if (result != 0) {
+      return result;
+    }
+    // If we got to here, then the current version parts are equal, so move on to the next set of parts
+    return compareVersions(version1Parts.length == 1 ? null : version1Parts[1], version2Parts.length == 1 ? null : version2Parts[1]);
   }
 }

--- a/src/main/java/org/folio/fqm/migration/strategies/V0POCMigration.java
+++ b/src/main/java/org/folio/fqm/migration/strategies/V0POCMigration.java
@@ -350,13 +350,8 @@ public class V0POCMigration extends AbstractSimpleMigrationStrategy {
   }
 
   @Override
-  public String getSourceVersion() {
+  public String getMaximumApplicableVersion() {
     return "0";
-  }
-
-  @Override
-  public String getTargetVersion() {
-    return "1";
   }
 
   @Override

--- a/src/main/java/org/folio/fqm/migration/strategies/V10OrganizationStatusValueChange.java
+++ b/src/main/java/org/folio/fqm/migration/strategies/V10OrganizationStatusValueChange.java
@@ -2,6 +2,7 @@ package org.folio.fqm.migration.strategies;
 
 import java.util.Map;
 import java.util.UUID;
+
 import lombok.extern.log4j.Log4j2;
 import org.folio.fql.service.FqlService;
 import org.folio.fqm.migration.MigratableQueryInformation;
@@ -18,9 +19,6 @@ import org.folio.fqm.migration.MigrationUtils;
 @Log4j2
 public class V10OrganizationStatusValueChange implements MigrationStrategy {
 
-  public static final String SOURCE_VERSION = "10";
-  public static final String TARGET_VERSION = "11";
-
   private static final UUID ORGANIZATIONS_ENTITY_TYPE_ID = UUID.fromString("b5ffa2e9-8080-471a-8003-a8c5a1274503");
   private static final String FIELD_NAME = "status";
 
@@ -31,13 +29,13 @@ public class V10OrganizationStatusValueChange implements MigrationStrategy {
   );
 
   @Override
-  public String getLabel() {
-    return "V10 -> V11 organization status value transformation (MODFQMMGR-602)";
+  public String getMaximumApplicableVersion() {
+    return "10";
   }
 
   @Override
-  public boolean applies(String version) {
-    return SOURCE_VERSION.equals(version);
+  public String getLabel() {
+    return "V10 -> V11 organization status value transformation (MODFQMMGR-602)";
   }
 
   @Override
@@ -45,7 +43,6 @@ public class V10OrganizationStatusValueChange implements MigrationStrategy {
     return query.withFqlQuery(
       MigrationUtils.migrateFqlValues(
         query.fqlQuery(),
-        originalVersion -> TARGET_VERSION,
         key -> ORGANIZATIONS_ENTITY_TYPE_ID.equals(query.entityTypeId()) && FIELD_NAME.equals(key),
         (key, value, fql) -> NEW_VALUES.getOrDefault(value, value)
       )

--- a/src/main/java/org/folio/fqm/migration/strategies/V11OrganizationNameCodeOperatorChange.java
+++ b/src/main/java/org/folio/fqm/migration/strategies/V11OrganizationNameCodeOperatorChange.java
@@ -37,23 +37,21 @@ import org.folio.fqm.migration.warnings.Warning;
 @RequiredArgsConstructor
 public class V11OrganizationNameCodeOperatorChange implements MigrationStrategy {
 
-  public static final String SOURCE_VERSION = "11";
-  public static final String TARGET_VERSION = "12";
-
   private static final UUID ORGANIZATIONS_ENTITY_TYPE_ID = UUID.fromString("b5ffa2e9-8080-471a-8003-a8c5a1274503");
   private static final List<String> FIELD_NAMES = List.of("code", "name");
 
   private final ObjectMapper objectMapper = new ObjectMapper();
   private final OrganizationsClient organizationsClient;
 
+
   @Override
-  public String getLabel() {
-    return "V11 -> V12 Organizations name/code operator/value transformation (MODFQMMGR-606)";
+  public String getMaximumApplicableVersion() {
+    return "11";
   }
 
   @Override
-  public boolean applies(String version) {
-    return SOURCE_VERSION.equals(version);
+  public String getLabel() {
+    return "V11 -> V12 Organizations name/code operator/value transformation (MODFQMMGR-606)";
   }
 
   @Override
@@ -66,7 +64,6 @@ public class V11OrganizationNameCodeOperatorChange implements MigrationStrategy 
       .withFqlQuery(
         MigrationUtils.migrateFql(
           query.fqlQuery(),
-          originalVersion -> TARGET_VERSION,
           (result, key, value) -> {
             if (!ORGANIZATIONS_ENTITY_TYPE_ID.equals(query.entityTypeId()) || !FIELD_NAMES.contains(key)) {
               result.set(key, value); // no-op
@@ -141,6 +138,7 @@ public class V11OrganizationNameCodeOperatorChange implements MigrationStrategy 
           }
         )
       )
+      .withHadBreakingChanges(query.hadBreakingChanges() || !warnings.isEmpty())
       .withWarnings(warnings);
   }
 }

--- a/src/main/java/org/folio/fqm/migration/strategies/V12PurchaseOrderIdFieldRemoval.java
+++ b/src/main/java/org/folio/fqm/migration/strategies/V12PurchaseOrderIdFieldRemoval.java
@@ -30,13 +30,8 @@ public class V12PurchaseOrderIdFieldRemoval extends AbstractSimpleMigrationStrat
   }
 
   @Override
-  public String getSourceVersion() {
+  public String getMaximumApplicableVersion() {
     return "12";
-  }
-
-  @Override
-  public String getTargetVersion() {
-    return "13";
   }
 
   @Override

--- a/src/main/java/org/folio/fqm/migration/strategies/V13CustomFieldRename.java
+++ b/src/main/java/org/folio/fqm/migration/strategies/V13CustomFieldRename.java
@@ -36,9 +36,6 @@ import static org.jooq.impl.DSL.field;
 @RequiredArgsConstructor
 public class V13CustomFieldRename implements MigrationStrategy {
 
-  public static final String SOURCE_VERSION = "13";
-  public static final String TARGET_VERSION = "14";
-
   static final UUID USERS_ENTITY_TYPE_ID = UUID.fromString("ddc93926-d15a-4a45-9d9c-93eadc3d9bbf");
   static final String CUSTOM_FIELD_SOURCE_VIEW = "src_user_custom_fields"; // Only user entity type currently supports custom fields
 
@@ -48,13 +45,13 @@ public class V13CustomFieldRename implements MigrationStrategy {
   private final Map<String, List<Pair<String, String>>> tenantCustomFieldNamePairs = new ConcurrentHashMap<>();
 
   @Override
-  public String getLabel() {
-    return "V13 -> V14 Custom field renaming (MODFQMMGR-642)";
+  public String getMaximumApplicableVersion() {
+    return "13";
   }
 
   @Override
-  public boolean applies(String version) {
-    return SOURCE_VERSION.equals(version);
+  public String getLabel() {
+    return "V13 -> V14 Custom field renaming (MODFQMMGR-642)";
   }
 
   @Override
@@ -65,7 +62,6 @@ public class V13CustomFieldRename implements MigrationStrategy {
       .withFqlQuery(
         MigrationUtils.migrateFql(
           query.fqlQuery(),
-          originalVersion -> TARGET_VERSION,
           (result, key, value) -> {
             if (!USERS_ENTITY_TYPE_ID.equals(query.entityTypeId())) {
               result.set(key, value); // no-op
@@ -92,6 +88,7 @@ public class V13CustomFieldRename implements MigrationStrategy {
           .orElse(oldName)
         ).toList()
       )
+      .withHadBreakingChanges(query.hadBreakingChanges() || !warnings.isEmpty())
       .withWarnings(warnings);
   }
 

--- a/src/main/java/org/folio/fqm/migration/strategies/V14AlertsAndReportingCodesRemoval.java
+++ b/src/main/java/org/folio/fqm/migration/strategies/V14AlertsAndReportingCodesRemoval.java
@@ -28,13 +28,8 @@ public class V14AlertsAndReportingCodesRemoval extends AbstractSimpleMigrationSt
   }
 
   @Override
-  public String getSourceVersion() {
+  public String getMaximumApplicableVersion() {
     return "14";
-  }
-
-  @Override
-  public String getTargetVersion() {
-    return "15";
   }
 
   @Override

--- a/src/main/java/org/folio/fqm/migration/strategies/V1ModeOfIssuanceConsolidation.java
+++ b/src/main/java/org/folio/fqm/migration/strategies/V1ModeOfIssuanceConsolidation.java
@@ -18,13 +18,8 @@ public class V1ModeOfIssuanceConsolidation extends AbstractSimpleMigrationStrate
   }
 
   @Override
-  public String getSourceVersion() {
+  public String getMaximumApplicableVersion() {
     return "1";
-  }
-
-  @Override
-  public String getTargetVersion() {
-    return "2";
   }
 
   @Override

--- a/src/main/java/org/folio/fqm/migration/strategies/V2ResourceTypeConsolidation.java
+++ b/src/main/java/org/folio/fqm/migration/strategies/V2ResourceTypeConsolidation.java
@@ -18,13 +18,8 @@ public class V2ResourceTypeConsolidation extends AbstractSimpleMigrationStrategy
   }
 
   @Override
-  public String getSourceVersion() {
+  public String getMaximumApplicableVersion() {
     return "2";
-  }
-
-  @Override
-  public String getTargetVersion() {
-    return "3";
   }
 
   @Override

--- a/src/main/java/org/folio/fqm/migration/strategies/V3RamsonsFieldCleanup.java
+++ b/src/main/java/org/folio/fqm/migration/strategies/V3RamsonsFieldCleanup.java
@@ -28,13 +28,8 @@ public class V3RamsonsFieldCleanup extends AbstractSimpleMigrationStrategy {
   }
 
   @Override
-  public String getSourceVersion() {
+  public String getMaximumApplicableVersion() {
     return "3";
-  }
-
-  @Override
-  public String getTargetVersion() {
-    return "4";
   }
 
   @Override

--- a/src/main/java/org/folio/fqm/migration/strategies/V4DateFieldTimezoneAddition.java
+++ b/src/main/java/org/folio/fqm/migration/strategies/V4DateFieldTimezoneAddition.java
@@ -29,8 +29,10 @@ import org.folio.fqm.service.FqlToSqlConverterService;
 @RequiredArgsConstructor
 public class V4DateFieldTimezoneAddition implements MigrationStrategy {
 
-  public static final String SOURCE_VERSION = "4";
-  public static final String TARGET_VERSION = "5";
+  @Override
+  public String getMaximumApplicableVersion() {
+    return "4";
+  }
 
   // must snapshot this point in time, as the entity types stored within may change past this migration
   // these names are unique enough that we don't need a per-ET listing
@@ -91,11 +93,6 @@ public class V4DateFieldTimezoneAddition implements MigrationStrategy {
   }
 
   @Override
-  public boolean applies(String version) {
-    return SOURCE_VERSION.equals(version);
-  }
-
-  @Override
   public MigratableQueryInformation apply(FqlService fqlService, MigratableQueryInformation query) {
     // avoid initializing this if we don't actually need it
     AtomicReference<ZoneId> timezone = new AtomicReference<>();
@@ -103,7 +100,6 @@ public class V4DateFieldTimezoneAddition implements MigrationStrategy {
     return query.withFqlQuery(
       MigrationUtils.migrateFqlValues(
         query.fqlQuery(),
-        originalVersion -> TARGET_VERSION,
         DATE_FIELDS::contains,
         (String key, String value, Supplier<String> fql) -> {
           // no-op, we already have a time component

--- a/src/main/java/org/folio/fqm/migration/strategies/V6ModeOfIssuanceValueChange.java
+++ b/src/main/java/org/folio/fqm/migration/strategies/V6ModeOfIssuanceValueChange.java
@@ -30,22 +30,19 @@ import org.folio.fqm.migration.warnings.Warning;
 @RequiredArgsConstructor
 public class V6ModeOfIssuanceValueChange implements MigrationStrategy {
 
-  public static final String SOURCE_VERSION = "6";
-  public static final String TARGET_VERSION = "7";
-
   private static final UUID INSTANCES_ENTITY_TYPE_ID = UUID.fromString("6b08439b-4f8e-4468-8046-ea620f5cfb74");
   private static final String FIELD_NAME = "instance.mode_of_issuance_name";
 
   private final ModesOfIssuanceClient modesOfIssuanceClient;
 
   @Override
-  public String getLabel() {
-    return "V6 -> V7 mode of issuance value transformation (MODFQMMGR-602)";
+  public String getMaximumApplicableVersion() {
+    return "6";
   }
 
   @Override
-  public boolean applies(String version) {
-    return SOURCE_VERSION.equals(version);
+  public String getLabel() {
+    return "V6 -> V7 mode of issuance value transformation (MODFQMMGR-602)";
   }
 
   @Override
@@ -58,7 +55,6 @@ public class V6ModeOfIssuanceValueChange implements MigrationStrategy {
       .withFqlQuery(
         MigrationUtils.migrateFqlValues(
           query.fqlQuery(),
-          originalVersion -> TARGET_VERSION,
           key -> INSTANCES_ENTITY_TYPE_ID.equals(query.entityTypeId()) && FIELD_NAME.equals(key),
           (String key, String value, Supplier<String> fql) -> {
             if (modesOfIssuance.get() == null) {
@@ -89,6 +85,7 @@ public class V6ModeOfIssuanceValueChange implements MigrationStrategy {
           }
         )
       )
-      .withWarnings(warnings);
+      .withWarnings(warnings)
+      .withHadBreakingChanges(query.hadBreakingChanges() || !warnings.isEmpty());
   }
 }

--- a/src/main/java/org/folio/fqm/migration/strategies/V7PatronGroupsValueChange.java
+++ b/src/main/java/org/folio/fqm/migration/strategies/V7PatronGroupsValueChange.java
@@ -28,9 +28,6 @@ import org.folio.fqm.migration.warnings.Warning;
 @RequiredArgsConstructor
 public class V7PatronGroupsValueChange implements MigrationStrategy {
 
-  public static final String SOURCE_VERSION = "7";
-  public static final String TARGET_VERSION = "8";
-
   private static final UUID LOANS_ENTITY_TYPE_ID = UUID.fromString("d6729885-f2fb-4dc7-b7d0-a865a7f461e4");
   private static final UUID USERS_ENTITY_TYPE_ID = UUID.fromString("ddc93926-d15a-4a45-9d9c-93eadc3d9bbf");
   private static final String FIELD_NAME = "groups.group";
@@ -38,13 +35,13 @@ public class V7PatronGroupsValueChange implements MigrationStrategy {
   private final PatronGroupsClient patronGroupsClient;
 
   @Override
-  public String getLabel() {
-    return "V7 -> V8 patron group name value transformation (MODFQMMGR-602)";
+  public String getMaximumApplicableVersion() {
+    return "7";
   }
 
   @Override
-  public boolean applies(String version) {
-    return SOURCE_VERSION.equals(version);
+  public String getLabel() {
+    return "V7 -> V8 patron group name value transformation (MODFQMMGR-602)";
   }
 
   @Override
@@ -57,7 +54,6 @@ public class V7PatronGroupsValueChange implements MigrationStrategy {
       .withFqlQuery(
         MigrationUtils.migrateFqlValues(
           query.fqlQuery(),
-          originalVersion -> TARGET_VERSION,
           key ->
             (LOANS_ENTITY_TYPE_ID.equals(query.entityTypeId()) || USERS_ENTITY_TYPE_ID.equals(query.entityTypeId())) &&
             FIELD_NAME.equals(key),
@@ -90,6 +86,7 @@ public class V7PatronGroupsValueChange implements MigrationStrategy {
           }
         )
       )
+      .withHadBreakingChanges(query.hadBreakingChanges() || !warnings.isEmpty())
       .withWarnings(warnings);
   }
 }

--- a/src/main/java/org/folio/fqm/migration/strategies/V8LocationValueChange.java
+++ b/src/main/java/org/folio/fqm/migration/strategies/V8LocationValueChange.java
@@ -28,9 +28,6 @@ import org.folio.fqm.migration.warnings.Warning;
 @RequiredArgsConstructor
 public class V8LocationValueChange implements MigrationStrategy {
 
-  public static final String SOURCE_VERSION = "8";
-  public static final String TARGET_VERSION = "9";
-
   private static final UUID HOLDINGS_ENTITY_TYPE_ID = UUID.fromString("8418e512-feac-4a6a-a56d-9006aab31e33");
   private static final UUID ITEMS_ENTITY_TYPE_ID = UUID.fromString("d0213d22-32cf-490f-9196-d81c3c66e53f");
   private static final List<String> FIELD_NAMES = List.of(
@@ -42,13 +39,13 @@ public class V8LocationValueChange implements MigrationStrategy {
   private final LocationsClient locationsClient;
 
   @Override
-  public String getLabel() {
-    return "V8 -> V9 item and holdings location name value transformation (MODFQMMGR-602)";
+  public String getMaximumApplicableVersion() {
+    return "8";
   }
 
   @Override
-  public boolean applies(String version) {
-    return SOURCE_VERSION.equals(version);
+  public String getLabel() {
+    return "V8 -> V9 item and holdings location name value transformation (MODFQMMGR-602)";
   }
 
   @Override
@@ -61,7 +58,6 @@ public class V8LocationValueChange implements MigrationStrategy {
       .withFqlQuery(
         MigrationUtils.migrateFqlValues(
           query.fqlQuery(),
-          originalVersion -> TARGET_VERSION,
           key ->
             (
               HOLDINGS_ENTITY_TYPE_ID.equals(query.entityTypeId()) || ITEMS_ENTITY_TYPE_ID.equals(query.entityTypeId())
@@ -96,6 +92,7 @@ public class V8LocationValueChange implements MigrationStrategy {
           }
         )
       )
+      .withHadBreakingChanges(query.hadBreakingChanges() || !warnings.isEmpty())
       .withWarnings(warnings);
   }
 }

--- a/src/main/java/org/folio/fqm/migration/strategies/V9LocLibraryValueChange.java
+++ b/src/main/java/org/folio/fqm/migration/strategies/V9LocLibraryValueChange.java
@@ -28,22 +28,19 @@ import org.folio.fqm.migration.warnings.Warning;
 @RequiredArgsConstructor
 public class V9LocLibraryValueChange implements MigrationStrategy {
 
-  public static final String SOURCE_VERSION = "9";
-  public static final String TARGET_VERSION = "10";
-
   private static final UUID HOLDINGS_ENTITY_TYPE_ID = UUID.fromString("8418e512-feac-4a6a-a56d-9006aab31e33");
   private static final List<String> FIELD_NAMES = List.of("effective_library.code", "effective_library.name");
 
   private final LocationUnitsClient locationUnitsClient;
 
   @Override
-  public String getLabel() {
-    return "V9 -> V10 holdings effective library name/code value transformation (MODFQMMGR-602)";
+  public String getMaximumApplicableVersion() {
+    return "9";
   }
 
   @Override
-  public boolean applies(String version) {
-    return SOURCE_VERSION.equals(version);
+  public String getLabel() {
+    return "V9 -> V10 holdings effective library name/code value transformation (MODFQMMGR-602)";
   }
 
   @Override
@@ -56,7 +53,6 @@ public class V9LocLibraryValueChange implements MigrationStrategy {
       .withFqlQuery(
         MigrationUtils.migrateFqlValues(
           query.fqlQuery(),
-          originalVersion -> TARGET_VERSION,
           key -> HOLDINGS_ENTITY_TYPE_ID.equals(query.entityTypeId()) && FIELD_NAMES.contains(key),
           (String key, String value, Supplier<String> fql) -> {
             if (records.get() == null) {
@@ -99,6 +95,7 @@ public class V9LocLibraryValueChange implements MigrationStrategy {
           }
         )
       )
+      .withHadBreakingChanges(query.hadBreakingChanges() || !warnings.isEmpty())
       .withWarnings(warnings);
   }
 }

--- a/src/test/java/org/folio/fqm/migration/AbstractSimpleMigrationStrategyTest.java
+++ b/src/test/java/org/folio/fqm/migration/AbstractSimpleMigrationStrategyTest.java
@@ -58,13 +58,8 @@ class AbstractSimpleMigrationStrategyTest {
     }
 
     @Override
-    public String getSourceVersion() {
+    public String getMaximumApplicableVersion() {
       return "source";
-    }
-
-    @Override
-    public String getTargetVersion() {
-      return "target";
     }
 
     @Override
@@ -104,34 +99,18 @@ class AbstractSimpleMigrationStrategyTest {
     }
   }
 
-  static List<Arguments> sourcesWithShouldApply() {
-    return List.of(
-      Arguments.of("", false),
-      Arguments.of("0", false),
-      Arguments.of("1", false),
-      Arguments.of("-1", false),
-      Arguments.of("source", true)
-    );
-  }
-
-  @ParameterizedTest(name = "{0} applies={1}")
-  @MethodSource("sourcesWithShouldApply")
-  void testAppliesToMatchingVersions(String version, boolean shouldApply) {
-    assertThat(new Impl().applies(version), is(shouldApply));
-  }
-
   static List<Arguments> sourcesForMigrationResults() {
     return List.of(
       // ET change, no FQL changes
       Arguments.of(
         new MigratableQueryInformation(
           UUID_A,
-          "{\"_version\":\"source\",\"test\":{\"$eq\":\"foo\"}}",
+          "{\"_version\":\"version\",\"test\":{\"$eq\":\"foo\"}}",
           List.of("unrelated", "foo", "also_unrelated")
         ),
         new MigratableQueryInformation(
           UUID_B,
-          "{\"_version\":\"target\",\"test\":{\"$eq\":\"foo\"}}",
+          "{\"_version\":\"version\",\"test\":{\"$eq\":\"foo\"}}",
           List.of("unrelated", "bar", "also_unrelated")
         )
       ),
@@ -139,12 +118,12 @@ class AbstractSimpleMigrationStrategyTest {
       Arguments.of(
         new MigratableQueryInformation(
           UUID_A,
-          "{\"_version\":\"source\",\"foo\":{\"$eq\":\"foo\"}}",
+          "{\"_version\":\"version\",\"foo\":{\"$eq\":\"foo\"}}",
           List.of("unrelated", "foo", "also_unrelated")
         ),
         new MigratableQueryInformation(
           UUID_B,
-          "{\"_version\":\"target\",\"bar\":{\"$eq\":\"foo\"}}",
+          "{\"_version\":\"version\",\"bar\":{\"$eq\":\"foo\"}}",
           List.of("unrelated", "bar", "also_unrelated")
         )
       ),
@@ -153,7 +132,7 @@ class AbstractSimpleMigrationStrategyTest {
         new MigratableQueryInformation(
           UUID_A,
           """
-          {"_version":"source","$and":[
+          {"_version":"version","$and":[
             {"field1": {"$eq": true}},
             {"field2": {"$lte": 3}}
           ]}
@@ -163,7 +142,7 @@ class AbstractSimpleMigrationStrategyTest {
         new MigratableQueryInformation(
           UUID_B,
           """
-          {"_version":"target","$and":[
+          {"_version":"version","$and":[
             {"field1": {"$eq": true}},
             {"field2": {"$lte": 3}}
           ]}
@@ -176,7 +155,7 @@ class AbstractSimpleMigrationStrategyTest {
         new MigratableQueryInformation(
           UUID_A,
           """
-          {"_version":"source","$and":[
+          {"_version":"version","$and":[
             {"field1": {"$eq": true}},
             {"$and": [
               {"field2": {"$gte": 2}},
@@ -190,7 +169,7 @@ class AbstractSimpleMigrationStrategyTest {
         new MigratableQueryInformation(
           UUID_B,
           """
-          {"_version":"target","$and":[
+          {"_version":"version","$and":[
             {"field1": {"$eq": true}},
             {"$and": [
               {"field2": {"$gte": 2}},
@@ -206,12 +185,12 @@ class AbstractSimpleMigrationStrategyTest {
       Arguments.of(
         new MigratableQueryInformation(
           UUID_C,
-          "{\"_version\":\"source\",\"foo\":{\"$eq\":\"foo\"}}",
+          "{\"_version\":\"version\",\"foo\":{\"$eq\":\"foo\"}}",
           List.of("unrelated", "foo", "also_unrelated")
         ),
         new MigratableQueryInformation(
           UUID_D,
-          "{\"_version\":\"target\",\"foo\":{\"$eq\":\"foo\"}}",
+          "{\"_version\":\"version\",\"foo\":{\"$eq\":\"foo\"}}",
           List.of("unrelated", "foo", "also_unrelated")
         )
       ),
@@ -219,12 +198,12 @@ class AbstractSimpleMigrationStrategyTest {
       Arguments.of(
         new MigratableQueryInformation(
           UUID_E,
-          "{\"_version\":\"source\",\"foo\":{\"$eq\":\"foo\"}}",
+          "{\"_version\":\"version\",\"foo\":{\"$eq\":\"foo\"}}",
           List.of("unrelated", "foo", "also_unrelated")
         ),
         new MigratableQueryInformation(
           UUID_E,
-          "{\"_version\":\"target\",\"bar\":{\"$eq\":\"foo\"}}",
+          "{\"_version\":\"version\",\"bar\":{\"$eq\":\"foo\"}}",
           List.of("unrelated", "bar", "also_unrelated")
         )
       ),
@@ -232,12 +211,12 @@ class AbstractSimpleMigrationStrategyTest {
       Arguments.of(
         new MigratableQueryInformation(
           UUID_F,
-          "{\"_version\":\"source\",\"foo\":{\"$eq\":\"foo\"}}",
+          "{\"_version\":\"version\",\"foo\":{\"$eq\":\"foo\"}}",
           List.of("field1", "foo", "field2")
         ),
         new MigratableQueryInformation(
           UUID_F,
-          "{\"_version\":\"target\",\"bar.foo\":{\"$eq\":\"foo\"}}",
+          "{\"_version\":\"version\",\"bar.foo\":{\"$eq\":\"foo\"}}",
           List.of("bar.field1", "bar.foo", "bar.field2")
         )
       ),
@@ -245,12 +224,12 @@ class AbstractSimpleMigrationStrategyTest {
       Arguments.of(
         new MigratableQueryInformation(
           UUID_0,
-          "{\"_version\":\"source\",\"foo\":{\"$eq\":\"foo\"}}",
+          "{\"_version\":\"version\",\"foo\":{\"$eq\":\"foo\"}}",
           List.of("field1", "foo", "field2")
         ),
         new MigratableQueryInformation(
           UUID_0,
-          "{\"_version\":\"target\",\"foo\":{\"$eq\":\"foo\"}}",
+          "{\"_version\":\"version\",\"foo\":{\"$eq\":\"foo\"}}",
           List.of("field1", "foo", "field2")
         )
       ),
@@ -258,30 +237,34 @@ class AbstractSimpleMigrationStrategyTest {
       Arguments.of(
         new MigratableQueryInformation(
           UUID_0A,
-          "{\"_version\":\"source\",\"foo\":{\"$eq\":\"foo\"}}",
+          "{\"_version\":\"version\",\"foo\":{\"$eq\":\"foo\"}}",
           List.of("field1", "foo", "field2")
         ),
         new MigratableQueryInformation(
           UUID_0A,
-          "{\"_version\":\"target\",\"foo\":{\"$eq\":\"foo\"}}",
+          "{\"_version\":\"version\",\"foo\":{\"$eq\":\"foo\"}}",
           List.of("field1", "foo", "field2"),
-          List.of(DeprecatedEntityWarning.withoutAlternative("0a").apply(null))
+          List.of(DeprecatedEntityWarning.withoutAlternative("0a").apply(null)),
+          null,
+          false
         )
       ),
       // Removed ET
       Arguments.of(
         new MigratableQueryInformation(
           UUID_0B,
-          "{\"_version\":\"source\",\"foo\":{\"$eq\":\"foo\"}}",
+          "{\"_version\":\"version\",\"foo\":{\"$eq\":\"foo\"}}",
           List.of("field1", "foo", "field2")
         ),
         new MigratableQueryInformation(
           MigrationConfiguration.REMOVED_ENTITY_TYPE_ID,
-          "{\"_version\":\"target\"}",
+          "",
           List.of(),
           List.of(
-            RemovedEntityWarning.withoutAlternative("0b").apply("{\"_version\":\"source\",\"foo\":{\"$eq\":\"foo\"}}")
-          )
+            RemovedEntityWarning.withoutAlternative("0b").apply("{\"_version\":\"version\",\"foo\":{\"$eq\":\"foo\"}}")
+          ),
+          null,
+          true
         )
       ),
       // field-level warnings
@@ -289,7 +272,7 @@ class AbstractSimpleMigrationStrategyTest {
         new MigratableQueryInformation(
           UUID_0C,
           """
-          {"_version":"source","$and":[
+          {"_version":"version","$and":[
             {"unrelated": {"$eq": true}},
             {"removed": {"$lte": 3}},
             {"deprecated": {"$lte": 2}},
@@ -301,7 +284,7 @@ class AbstractSimpleMigrationStrategyTest {
         new MigratableQueryInformation(
           UUID_0C,
           """
-          {"_version":"target","$and":[
+          {"_version":"version","$and":[
             {"unrelated": {"$eq": true}},
             {"deprecated": {"$lte": 2}}
           ]}
@@ -313,7 +296,9 @@ class AbstractSimpleMigrationStrategyTest {
             QueryBreakingWarning.withAlternative("alt").apply("query_breaking", "{\n  \"$ne\" : 2\n}"),
             RemovedFieldWarning.withAlternative("alt").apply("removed", "{\n  \"$lte\" : 3\n}"),
             RemovedFieldWarning.withAlternative("alt").apply("removed", null)
-          )
+          ),
+          null,
+          false
         )
       ),
       // removed top-level query field
@@ -322,7 +307,7 @@ class AbstractSimpleMigrationStrategyTest {
           UUID_0C,
           """
           {
-            "_version":"source",
+            "_version":"version",
             "query_breaking": {"$ne": 2}
           }
           """,
@@ -330,9 +315,11 @@ class AbstractSimpleMigrationStrategyTest {
         ),
         new MigratableQueryInformation(
           UUID_0C,
-          "{\"_version\":\"target\"}",
+          "{\"_version\":\"version\"}",
           List.of("query_breaking"),
-          List.of(QueryBreakingWarning.withAlternative("alt").apply("query_breaking", "{\n  \"$ne\" : 2\n}"))
+          List.of(QueryBreakingWarning.withAlternative("alt").apply("query_breaking", "{\n  \"$ne\" : 2\n}")),
+          null,
+          false
         )
       )
     );

--- a/src/test/java/org/folio/fqm/migration/MigrationUtilsValuesTest.java
+++ b/src/test/java/org/folio/fqm/migration/MigrationUtilsValuesTest.java
@@ -160,8 +160,7 @@ class MigrationUtilsValuesTest {
 
     String actualQuery = MigrationUtils.migrateFqlValues(
       query,
-      v -> "1",
-      predicate,
+        predicate,
       (String key, String value, Supplier<String> fql) -> {
         assertThat(key, is(notNullValue()));
         assertThat(value, is(notNullValue()));
@@ -219,8 +218,7 @@ class MigrationUtilsValuesTest {
 
     String actualQuery = MigrationUtils.migrateFqlValues(
       originalQuery,
-      v -> "1",
-      k -> !k.equals("do-not-touch"),
+        k -> !k.equals("do-not-touch"),
       (String key, String value, Supplier<String> fql) -> "keep-me".equals(value) ? value : null
     );
 

--- a/src/test/java/org/folio/fqm/migration/strategies/V0POCMigrationTest.java
+++ b/src/test/java/org/folio/fqm/migration/strategies/V0POCMigrationTest.java
@@ -64,7 +64,7 @@ class V0POCMigrationTest extends TestTemplate {
           .builder()
           .entityTypeId(UUID.fromString("d0213d22-32cf-490f-9196-d81c3c66e53f"))
           .fqlQuery(
-            "{\"_version\":\"1\",\"items.status_name\":{\"$in\":[\"missing\",\"aged to lost\",\"claimed returned\",\"declared lost\",\"long missing\"]}}"
+            "{\"items.status_name\":{\"$in\":[\"missing\",\"aged to lost\",\"claimed returned\",\"declared lost\",\"long missing\"]}}"
           )
           .fields(
             List.of(
@@ -136,7 +136,7 @@ class V0POCMigrationTest extends TestTemplate {
           .builder()
           .entityTypeId(UUID.fromString("d6729885-f2fb-4dc7-b7d0-a865a7f461e4"))
           .fqlQuery(
-            "{\"_version\":\"1\",\"$and\":[{\"loans.status_name\":{\"$eq\":\"Open\"}},{\"users.active\":{\"$eq\":\"false\"}}]}"
+            "{\"$and\":[{\"loans.status_name\":{\"$eq\":\"Open\"}},{\"users.active\":{\"$eq\":\"false\"}}]}"
           )
           .fields(
             List.of(

--- a/src/test/java/org/folio/fqm/migration/strategies/V10OrganizationStatusValueChangeTest.java
+++ b/src/test/java/org/folio/fqm/migration/strategies/V10OrganizationStatusValueChangeTest.java
@@ -27,7 +27,7 @@ class V10OrganizationStatusValueChangeTest extends TestTemplate {
         MigratableQueryInformation
           .builder()
           .entityTypeId(UUID.fromString("a9112682-958f-576c-b46c-d851abc62cd1"))
-          .fqlQuery("{\"status\": {\"$ne\": \"active\"}, \"_version\":\"11\"}")
+          .fqlQuery("{\"status\": {\"$ne\": \"active\"}}")
           .fields(List.of())
           .build()
       ),
@@ -54,7 +54,6 @@ class V10OrganizationStatusValueChangeTest extends TestTemplate {
           .fqlQuery(
             """
             {
-              "_version": "11",
               "$and": [
                 { "status": { "$eq": "Active" }},
                 { "status": { "$eq": "what" }},

--- a/src/test/java/org/folio/fqm/migration/strategies/V11OrganizationCodeOperatorChangeTest.java
+++ b/src/test/java/org/folio/fqm/migration/strategies/V11OrganizationCodeOperatorChangeTest.java
@@ -53,7 +53,7 @@ class V11OrganizationCodeOperatorChangeTest extends TestTemplate {
         MigratableQueryInformation
           .builder()
           .entityTypeId(UUID.fromString("a9112682-958f-576c-b46c-d851abc62cd1"))
-          .fqlQuery("{\"code\": {\"$ne\": \"active\"}, \"_version\":\"12\"}")
+          .fqlQuery("{\"code\": {\"$ne\": \"active\"}}")
           .fields(List.of())
           .build()
       ),
@@ -72,7 +72,7 @@ class V11OrganizationCodeOperatorChangeTest extends TestTemplate {
           .entityTypeId(UUID.fromString("b5ffa2e9-8080-471a-8003-a8c5a1274503"))
           .fqlQuery(
             """
-            { "_version": "12", "code": { "$eq": "id1" }, "name": { "$eq": "id1" } }
+            { "code": { "$eq": "id1" }, "name": { "$eq": "id1" } }
             """
           )
           .fields(List.of())
@@ -95,7 +95,7 @@ class V11OrganizationCodeOperatorChangeTest extends TestTemplate {
           .entityTypeId(UUID.fromString("b5ffa2e9-8080-471a-8003-a8c5a1274503"))
           .fqlQuery(
             """
-            { "_version": "12", "code": { "$ne": "id1", "$empty": true, "$unknown": 1234 } }
+            { "code": { "$ne": "id1", "$empty": true, "$unknown": 1234 } }
             """
           )
           .fields(List.of())
@@ -118,7 +118,7 @@ class V11OrganizationCodeOperatorChangeTest extends TestTemplate {
           .builder()
           .entityTypeId(UUID.fromString("b5ffa2e9-8080-471a-8003-a8c5a1274503"))
           .fqlQuery("""
-            { "ignore_me": { "$eq": "z" }, "_version": "12" }
+            { "ignore_me": { "$eq": "z" } }
             """)
           .fields(List.of())
           .warning(

--- a/src/test/java/org/folio/fqm/migration/strategies/V13CustomFieldRenameTest.java
+++ b/src/test/java/org/folio/fqm/migration/strategies/V13CustomFieldRenameTest.java
@@ -94,7 +94,7 @@ class V13CustomFieldRenameTest extends TestTemplate {
         MigratableQueryInformation
           .builder()
           .entityTypeId(UUID.fromString("a9112682-958f-576c-b46c-d851abc62cd1"))
-          .fqlQuery("{\"code\": {\"$ne\": \"active\"}, \"_version\":\"14\"}")
+          .fqlQuery("{\"code\": {\"$ne\": \"active\"}}")
           .fields(List.of())
           .build()
       ),
@@ -110,7 +110,7 @@ class V13CustomFieldRenameTest extends TestTemplate {
         MigratableQueryInformation
           .builder()
           .entityTypeId(UUID.fromString("ddc93926-d15a-4a45-9d9c-93eadc3d9bbf"))
-          .fqlQuery("{\"_custom_field_97ebe38d-4733-4631-b264-5d29f4f50b07\": {\"$ne\": \"active\"}, \"_version\":\"14\"}")
+          .fqlQuery("{\"_custom_field_97ebe38d-4733-4631-b264-5d29f4f50b07\": {\"$ne\": \"active\"}}")
           .fields(List.of())
           .build()
       ),
@@ -126,7 +126,7 @@ class V13CustomFieldRenameTest extends TestTemplate {
         MigratableQueryInformation
           .builder()
           .entityTypeId(UUID.fromString("ddc93926-d15a-4a45-9d9c-93eadc3d9bbf"))
-          .fqlQuery("{\"_custom_field_97ebe38d-4733-4631-b264-5d29f4f50b07\": {\"$in\": [\"active\", \"inactive\"]}, \"_version\":\"14\"}")
+          .fqlQuery("{\"_custom_field_97ebe38d-4733-4631-b264-5d29f4f50b07\": {\"$in\": [\"active\", \"inactive\"]}}")
           .fields(List.of())
           .build()
       ),
@@ -142,7 +142,7 @@ class V13CustomFieldRenameTest extends TestTemplate {
         MigratableQueryInformation
           .builder()
           .entityTypeId(UUID.fromString("ddc93926-d15a-4a45-9d9c-93eadc3d9bbf"))
-          .fqlQuery("{\"$and\": [{\"_custom_field_97ebe38d-4733-4631-b264-5d29f4f50b07\": {\"$ne\": \"val1\"}}, {\"not_a_custom_field\": {\"$ne\": \"val2\"}}, {\"_custom_field_48e035c3-d2fe-4575-b387-e7fdc07dde58\": {\"$eq\": \"val3\"}}], \"_version\":\"14\"}")
+          .fqlQuery("{\"$and\": [{\"_custom_field_97ebe38d-4733-4631-b264-5d29f4f50b07\": {\"$ne\": \"val1\"}}, {\"not_a_custom_field\": {\"$ne\": \"val2\"}}, {\"_custom_field_48e035c3-d2fe-4575-b387-e7fdc07dde58\": {\"$eq\": \"val3\"}}]}")
           .fields(List.of())
           .build()
       ),
@@ -158,7 +158,7 @@ class V13CustomFieldRenameTest extends TestTemplate {
         MigratableQueryInformation
           .builder()
           .entityTypeId(UUID.fromString("ddc93926-d15a-4a45-9d9c-93eadc3d9bbf"))
-          .fqlQuery("{\"not_a_custom_field\": {\"$in\": [\"active\", \"inactive\"]}, \"_version\":\"14\"}")
+          .fqlQuery("{\"not_a_custom_field\": {\"$in\": [\"active\", \"inactive\"]}}")
           .fields(List.of("not_a_custom_field", "_custom_field_97ebe38d-4733-4631-b264-5d29f4f50b07", "_custom_field_48e035c3-d2fe-4575-b387-e7fdc07dde58"))
           .build()
       )

--- a/src/test/java/org/folio/fqm/migration/strategies/V4DateFieldTimezoneAdditionTest.java
+++ b/src/test/java/org/folio/fqm/migration/strategies/V4DateFieldTimezoneAdditionTest.java
@@ -48,7 +48,7 @@ class V4DateFieldTimezoneAdditionTest extends TestTemplate {
         MigratableQueryInformation
           .builder()
           .entityTypeId(UUID.fromString("3ad4b672-a69c-5a80-b483-bbc77c29cbfd"))
-          .fqlQuery("{\"name\": {\"$eq\":\"foo\"}, \"_version\": \"5\"}")
+          .fqlQuery("{\"name\": {\"$eq\":\"foo\"}}")
           .fields(List.of())
           .build(),
         (Consumer<MigratableQueryInformation>) transformed -> verifyNoInteractions(configurationClient)
@@ -101,8 +101,7 @@ class V4DateFieldTimezoneAdditionTest extends TestTemplate {
               },
               "unrelated.field": {
                 "$contains": "2024-07-01"
-              },
-              "_version": "5"
+              }
             }
             """
           )

--- a/src/test/java/org/folio/fqm/migration/strategies/V5UUIDNotEqualOperatorRemovalTest.java
+++ b/src/test/java/org/folio/fqm/migration/strategies/V5UUIDNotEqualOperatorRemovalTest.java
@@ -28,7 +28,7 @@ class V5UUIDNotEqualOperatorRemovalTest extends TestTemplate {
         MigratableQueryInformation
           .builder()
           .entityTypeId(UUID.fromString("a9112682-958f-576c-b46c-d851abc62cd1"))
-          .fqlQuery("{\"users.id\": {\"$ne\": \"cf1baaa9-a55c-5ac7-bcbd-d27fbc477303\"},\"_version\":\"6\"}")
+          .fqlQuery("{\"users.id\": {\"$ne\": \"cf1baaa9-a55c-5ac7-bcbd-d27fbc477303\"}}")
           .fields(List.of())
           .build()
       ),
@@ -43,7 +43,7 @@ class V5UUIDNotEqualOperatorRemovalTest extends TestTemplate {
         MigratableQueryInformation
           .builder()
           .entityTypeId(UUID.fromString("ddc93926-d15a-4a45-9d9c-93eadc3d9bbf"))
-          .fqlQuery("{\"users.username\": {\"$ne\": \"admin\"},\"_version\":\"6\"}")
+          .fqlQuery("{\"users.username\": {\"$ne\": \"admin\"}}")
           .fields(List.of())
           .build()
       ),
@@ -58,7 +58,7 @@ class V5UUIDNotEqualOperatorRemovalTest extends TestTemplate {
         MigratableQueryInformation
           .builder()
           .entityTypeId(UUID.fromString("ddc93926-d15a-4a45-9d9c-93eadc3d9bbf"))
-          .fqlQuery("{\"_version\":\"6\"}")
+          .fqlQuery("{}")
           .fields(List.of())
           .warning(
             OperatorBreakingWarning
@@ -90,7 +90,7 @@ class V5UUIDNotEqualOperatorRemovalTest extends TestTemplate {
         MigratableQueryInformation
           .builder()
           .entityTypeId(UUID.fromString("ddc93926-d15a-4a45-9d9c-93eadc3d9bbf"))
-          .fqlQuery("{\"_version\": \"6\", \"users.id\": {\"$le\": \"ffffffff-a55c-5ac7-bcbd-d27fbc477303\"}}")
+          .fqlQuery("{\"users.id\": {\"$le\": \"ffffffff-a55c-5ac7-bcbd-d27fbc477303\"}}")
           .fields(List.of())
           .warning(
             OperatorBreakingWarning
@@ -130,7 +130,6 @@ class V5UUIDNotEqualOperatorRemovalTest extends TestTemplate {
           .fqlQuery(
             """
             {
-              "_version": "6",
               "groups.id": {
                 "$eq": "cf1baaa9-a55c-5ac7-bcbd-d27fbc477303"
               },

--- a/src/test/java/org/folio/fqm/migration/strategies/V6V7V8V9ValueChangeConsolidatedTest.java
+++ b/src/test/java/org/folio/fqm/migration/strategies/V6V7V8V9ValueChangeConsolidatedTest.java
@@ -27,6 +27,7 @@ import org.folio.fqm.client.PatronGroupsClient.PatronGroupsResponse;
 import org.folio.fqm.migration.MigratableQueryInformation;
 import org.folio.fqm.migration.MigrationStrategy;
 import org.folio.fqm.migration.warnings.ValueBreakingWarning;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.provider.Arguments;
@@ -87,7 +88,12 @@ class V6V7V8V9ValueChangeConsolidatedTest extends TestTemplate {
       }
 
       @Override
-      public boolean applies(String version) {
+      public String getMaximumApplicableVersion() {
+        return "source";
+      }
+
+      @Override
+      public boolean applies(@NotNull MigratableQueryInformation queryInformation) {
         throw new UnsupportedOperationException("Unimplemented method 'applies'");
       }
 
@@ -181,7 +187,7 @@ class V6V7V8V9ValueChangeConsolidatedTest extends TestTemplate {
               MigratableQueryInformation
                 .builder()
                 .entityTypeId(UUID.fromString(pair.getLeft()))
-                .fqlQuery("{\"" + pair.getRight() + "\": {\"$ne\": \"invalid\"}, \"_version\":\"10\"}")
+                .fqlQuery("{\"" + pair.getRight() + "\": {\"$ne\": \"invalid\"}}")
                 .fields(List.of())
                 .build(),
               (Consumer<MigratableQueryInformation>) (
@@ -221,8 +227,7 @@ class V6V7V8V9ValueChangeConsolidatedTest extends TestTemplate {
                       """
                       {
                         "%s": {"$ne": "name1"},
-                        "not_a_relevant_field": {"$ne": "id1"},
-                        "_version": "10"
+                        "not_a_relevant_field": {"$ne": "id1"}
                       }
                       """.formatted(
                           triple.getMiddle()
@@ -248,7 +253,7 @@ class V6V7V8V9ValueChangeConsolidatedTest extends TestTemplate {
                     .builder()
                     .entityTypeId(UUID.fromString(triple.getLeft()))
                     .fqlQuery(
-                      "{\"%s\": {\"$eq\": \"name1\", \"$ne\": \"name1\", \"$in\": [\"name2\"]}, \"_version\":\"10\"}".formatted(
+                      "{\"%s\": {\"$eq\": \"name1\", \"$ne\": \"name1\", \"$in\": [\"name2\"]}}".formatted(
                           triple.getMiddle()
                         )
                     )


### PR DESCRIPTION
This commit also refactors how FQM approaches migration versions, to be a bit simpler and easier to work with