### PR TITLE
[MODFQMMGR-883] Migrate effective library fields for Items ET

### DIFF
--- a/src/main/java/org/folio/fqm/config/MigrationConfiguration.java
+++ b/src/main/java/org/folio/fqm/config/MigrationConfiguration.java
@@ -9,7 +9,7 @@ public class MigrationConfiguration {
   public static final String VERSION_KEY = "_version";
   public static final UUID REMOVED_ENTITY_TYPE_ID = UUID.fromString("deadbeef-dead-dead-dead-deaddeadbeef");
 
-  private static final String CURRENT_VERSION = "16";
+  private static final String CURRENT_VERSION = "17";
   // TODO: replace this with current version in the future?
   private static final String DEFAULT_VERSION = "0";
 

--- a/src/main/java/org/folio/fqm/migration/MigrationStrategyRepository.java
+++ b/src/main/java/org/folio/fqm/migration/MigrationStrategyRepository.java
@@ -12,6 +12,7 @@ import org.folio.fqm.migration.strategies.V10OrganizationStatusValueChange;
 import org.folio.fqm.migration.strategies.V11OrganizationNameCodeOperatorChange;
 import org.folio.fqm.migration.strategies.V12PurchaseOrderIdFieldRemoval;
 import org.folio.fqm.migration.strategies.V13CustomFieldRename;
+import org.folio.fqm.migration.strategies.V14ItemLocLibraryValueChange;
 import org.folio.fqm.migration.strategies.V1ModeOfIssuanceConsolidation;
 import org.folio.fqm.migration.strategies.V2ResourceTypeConsolidation;
 import org.folio.fqm.migration.strategies.V3RamsonsFieldCleanup;
@@ -21,8 +22,8 @@ import org.folio.fqm.migration.strategies.V6ModeOfIssuanceValueChange;
 import org.folio.fqm.migration.strategies.V7PatronGroupsValueChange;
 import org.folio.fqm.migration.strategies.V8LocationValueChange;
 import org.folio.fqm.migration.strategies.V9LocLibraryValueChange;
-import org.folio.fqm.migration.strategies.V14AlertsAndReportingCodesRemoval;
-import org.folio.fqm.migration.strategies.V15OrganizationSimpleToCompositeMigration;
+import org.folio.fqm.migration.strategies.V15AlertsAndReportingCodesRemoval;
+import org.folio.fqm.migration.strategies.V16OrganizationSimpleToCompositeMigration;
 import org.folio.spring.FolioExecutionContext;
 import org.jooq.DSLContext;
 import org.springframework.stereotype.Component;
@@ -58,8 +59,9 @@ public class MigrationStrategyRepository {
         new V11OrganizationNameCodeOperatorChange(organizationsClient),
         new V12PurchaseOrderIdFieldRemoval(),
         new V13CustomFieldRename(executionContext, jooqContext),
-        new V14AlertsAndReportingCodesRemoval(),
-        new V15OrganizationSimpleToCompositeMigration()
+        new V14ItemLocLibraryValueChange(locationUnitsClient),
+        new V15AlertsAndReportingCodesRemoval(),
+        new V16OrganizationSimpleToCompositeMigration()
         // adding a strategy? be sure to update the `CURRENT_VERSION` in MigrationConfiguration!
       );
   }

