### PR TITLE
MODFQMMGR-867 - Repeatable fields "contains" implementation

### DIFF
--- a/src/test/java/org/folio/fqm/service/FqlToSqlConverterServiceTest.java
+++ b/src/test/java/org/folio/fqm/service/FqlToSqlConverterServiceTest.java
@@ -456,6 +456,18 @@ class FqlToSqlConverterServiceTest {
         condition("{0} ~* {1}", field("field1"), val("some_text"))
       ),
       Arguments.of(
+        "regex array string",
+        """
+          {"arrayField": {"$regex": "value1"}}""",
+        condition("exists (select 1 from unnest({0}) where unnest ~* {1})", field("arrayField"), "value1")
+      ),
+      Arguments.of(
+        "regex jsonb array string",
+        """
+          {"jsonbArrayField": {"$regex": "value1"}}""",
+        condition("exists (select 1 from jsonb_array_elements_text({0}) as elem where elem ~* {1})", field("jsonbArrayField").cast(JSONB.class), "value1")
+      ),
+      Arguments.of(
         "regex",
         """
           {"fieldWithAValueFunction": {"$regex": "some_text"}}""",


### PR DESCRIPTION
## Purpose
[MODFQMMGR-867](https://folio-org.atlassian.net/browse/MODFQMMGR-867) - Repeatable fields "contains" implementation

## Approach
Implemented handleRegEx logic for arrays and jsonb arrays

## Pre-Merge Checklist

If you are adding entity type(s), have you:
- [ ] Added the JSON5 definition to the `src/main/resources/entity-types` directory?
- [ ] Ensured that GETing the entity type at `/entity-types/{id}` works as expected?
- [ ] Added translations for all fields, per the [translation guidelines](/translations/README.md)? (Check this by ensuring `GET /entity-types/{id}` does not have `mod-fqm-manager.entityType.` in the response)
- [ ] Added views to liquibase, as applicable?
- [ ] Added required interfaces to the module descriptor?
- [ ] Checked that querying fields works correctly and all SQL is valid?

If you are changing/removing entity type(s), have you:
- [ ] Added migration code for any changes?