### PR TITLE
[MODFQMMGR-761] Fix synchronous cross-tenant queries

### DIFF
--- a/src/main/java/org/folio/fqm/resource/FqlQueryController.java
+++ b/src/main/java/org/folio/fqm/resource/FqlQueryController.java
@@ -73,7 +73,7 @@ public class FqlQueryController implements FqlQueryApi {
   @Override
   public ResponseEntity<ResultsetPage> runFqlQuery(String query, UUID entityTypeId, List<String> fields,
                                                    List<String> afterId, Integer limit) {
-    return ResponseEntity.ok(queryManagementService.runFqlQuery(query, entityTypeId, fields, afterId, limit));
+    return ResponseEntity.ok(queryManagementService.runFqlQuery(query, entityTypeId, fields, limit));
   }
   @EntityTypePermissionsRequired(idType = EntityTypePermissionsRequired.IdType.QUERY)
   @Override

--- a/src/main/java/org/folio/fqm/service/EntityTypeService.java
+++ b/src/main/java/org/folio/fqm/service/EntityTypeService.java
@@ -262,7 +262,6 @@ public class EntityTypeService {
       entityType,
       fql,
       List.of(ID_FIELD_NAME, fieldName),
-      null,
       COLUMN_VALUE_DEFAULT_PAGE_SIZE
     );
     List<ValueWithLabel> valueWithLabels = results

--- a/src/main/java/org/folio/fqm/service/QueryManagementService.java
+++ b/src/main/java/org/folio/fqm/service/QueryManagementService.java
@@ -134,13 +134,11 @@ public class QueryManagementService {
    * @param query        Query to execute
    * @param entityTypeId ID of the entity type corresponding to the query
    * @param fields       List of fields to return for each element in the result set
-   * @param afterId      ID of the element to begin retrieving results after (e.g. if the id of 100th element
-   *                     is provided, the first element retrieved in the result set will be the 101st element)
    * @param limit        Maximum number of results to retrieves
    * @return Page containing the results of the query
    */
   public ResultsetPage runFqlQuery(String query, UUID entityTypeId, List<String> fields,
-                                   List<String> afterId, Integer limit) {
+                                   Integer limit) {
     validateQuery(entityTypeId, query);
     if (CollectionUtils.isEmpty(fields)) {
       fields = new ArrayList<>();
@@ -157,7 +155,7 @@ public class QueryManagementService {
     MigratableQueryInformation migratableQueryInformation = new MigratableQueryInformation(entityTypeId, query, fields);
     migrationService.throwExceptionIfQueryNeedsMigration(migratableQueryInformation);
 
-    List<Map<String, Object>> queryResults = queryProcessorService.processQuery(entityType, query, fields, afterId, limit);
+    List<Map<String, Object>> queryResults = queryProcessorService.processQuery(entityType, query, fields, limit);
     return new ResultsetPage().content(queryResults);
   }
 

--- a/src/main/java/org/folio/fqm/service/QueryProcessorService.java
+++ b/src/main/java/org/folio/fqm/service/QueryProcessorService.java
@@ -34,7 +34,6 @@ public class QueryProcessorService {
   private final CrossTenantQueryService crossTenantQueryService;
   private final QueryRepository queryRepository;
 
-
   /**
    * Process the FQL query and return the result IDs in batches.
    *
@@ -78,13 +77,10 @@ public class QueryProcessorService {
    * @param entityType Entity type
    * @param fqlQuery   FQL query
    * @param fields     fields to return in query results
-   * @param afterId    A cursor used for pagination. 'afterId' is the ID representing your place in the paginated list.
-   *                   This parameter should be omitted in the first call. All subsequent pagination call should
-   *                   include 'afterId'
    * @param limit      Count of records to be returned.
    * @return Results matching the query
    */
-  public List<Map<String, Object>> processQuery(EntityType entityType, String fqlQuery, List<String> fields, List<String> afterId, Integer limit) {
+  public List<Map<String, Object>> processQuery(EntityType entityType, String fqlQuery, List<String> fields, Integer limit) {
     Fql fql = fqlService.getFql(fqlQuery);
     boolean ecsEnabled = crossTenantQueryService.ecsEnabled();
     List<String> tenantsToQuery = crossTenantQueryService.getTenantsToQuery(entityType);
@@ -92,7 +88,6 @@ public class QueryProcessorService {
       UUID.fromString(entityType.getId()),
       fql,
       fields,
-      afterId,
       limit,
       tenantsToQuery,
       ecsEnabled

--- a/src/test/java/org/folio/fqm/controller/FqlQueryControllerTest.java
+++ b/src/test/java/org/folio/fqm/controller/FqlQueryControllerTest.java
@@ -145,7 +145,7 @@ class FqlQueryControllerTest {
     String fields = "field1,field2";
     ResultsetPage expectedResults = new ResultsetPage().content(expectedContent);
     when(executionContext.getTenantId()).thenReturn(TENANT_ID);
-    when(queryManagementService.runFqlQuery(fqlQuery, entityTypeId, fieldsList, null,  defaultLimit)).thenReturn(expectedResults);
+    when(queryManagementService.runFqlQuery(fqlQuery, entityTypeId, fieldsList, defaultLimit)).thenReturn(expectedResults);
     RequestBuilder builder = get("/query").contentType(MediaType.APPLICATION_JSON)
       .header(XOkapiHeaders.TENANT, TENANT_ID)
       .queryParam("query", fqlQuery)
@@ -170,7 +170,7 @@ class FqlQueryControllerTest {
     );
     ResultsetPage expectedResults = new ResultsetPage().content(expectedContent);
     when(executionContext.getTenantId()).thenReturn(TENANT_ID);
-    when(queryManagementService.runFqlQuery(fqlQuery, entityTypeId, null, null, defaultLimit)).thenReturn(expectedResults);
+    when(queryManagementService.runFqlQuery(fqlQuery, entityTypeId, null, defaultLimit)).thenReturn(expectedResults);
     RequestBuilder builder = get("/query").contentType(MediaType.APPLICATION_JSON)
       .header(XOkapiHeaders.TENANT, TENANT_ID)
       .queryParam("query", fqlQuery)
@@ -184,7 +184,6 @@ class FqlQueryControllerTest {
   void shouldRunSynchronousQueryWithOptionalParametersAndReturnResults() throws Exception {
     UUID entityTypeId = UUID.randomUUID();
     UUID afterUUID = UUID.randomUUID();
-    List<String> afterId = List.of(afterUUID.toString());
     String fqlQuery = """
                       {"field1": {"$in": ["value1", "value2", "value3", "value4", "value5" ] }}
                       """;
@@ -198,7 +197,7 @@ class FqlQueryControllerTest {
     String fields = "id,field1,field2";
     ResultsetPage expectedResults = new ResultsetPage().content(expectedContent);
     when(executionContext.getTenantId()).thenReturn(TENANT_ID);
-    when(queryManagementService.runFqlQuery(fqlQuery, entityTypeId, fieldsList, afterId, limit)).thenReturn(expectedResults);
+    when(queryManagementService.runFqlQuery(fqlQuery, entityTypeId, fieldsList, limit)).thenReturn(expectedResults);
     RequestBuilder builder = get("/query").contentType(MediaType.APPLICATION_JSON)
       .header(XOkapiHeaders.TENANT, TENANT_ID)
       .queryParam("query", fqlQuery)
@@ -238,7 +237,7 @@ class FqlQueryControllerTest {
     UUID entityTypeId = UUID.randomUUID();
 
     doThrow(new InvalidFqlException(fqlQuery, Map.of("field1", "Field not present")))
-      .when(queryManagementService).runFqlQuery(fqlQuery, entityTypeId, null, null, 100);
+      .when(queryManagementService).runFqlQuery(fqlQuery, entityTypeId, null, 100);
 
     RequestBuilder builder = get("/query").contentType(MediaType.APPLICATION_JSON)
       .header(XOkapiHeaders.TENANT, TENANT_ID)
@@ -423,5 +422,4 @@ class FqlQueryControllerTest {
     mockMvc.perform(builder)
       .andExpect(status().isBadRequest());
   }
-
 }

--- a/src/test/java/org/folio/fqm/service/EntityTypeServiceTest.java
+++ b/src/test/java/org/folio/fqm/service/EntityTypeServiceTest.java
@@ -260,7 +260,7 @@ class EntityTypeServiceTest {
         )
       );
 
-    when(queryProcessorService.processQuery(any(), any(), any(), any(), any()))
+    when(queryProcessorService.processQuery(any(), any(), any(), any()))
       .thenReturn(
         List.of(
           Map.of("id", "value_01", valueColumnName, "label_01"),
@@ -284,7 +284,7 @@ class EntityTypeServiceTest {
         .source(new SourceColumn(entityTypeId, valueColumnName)
           .type(SourceColumn.TypeEnum.ENTITY_TYPE))));
 
-    when(queryProcessorService.processQuery(any(EntityType.class), any(), any(), any(), any()))
+    when(queryProcessorService.processQuery(any(EntityType.class), any(), any(), any()))
       .thenReturn(
         List.of(
           Map.of(valueColumnName, "value_01"),
@@ -318,7 +318,7 @@ class EntityTypeServiceTest {
     String expectedFql = "{\"" + valueColumnName + "\": {\"$regex\": " + "\"" + searchText + "\"}}";
     when(entityTypeFlatteningService.getFlattenedEntityType(entityTypeId, null, false)).thenReturn(entityType);
     entityTypeService.getFieldValues(entityTypeId, valueColumnName, searchText);
-    verify(queryProcessorService).processQuery(entityType, expectedFql, fields, null, 1000);
+    verify(queryProcessorService).processQuery(entityType, expectedFql, fields, 1000);
   }
 
   @Test
@@ -335,7 +335,7 @@ class EntityTypeServiceTest {
     String expectedFql = "{\"" + valueColumnName + "\": {\"$regex\": " + "\"\"}}";
     when(entityTypeFlatteningService.getFlattenedEntityType(entityTypeId, null, false)).thenReturn(entityType);
     entityTypeService.getFieldValues(entityTypeId, valueColumnName, null);
-    verify(queryProcessorService).processQuery(entityType, expectedFql, fields, null, 1000);
+    verify(queryProcessorService).processQuery(entityType, expectedFql, fields, 1000);
   }
 
   @Test

--- a/src/test/java/org/folio/fqm/service/QueryManagementServiceTest.java
+++ b/src/test/java/org/folio/fqm/service/QueryManagementServiceTest.java
@@ -42,7 +42,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -274,8 +273,8 @@ class QueryManagementServiceTest {
     ResultsetPage expectedResults = new ResultsetPage().content(expectedContent);
     when(entityTypeService.getEntityTypeDefinition(entityTypeId,true)).thenReturn(entityType);
     when(fqlValidationService.validateFql(entityType, fqlQuery)).thenReturn(Map.of());
-    when(queryProcessorService.processQuery(any(EntityType.class), eq(fqlQuery), eq(fields), isNull(), eq(defaultLimit))).thenReturn(expectedContent);
-    ResultsetPage actualResults = queryManagementService.runFqlQuery(fqlQuery, entityTypeId, fields, null, defaultLimit);
+    when(queryProcessorService.processQuery(any(EntityType.class), eq(fqlQuery), eq(fields), eq(defaultLimit))).thenReturn(expectedContent);
+    ResultsetPage actualResults = queryManagementService.runFqlQuery(fqlQuery, entityTypeId, fields, defaultLimit);
     assertEquals(expectedResults, actualResults);
   }
 
@@ -302,9 +301,9 @@ class QueryManagementServiceTest {
     ResultsetPage expectedResults = new ResultsetPage().content(expectedContent);
     when(entityTypeService.getEntityTypeDefinition(entityTypeId, true)).thenReturn(entityType);
     when(fqlValidationService.validateFql(entityType, fqlQuery)).thenReturn(Map.of());
-    when(queryProcessorService.processQuery(any(EntityType.class), eq(fqlQuery), eq(List.of("field1", "field2", "id")), isNull(), eq(defaultLimit)))
+    when(queryProcessorService.processQuery(any(EntityType.class), eq(fqlQuery), eq(List.of("field1", "field2", "id")), eq(defaultLimit)))
       .thenReturn(expectedContent);
-    ResultsetPage actualResults = queryManagementService.runFqlQuery(fqlQuery, entityTypeId, fields, null, defaultLimit);
+    ResultsetPage actualResults = queryManagementService.runFqlQuery(fqlQuery, entityTypeId, fields, defaultLimit);
     assertEquals(expectedResults, actualResults);
   }
 
@@ -366,13 +365,13 @@ class QueryManagementServiceTest {
 
     when(entityTypeService.getEntityTypeDefinition(entityTypeId, true)).thenReturn(entityType);
     when(fqlValidationService.validateFql(entityType, fqlQuery)).thenReturn(Map.of());
-    when(queryProcessorService.processQuery(any(EntityType.class), eq(fqlQuery), eq(fields), isNull(), eq(defaultLimit)))
+    when(queryProcessorService.processQuery(any(EntityType.class), eq(fqlQuery), eq(fields), eq(defaultLimit)))
       .thenReturn(List.of());
 
     // Reset the mock to clear the lenient stubbing from setup
     reset(migrationService);
 
-    queryManagementService.runFqlQuery(fqlQuery, entityTypeId, fields, null, defaultLimit);
+    queryManagementService.runFqlQuery(fqlQuery, entityTypeId, fields, defaultLimit);
 
     // Verify that verifyQueryIsUpToDate was called with the correct parameters
     ArgumentCaptor<MigratableQueryInformation> captor = ArgumentCaptor.forClass(MigratableQueryInformation.class);
@@ -405,9 +404,9 @@ class QueryManagementServiceTest {
     ResultsetPage expectedResults = new ResultsetPage().content(expectedContent);
     when(entityTypeService.getEntityTypeDefinition(entityTypeId, true)).thenReturn(entityType);
     when(fqlValidationService.validateFql(entityType, fqlQuery)).thenReturn(Map.of());
-    when(queryProcessorService.processQuery(any(EntityType.class), eq(fqlQuery), eq(List.of("id")), isNull(), eq(defaultLimit)))
+    when(queryProcessorService.processQuery(any(EntityType.class), eq(fqlQuery), eq(List.of("id")), eq(defaultLimit)))
       .thenReturn(expectedContent);
-    ResultsetPage actualResults = queryManagementService.runFqlQuery(fqlQuery, entityTypeId, null, null, defaultLimit);
+    ResultsetPage actualResults = queryManagementService.runFqlQuery(fqlQuery, entityTypeId, null, defaultLimit);
     assertEquals(expectedResults, actualResults);
   }
 

--- a/src/test/java/org/folio/fqm/service/QueryProcessorServiceTest.java
+++ b/src/test/java/org/folio/fqm/service/QueryProcessorServiceTest.java
@@ -77,7 +77,6 @@ class QueryProcessorServiceTest {
       {"field1": {"eq": "value1" }}
       """;
     List<String> tenantIds = List.of("tenant_01");
-    List<String> afterId = List.of(UUID.randomUUID().toString());
     int limit = 100;
     Fql expectedFql = new Fql("", new EqualsCondition(new FqlField("status"), "value1"));
     List<String> fields = List.of("field1", "field2");
@@ -87,8 +86,8 @@ class QueryProcessorServiceTest {
     );
     when(fqlService.getFql(fqlQuery)).thenReturn(expectedFql);
     when(crossTenantQueryService.getTenantsToQuery(entityType)).thenReturn(tenantIds);
-    when(resultSetRepository.getResultSetSync(entityTypeId, expectedFql, fields, afterId, limit, tenantIds, false)).thenReturn(expectedContent);
-    List<Map<String, Object>> actualContent = service.processQuery(entityType, fqlQuery, fields, afterId, limit);
+    when(resultSetRepository.getResultSetSync(entityTypeId, expectedFql, fields, limit, tenantIds, false)).thenReturn(expectedContent);
+    List<Map<String, Object>> actualContent = service.processQuery(entityType, fqlQuery, fields, limit);
     assertEquals(expectedContent, actualContent);
   }
 


### PR DESCRIPTION
## Purpose
[MODFQMMGR-761](https://folio-org.atlassian.net/browse/MODFQMMGR-761): Error with GET /query synchronous in ECS with cross-tenant queries 

- also remove all uses of afterId parameter