--- a/src/main/java/org/folio/fqm/migration/strategies/AbstractLibraryValueChangeMigration.java
+++ b/src/main/java/org/folio/fqm/migration/strategies/AbstractLibraryValueChangeMigration.java
@@ -1,0 +1,89 @@
+package org.folio.fqm.migration.strategies;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.folio.fql.service.FqlService;
+import org.folio.fqm.client.LocationUnitsClient;
+import org.folio.fqm.client.LocationUnitsClient.LibraryLocation;
+import org.folio.fqm.migration.MigratableQueryInformation;
+import org.folio.fqm.migration.MigrationStrategy;
+import org.folio.fqm.migration.MigrationUtils;
+import org.folio.fqm.migration.warnings.ValueBreakingWarning;
+import org.folio.fqm.migration.warnings.Warning;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+/**
+ * Base class for library value change migrations.
+ * Handles transformation of library ID values to their corresponding names/codes.
+ */
+@Log4j2
+@RequiredArgsConstructor
+public abstract class AbstractLibraryValueChangeMigration implements MigrationStrategy {
+
+  private final LocationUnitsClient locationUnitsClient;
+
+  protected abstract UUID getEntityTypeId();
+  protected abstract List<String> getFieldNames();
+
+  @Override
+  public MigratableQueryInformation apply(FqlService fqlService, MigratableQueryInformation query) {
+    List<Warning> warnings = new ArrayList<>(query.warnings());
+
+    AtomicReference<List<LibraryLocation>> records = new AtomicReference<>();
+
+    return query
+      .withFqlQuery(
+        MigrationUtils.migrateFqlValues(
+          query.fqlQuery(),
+          key -> getEntityTypeId().equals(query.entityTypeId()) && getFieldNames().contains(key),
+          (String key, String value, Supplier<String> fql) -> {
+            if (records.get() == null) {
+              records.set(locationUnitsClient.getLibraries().loclibs());
+
+              log.info("Fetched {} records from API", records.get().size());
+            }
+
+            return records
+              .get()
+              .stream()
+              .filter(r -> r.id().equals(value))
+              .findFirst()
+              .map(loclib -> {
+                if (key.contains(".name")) {
+                  return loclib.name();
+                } else {
+                  return loclib.code();
+                }
+              })
+              .orElseGet(() -> {
+                // some of these may already be the correct value, as both the name and ID fields
+                // got mapped to the same place. If the name is already being used, we want to make
+                // sure not to discard it
+                boolean existsAsValue = records
+                  .get()
+                  .stream()
+                  .anyMatch(r ->
+                    (key.contains(".name") && r.name().equals(value)) ||
+                    (key.contains(".code") && r.code().equals(value))
+                  );
+
+                if (existsAsValue) {
+                  return value;
+                } else {
+                  warnings.add(ValueBreakingWarning.builder().field(key).value(value).fql(fql.get()).build());
+                  return null;
+                }
+              });
+          }
+        )
+      )
+      .withHadBreakingChanges(query.hadBreakingChanges() || !warnings.isEmpty())
+      .withWarnings(warnings);
+  }
+}
+

--- a/src/main/java/org/folio/fqm/migration/strategies/V13CustomFieldRename.java
+++ b/src/main/java/org/folio/fqm/migration/strategies/V13CustomFieldRename.java
@@ -26,7 +26,7 @@ import static org.folio.fqm.repository.EntityTypeRepository.SUPPORTED_CUSTOM_FIE
 import static org.jooq.impl.DSL.field;
 
 /**
- * Version 13 -> 14, handles custom field renaming.
+ * Version 13 / V13.5 -> 14, handles custom field renaming.
  *
  * The custom field naming scheme was changed in MODFQMMGR-376. This migration handles updating custom field names to match the new scheme.
  *
@@ -46,12 +46,12 @@ public class V13CustomFieldRename implements MigrationStrategy {
 
   @Override
   public String getMaximumApplicableVersion() {
-    return "13";
+    return "13.5";
   }
 
   @Override
   public String getLabel() {
-    return "V13 -> V14 Custom field renaming (MODFQMMGR-642)";
+    return "V13 / V13.5 -> V14 Custom field renaming (MODFQMMGR-642)";
   }
 
   @Override

--- a/src/main/java/org/folio/fqm/migration/strategies/V14ItemLocLibraryValueChange.java
+++ b/src/main/java/org/folio/fqm/migration/strategies/V14ItemLocLibraryValueChange.java
@@ -1,0 +1,43 @@
+package org.folio.fqm.migration.strategies;
+
+import java.util.List;
+import java.util.UUID;
+import org.folio.fqm.client.LocationUnitsClient;
+
+/**
+ * Version 14 -> 15, handles a change in the effective library name and code fields in the items entity type.
+ *
+ * Originally, values for this field were stored as the library's ID, however, this was changed to use the
+ * name/code itself. As such, we need to update queries to map the original IDs to their corresponding values.
+ *
+ * @see https://folio-org.atlassian.net/browse/MODFQMMGR-883 for adding this migration
+ */
+public class V14ItemLocLibraryValueChange extends AbstractLibraryValueChangeMigration {
+
+  private static final UUID ITEMS_ENTITY_TYPE_ID = UUID.fromString("d0213d22-32cf-490f-9196-d81c3c66e53f");
+  private static final List<String> FIELD_NAMES = List.of("loclibrary.code", "loclibrary.name");
+
+  public V14ItemLocLibraryValueChange(LocationUnitsClient locationUnitsClient) {
+    super(locationUnitsClient);
+  }
+
+  @Override
+  protected UUID getEntityTypeId() {
+    return ITEMS_ENTITY_TYPE_ID;
+  }
+
+  @Override
+  protected List<String> getFieldNames() {
+    return FIELD_NAMES;
+  }
+
+  @Override
+  public String getMaximumApplicableVersion() {
+    return "14";
+  }
+
+  @Override
+  public String getLabel() {
+    return "V14 -> V15 item effective library name/code value transformation (MODFQMMGR-883)";
+  }
+}

