### PR TITLE
MODFQMMGR-827 Add ET ID check when loading ETs

### DIFF
--- a/src/main/java/org/folio/fqm/exception/InvalidEntityTypeDefinitionException.java
+++ b/src/main/java/org/folio/fqm/exception/InvalidEntityTypeDefinitionException.java
@@ -20,6 +20,11 @@ public class InvalidEntityTypeDefinitionException extends FqmException {
     this.entityTypeId = entityType.getId();
   }
 
+  public InvalidEntityTypeDefinitionException(String message, EntityType entityType, Throwable cause) {
+    super(message, cause);
+    this.entityTypeId = entityType.getId();
+  }
+
   @Override
   public HttpStatus getHttpStatus() {
     return HttpStatus.INTERNAL_SERVER_ERROR;

--- a/src/test/java/org/folio/fqm/repository/EntityTypeRepositoryTest.java
+++ b/src/test/java/org/folio/fqm/repository/EntityTypeRepositoryTest.java
@@ -336,4 +336,21 @@ class EntityTypeRepositoryTest {
       repo.updateCustomEntityType(customEntityType));
   }
 
+  @Test
+  void throwIfEntityTypeInvalid_shouldThrowForInvalidId() {
+    EntityType invalidEntityType = new EntityType().id("not-a-uuid");
+    InvalidEntityTypeDefinitionException ex = assertThrows(
+      InvalidEntityTypeDefinitionException.class,
+      () -> EntityTypeRepository.throwIfEntityTypeInvalid(invalidEntityType)
+    );
+    assertTrue(ex.getMessage().contains("Invalid entity type ID"));
+    assertEquals("not-a-uuid", ex.getError().getParameters().get(0).getValue());
+  }
+
+  @Test
+  void throwIfEntityTypeInvalid_shouldNotThrowForValidId() {
+    EntityType validEntityType = new EntityType().id(UUID.randomUUID().toString());
+    assertDoesNotThrow(() -> EntityTypeRepository.throwIfEntityTypeInvalid(validEntityType));
+  }
+
 }


### PR DESCRIPTION
This check happens immediately after loading and parsing the ET, to ensure the ID is a valid UUID, as in invalid ID will cause issues later on