--- a/src/main/java/org/folio/fqm/migration/strategies/V15AlertsAndReportingCodesRemoval.java
+++ b/src/main/java/org/folio/fqm/migration/strategies/V15AlertsAndReportingCodesRemoval.java
@@ -10,13 +10,13 @@ import org.folio.fqm.migration.warnings.FieldWarning;
 import org.folio.fqm.migration.warnings.RemovedFieldWarning;
 
 /**
- * Version 14 -> 15, remove POL alerts and reporting codes.
+ * Version 15 -> 16, remove POL alerts and reporting codes.
  *
  * @see https://folio-org.atlassian.net/browse/MODORDERS-1269 for the addition of this migration
  */
 @Log4j2
 @RequiredArgsConstructor
-public class V14AlertsAndReportingCodesRemoval extends AbstractSimpleMigrationStrategy {
+public class V15AlertsAndReportingCodesRemoval extends AbstractSimpleMigrationStrategy {
 
   private static final UUID PURCHASE_ORDER_LINE_ENTITY_TYPE_ID = UUID.fromString(
     "58148257-bfb0-4687-8c42-d2833d772f3e"
@@ -24,12 +24,12 @@ public class V14AlertsAndReportingCodesRemoval extends AbstractSimpleMigrationSt
 
   @Override
   public String getLabel() {
-    return "V14 -> V15 Alerts and reporting codes removal (MODORDERS-1269)";
+    return "V15 -> V16 Alerts and reporting codes removal (MODORDERS-1269)";
   }
 
   @Override
   public String getMaximumApplicableVersion() {
-    return "14";
+    return "15";
   }
 
   @Override

--- a/src/main/java/org/folio/fqm/migration/strategies/V16OrganizationSimpleToCompositeMigration.java
+++ b/src/main/java/org/folio/fqm/migration/strategies/V16OrganizationSimpleToCompositeMigration.java
@@ -8,26 +8,26 @@ import java.util.Map;
 import java.util.UUID;
 
 /**
- * Version 15 -> 16, migrates from simple_organization to composite_organization entity type.
+ * Version 16 -> 17, migrates from simple_organization to composite_organization entity type.
  * The public Organizations ET is being changed from a simple ET to a composite. Because of this,
  * all fields get "organization." prepended to their names.
  * @see https://folio-org.atlassian.net/browse/MODFQMMGR-679
  */
 @Log4j2
 @RequiredArgsConstructor
-public class V15OrganizationSimpleToCompositeMigration extends AbstractSimpleMigrationStrategy {
+public class V16OrganizationSimpleToCompositeMigration extends AbstractSimpleMigrationStrategy {
 
   private static final UUID SIMPLE_ORGANIZATIONS_ID = UUID.fromString("b5ffa2e9-8080-471a-8003-a8c5a1274503");
   private static final UUID COMPOSITE_ORGANIZATIONS_ID = UUID.fromString("e0ea4212-4023-458a-adce-8003ff6c5d9e");
 
   @Override
   public String getMaximumApplicableVersion() {
-    return "15";
+    return "16";
   }
 
   @Override
   public String getLabel() {
-    return "V15 -> V16 Organization simple to composite migration (part of MODFQMMGR-679)";
+    return "V16 -> V17 Organization simple to composite migration (part of MODFQMMGR-679)";
   }
 
   @Override

--- a/src/main/java/org/folio/fqm/migration/strategies/V9LocLibraryValueChange.java
+++ b/src/main/java/org/folio/fqm/migration/strategies/V9LocLibraryValueChange.java
@@ -1,20 +1,8 @@
 package org.folio.fqm.migration.strategies;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Supplier;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
-import org.folio.fql.service.FqlService;
 import org.folio.fqm.client.LocationUnitsClient;
-import org.folio.fqm.client.LocationUnitsClient.LibraryLocation;
-import org.folio.fqm.migration.MigratableQueryInformation;
-import org.folio.fqm.migration.MigrationStrategy;
-import org.folio.fqm.migration.MigrationUtils;
-import org.folio.fqm.migration.warnings.ValueBreakingWarning;
-import org.folio.fqm.migration.warnings.Warning;
 
 /**
  * Version 9 -> 10, handles a change in the effective library name and code fields in the holdings entity type.
@@ -24,14 +12,24 @@ import org.folio.fqm.migration.warnings.Warning;
  *
  * @see https://folio-org.atlassian.net/browse/MODFQMMGR-602 for adding this migration
  */
-@Log4j2
-@RequiredArgsConstructor
-public class V9LocLibraryValueChange implements MigrationStrategy {
+public class V9LocLibraryValueChange extends AbstractLibraryValueChangeMigration {
 
   private static final UUID HOLDINGS_ENTITY_TYPE_ID = UUID.fromString("8418e512-feac-4a6a-a56d-9006aab31e33");
   private static final List<String> FIELD_NAMES = List.of("effective_library.code", "effective_library.name");
 
-  private final LocationUnitsClient locationUnitsClient;
+  public V9LocLibraryValueChange(LocationUnitsClient locationUnitsClient) {
+    super(locationUnitsClient);
+  }
+
+  @Override
+  protected UUID getEntityTypeId() {
+    return HOLDINGS_ENTITY_TYPE_ID;
+  }
+
+  @Override
+  protected List<String> getFieldNames() {
+    return FIELD_NAMES;
+  }
 
   @Override
   public String getMaximumApplicableVersion() {
@@ -41,61 +39,5 @@ public class V9LocLibraryValueChange implements MigrationStrategy {
   @Override
   public String getLabel() {
     return "V9 -> V10 holdings effective library name/code value transformation (MODFQMMGR-602)";
-  }
-
-  @Override
-  public MigratableQueryInformation apply(FqlService fqlService, MigratableQueryInformation query) {
-    List<Warning> warnings = new ArrayList<>(query.warnings());
-
-    AtomicReference<List<LibraryLocation>> records = new AtomicReference<>();
-
-    return query
-      .withFqlQuery(
-        MigrationUtils.migrateFqlValues(
-          query.fqlQuery(),
-          key -> HOLDINGS_ENTITY_TYPE_ID.equals(query.entityTypeId()) && FIELD_NAMES.contains(key),
-          (String key, String value, Supplier<String> fql) -> {
-            if (records.get() == null) {
-              records.set(locationUnitsClient.getLibraries().loclibs());
-
-              log.info("Fetched {} records from API", records.get().size());
-            }
-
-            return records
-              .get()
-              .stream()
-              .filter(r -> r.id().equals(value))
-              .findFirst()
-              .map(loclib -> {
-                if (key.contains(".name")) {
-                  return loclib.name();
-                } else {
-                  return loclib.code();
-                }
-              })
-              .orElseGet(() -> {
-                // some of these may already be the correct value, as both the name and ID fields
-                // got mapped to the same place. If the name is already being used, we want to make
-                // sure not to discard it
-                boolean existsAsValue = records
-                  .get()
-                  .stream()
-                  .anyMatch(r ->
-                    (key.contains(".name") && r.name().equals(value)) ||
-                    (key.contains(".code") && r.code().equals(value))
-                  );
-
-                if (existsAsValue) {
-                  return value;
-                } else {
-                  warnings.add(ValueBreakingWarning.builder().field(key).value(value).fql(fql.get()).build());
-                  return null;
-                }
-              });
-          }
-        )
-      )
-      .withHadBreakingChanges(query.hadBreakingChanges() || !warnings.isEmpty())
-      .withWarnings(warnings);
   }
 }

--- a/src/test/java/org/folio/fqm/migration/strategies/V6V7V8V9V14ValueChangeConsolidatedTest.java
+++ b/src/test/java/org/folio/fqm/migration/strategies/V6V7V8V9V14ValueChangeConsolidatedTest.java
@@ -35,8 +35,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-// tests all four together, as they're all very similar
-class V6V7V8V9ValueChangeConsolidatedTest extends TestTemplate {
+// tests all five together, as they're all very similar
+class V6V7V8V9V14ValueChangeConsolidatedTest extends TestTemplate {
 
   @Mock
   LocationsClient locationsClient;
@@ -51,7 +51,7 @@ class V6V7V8V9ValueChangeConsolidatedTest extends TestTemplate {
   PatronGroupsClient patronGroupsClient;
 
   @BeforeEach
-  public void setup() {
+  void setup() {
     lenient()
       .when(locationsClient.getLocations())
       .thenReturn(new LocationsResponse(List.of(new Location("id1", "name1"), new Location("id2", "name2"))));
@@ -78,7 +78,8 @@ class V6V7V8V9ValueChangeConsolidatedTest extends TestTemplate {
       new V6ModeOfIssuanceValueChange(modesOfIssuanceClient),
       new V7PatronGroupsValueChange(patronGroupsClient),
       new V8LocationValueChange(locationsClient),
-      new V9LocLibraryValueChange(locationUnitsClient)
+      new V9LocLibraryValueChange(locationUnitsClient),
+      new V14ItemLocLibraryValueChange(locationUnitsClient)
     );
 
     return new MigrationStrategy() {
@@ -148,6 +149,16 @@ class V6V7V8V9ValueChangeConsolidatedTest extends TestTemplate {
         "d0213d22-32cf-490f-9196-d81c3c66e53f",
         "temporary_location.name",
         () -> verify(locationsClient, times(1)).getLocations()
+      ),
+      Triple.of(
+        "d0213d22-32cf-490f-9196-d81c3c66e53f",
+        "loclibrary.name",
+        () -> verify(locationUnitsClient, times(1)).getLibraries()
+      ),
+      Triple.of(
+        "d0213d22-32cf-490f-9196-d81c3c66e53f",
+        "loclibrary.code",
+        () -> verify(locationUnitsClient, times(1)).getLibraries()
       ),
       Triple.of(
         "8418e512-feac-4a6a-a56d-9006aab31e33",


### PR DESCRIPTION
## Purpose
[MODFQMMGR-883](https://folio-org.atlassian.net/browse/MODFQMMGR-883) Migrate "Effective library - Name" and "Effective library - Code" fields for Items ET

As of right now, the latest migration on Ramsons is V12 (meaning queries end up as version 13) and the latest migration on Sunflower is V13 (meaning queries end up as version 14).

## Plan
- The original V14 and V15 (present only in Trillium and later) get incremented by one each, so V14 becomes V15 and V15 becomes V16
- This new migration (call it bugfix-migration) is inserted as V14 in Sunflower and Trillium
- bugfix-migration is inserted as V13 in Ramsons and upgrades queries to version 13.5
- In Sunflower and Trillium, the original V13 becomes V13.5 and is modified to accept queries with version 13.5

## How it should work
- Tenants on Ramsons: tenant will originally be on version 13 queries. When this is deployed with Ramsons CSP, queries will be incremented to 13.5. When upgraded to Sunflower, they'll be incremented 13.5 -> 14 -> 15. When upgraded to trillium, they'll go 15 -> 16 -> 17.

- Tenants already on Sunflower: tenant will originally be on version 14 queries. When this is deployed with Sunflower CSP, queries will go through bugfix-migration as V14.