### PR TITLE
MODFQMMGR-608 Restructure the available-joins endpoint

### DIFF
--- a/src/main/java/org/folio/fqm/resource/EntityTypeController.java
+++ b/src/main/java/org/folio/fqm/resource/EntityTypeController.java
@@ -4,11 +4,12 @@ import lombok.RequiredArgsConstructor;
 import org.folio.fqm.annotation.EntityTypePermissionsRequired;
 import org.folio.fqm.service.EntityTypeService;
 import org.folio.fqm.service.MigrationService;
-import org.folio.querytool.domain.dto.AvailableJoins;
+import org.folio.fqm.domain.dto.EntityTypeSummaries;
+import org.folio.querytool.domain.dto.AvailableJoinsRequest;
+import org.folio.querytool.domain.dto.AvailableJoinsResponse;
 import org.folio.querytool.domain.dto.ColumnValues;
 import org.folio.querytool.domain.dto.CustomEntityType;
 import org.folio.querytool.domain.dto.EntityType;
-import org.folio.fqm.domain.dto.EntityTypeSummaries;
 import org.folio.querytool.rest.resource.EntityTypesApi;
 import org.folio.spring.FolioExecutionContext;
 import org.springframework.http.ResponseEntity;
@@ -75,9 +76,18 @@ public class EntityTypeController implements org.folio.fqm.resource.EntityTypesA
     return ResponseEntity.noContent().build();
   }
 
+
   @Override
-  public ResponseEntity<AvailableJoins> getAvailableJoins(String customEntityTypeField, UUID targetEntityTypeId, String targetEntityTypeField, CustomEntityType customEntityType) {
-    return ResponseEntity.ok(entityTypeService.getAvailableJoins(customEntityType, customEntityTypeField, targetEntityTypeId, targetEntityTypeField));
+  public ResponseEntity<AvailableJoinsResponse> getAvailableJoins(AvailableJoinsRequest availableJoinsRequest) {
+    if (availableJoinsRequest == null) {
+      return ResponseEntity.ok(entityTypeService.getAvailableJoins(null, null, null, null));
+    }
+    return ResponseEntity.ok(entityTypeService.getAvailableJoins(
+      availableJoinsRequest.getCustomEntityType(),
+      availableJoinsRequest.getSourceField(),
+      availableJoinsRequest.getTargetId(),
+      availableJoinsRequest.getTargetField()
+    ));
   }
 
   @Override

--- a/src/main/java/org/folio/fqm/service/EntityTypeService.java
+++ b/src/main/java/org/folio/fqm/service/EntityTypeService.java
@@ -24,7 +24,7 @@ import org.folio.fqm.exception.EntityTypeNotFoundException;
 import org.folio.fqm.exception.FieldNotFoundException;
 import org.folio.fqm.exception.InvalidEntityTypeDefinitionException;
 import org.folio.fqm.repository.EntityTypeRepository;
-import org.folio.querytool.domain.dto.AvailableJoins;
+import org.folio.querytool.domain.dto.AvailableJoinsResponse;
 import org.folio.querytool.domain.dto.ColumnValues;
 import org.folio.querytool.domain.dto.CustomEntityType;
 import org.folio.querytool.domain.dto.EntityType;
@@ -492,10 +492,10 @@ public class EntityTypeService {
       .collect(Collectors.toMap(et -> UUID.fromString(et.getId()), et -> et, (a, b) -> a));
   }
 
-  public AvailableJoins getAvailableJoins(CustomEntityType customEntityType, String customEntityTypeField, UUID targetEntityTypeId, String targetEntityTypeField) {
+  public AvailableJoinsResponse getAvailableJoins(CustomEntityType customEntityType, String customEntityTypeField, UUID targetEntityTypeId, String targetEntityTypeField) {
     // See https://folio-org.atlassian.net/browse/MODFQMMGR-608 for details on what this should return
     // TL;DR - It returns the possible options for the properties that aren't provided in the request (the method parameters)
-    var builder = AvailableJoins.builder();
+    var builder = AvailableJoinsResponse.builder();
 
     // Special case where all parameters are provided. The user already has everything they need to build a join, so return an empty AvailableJoins object
     if (customEntityType != null && customEntityTypeField != null && targetEntityTypeId != null && targetEntityTypeField != null) {
@@ -506,7 +506,7 @@ public class EntityTypeService {
     Map<UUID, EntityType> accessibleEntityTypesById = getAccessibleEntityTypesById();
 
     if (targetEntityTypeId == null || flattenedCustomEntityType == null) {
-      builder.targetEntityTypes(discoverTargetEntityTypes(flattenedCustomEntityType, customEntityTypeField, accessibleEntityTypesById));
+      builder.availableTargetIds(discoverTargetEntityTypes(flattenedCustomEntityType, customEntityTypeField, accessibleEntityTypesById));
       // Special case where the custom ET isn't provided: Only provide the target entity types
       if (flattenedCustomEntityType == null) {
         return builder.build();
@@ -514,12 +514,12 @@ public class EntityTypeService {
     }
 
     if (customEntityTypeField == null) {
-      builder.customEntityTypeFields(discoverCustomEntityTypeFields(flattenedCustomEntityType, targetEntityTypeId, accessibleEntityTypesById));
+      builder.availableSourceFields(discoverCustomEntityTypeFields(flattenedCustomEntityType, targetEntityTypeId, accessibleEntityTypesById));
     }
 
     // Only provide target ET fields when the target ET has been provided
     if (targetEntityTypeField == null && targetEntityTypeId != null) {
-      builder.availableTargetEntityTypeFields(discoverTargetEntityTypeFields(flattenedCustomEntityType, customEntityTypeField, accessibleEntityTypesById.get(targetEntityTypeId)));
+      builder.availableTargetFields(discoverTargetEntityTypeFields(flattenedCustomEntityType, customEntityTypeField, accessibleEntityTypesById.get(targetEntityTypeId)));
     }
 
     return builder.build();

--- a/src/test/java/org/folio/fqm/service/EntityTypeServiceAvailableJoinsTest.java
+++ b/src/test/java/org/folio/fqm/service/EntityTypeServiceAvailableJoinsTest.java
@@ -2,7 +2,7 @@ package org.folio.fqm.service;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.folio.fqm.repository.EntityTypeRepository;
-import org.folio.querytool.domain.dto.AvailableJoins;
+import org.folio.querytool.domain.dto.AvailableJoinsResponse;
 import org.folio.querytool.domain.dto.CustomEntityType;
 import org.folio.querytool.domain.dto.EntityType;
 import org.folio.querytool.domain.dto.EntityTypeColumn;
@@ -158,28 +158,28 @@ class EntityTypeServiceAvailableJoinsTest {
     String targetEntityTypeField = "colA";
 
     // When there's a request for available joins with those components
-    AvailableJoins result = entityTypeService.getAvailableJoins(customEntityType, customEntityTypeField, targetEntityTypeId, targetEntityTypeField);
+    AvailableJoinsResponse result = entityTypeService.getAvailableJoins(customEntityType, customEntityTypeField, targetEntityTypeId, targetEntityTypeField);
 
     // Then the available options are all empty or null, since there are no unknowns
     assertNotNull(result);
-    assertTrue(CollectionUtils.isEmpty(result.getTargetEntityTypes()));
-    assertTrue(CollectionUtils.isEmpty(result.getCustomEntityTypeFields()));
-    assertTrue(CollectionUtils.isEmpty(result.getAvailableTargetEntityTypeFields()));
+    assertTrue(CollectionUtils.isEmpty(result.getAvailableTargetIds()));
+    assertTrue(CollectionUtils.isEmpty(result.getAvailableSourceFields()));
+    assertTrue(CollectionUtils.isEmpty(result.getAvailableTargetFields()));
   }
 
   @Test
   void getAvailableJoins_shouldReturnTargetEntityTypesWhenCustomEntityTypeIsNull() {
     // When there's a request for available joins without a custom entity type
-    AvailableJoins result = entityTypeService.getAvailableJoins(null, null, null, null);
+    AvailableJoinsResponse result = entityTypeService.getAvailableJoins(null, null, null, null);
 
     // Then it should return all available target entity types
-    AvailableJoins expected = new AvailableJoins()
-      .targetEntityTypes(entityTypeService.getAccessibleEntityTypesById().values().stream()
+    AvailableJoinsResponse expected = new AvailableJoinsResponse()
+      .availableTargetIds(entityTypeService.getAccessibleEntityTypesById().values().stream()
         .map(et -> new LabeledValue(et.getLabelAlias()).value(et.getId()))
         .sorted(comparing(LabeledValue::getLabel, String.CASE_INSENSITIVE_ORDER))
         .toList())
-      .availableTargetEntityTypeFields(null)
-      .customEntityTypeFields(null);
+      .availableTargetFields(null)
+      .availableSourceFields(null);
     assertEquals(expected, result);
   }
 
@@ -201,12 +201,12 @@ class EntityTypeServiceAvailableJoinsTest {
     doReturn(customEt).when(entityTypeFlatteningService).getFlattenedEntityType(any(CustomEntityType.class), any(), eq(true));
 
     // When there's a request for available joins with the custom entity type and no specific fields
-    AvailableJoins result = entityTypeService.getAvailableJoins(new CustomEntityType().id(customEtId.toString()), null, targetEtId, null);
+    AvailableJoinsResponse result = entityTypeService.getAvailableJoins(new CustomEntityType().id(customEtId.toString()), null, targetEtId, null);
 
     // Then it should return the fields from both entity types that can be used in a join between the two
-    assertEquals(1, result.getCustomEntityTypeFields().size());
-    assertEquals("Join Field", result.getCustomEntityTypeFields().get(0).getLabel());
-    assertEquals(List.of(new LabeledValue("Column A").value("colA")), result.getAvailableTargetEntityTypeFields());
+    assertEquals(1, result.getAvailableSourceFields().size());
+    assertEquals("Join Field", result.getAvailableSourceFields().get(0).getLabel());
+    assertEquals(List.of(new LabeledValue("Column A").value("colA")), result.getAvailableTargetFields());
   }
 
   @Test
@@ -230,25 +230,25 @@ class EntityTypeServiceAvailableJoinsTest {
     doReturn(customEt).when(entityTypeFlatteningService).getFlattenedEntityType(any(CustomEntityType.class), any(), eq(true));
 
     // When there's a request for available joins with the custom entity type and no specified target field
-    AvailableJoins result = entityTypeService.getAvailableJoins(new CustomEntityType().id(customEtId.toString()), "customField", targetEtId, null);
+    AvailableJoinsResponse result = entityTypeService.getAvailableJoins(new CustomEntityType().id(customEtId.toString()), "customField", targetEtId, null);
 
     // Then it should return the fields from the target entity type that can be used in a join with the custom entity type
-    assertNotNull(result.getAvailableTargetEntityTypeFields());
-    assertEquals(1, result.getAvailableTargetEntityTypeFields().size());
-    assertEquals("Column X", result.getAvailableTargetEntityTypeFields().get(0).getLabel());
+    assertNotNull(result.getAvailableTargetFields());
+    assertEquals(1, result.getAvailableTargetFields().size());
+    assertEquals("Column X", result.getAvailableTargetFields().get(0).getLabel());
   }
 
   @Test
   void getAvailableJoins_shouldReturnAllAccessibleEntityTypesWhenCustomEntityTypeIsNull() {
     // When there's a request for target entity types without a custom entity type set
-    AvailableJoins result = entityTypeService.getAvailableJoins(null, null, null, null);
+    AvailableJoinsResponse result = entityTypeService.getAvailableJoins(null, null, null, null);
 
     // Then it should return all accessible entity types
-    assertEquals(entityTypeService.getAccessibleEntityTypesById().size(), result.getTargetEntityTypes().size());
-    assertTrue(result.getTargetEntityTypes().stream().anyMatch(lv -> "Test Entity 1".equals(lv.getLabel())));
-    assertTrue(result.getTargetEntityTypes().stream().anyMatch(lv -> "Test Entity 2".equals(lv.getLabel())));
-    assertTrue(result.getTargetEntityTypes().stream().anyMatch(lv -> "Test Entity 3".equals(lv.getLabel())));
-    assertTrue(result.getTargetEntityTypes().stream().anyMatch(lv -> "Composite Entity 1-2".equals(lv.getLabel())));
+    assertEquals(entityTypeService.getAccessibleEntityTypesById().size(), result.getAvailableTargetIds().size());
+    assertTrue(result.getAvailableTargetIds().stream().anyMatch(lv -> "Test Entity 1".equals(lv.getLabel())));
+    assertTrue(result.getAvailableTargetIds().stream().anyMatch(lv -> "Test Entity 2".equals(lv.getLabel())));
+    assertTrue(result.getAvailableTargetIds().stream().anyMatch(lv -> "Test Entity 3".equals(lv.getLabel())));
+    assertTrue(result.getAvailableTargetIds().stream().anyMatch(lv -> "Composite Entity 1-2".equals(lv.getLabel())));
   }
 
   @Test
@@ -269,11 +269,11 @@ class EntityTypeServiceAvailableJoinsTest {
     doReturn(customEt).when(entityTypeFlatteningService).getFlattenedEntityType(any(CustomEntityType.class), any(), eq(true));
 
     // When there's a request for custom entity type fields with the custom entity type and target entity type ID
-    AvailableJoins result = entityTypeService.getAvailableJoins(new CustomEntityType().id(customEtId.toString()), null, targetEtId, null);
+    AvailableJoinsResponse result = entityTypeService.getAvailableJoins(new CustomEntityType().id(customEtId.toString()), null, targetEtId, null);
 
     // Then it should return the field from the custom entity type
-    assertEquals(1, result.getCustomEntityTypeFields().size());
-    assertEquals("Join Field", result.getCustomEntityTypeFields().get(0).getLabel());
+    assertEquals(1, result.getAvailableSourceFields().size());
+    assertEquals("Join Field", result.getAvailableSourceFields().get(0).getLabel());
   }
 
   @Test
@@ -295,11 +295,11 @@ class EntityTypeServiceAvailableJoinsTest {
     doReturn(customEt).when(entityTypeFlatteningService).getFlattenedEntityType(any(CustomEntityType.class), any(), eq(true));
 
     // When there's a request for target entity type fields with the custom entity type and no specified target field
-    AvailableJoins result = entityTypeService.getAvailableJoins(new CustomEntityType().id(customEtId.toString()), "customField", targetEtId, null);
+    AvailableJoinsResponse result = entityTypeService.getAvailableJoins(new CustomEntityType().id(customEtId.toString()), "customField", targetEtId, null);
 
     // Then it should return the fields from the target entity type that can be used in a join with the custom entity type
-    assertEquals(1, result.getAvailableTargetEntityTypeFields().size());
-    assertEquals("Column X", result.getAvailableTargetEntityTypeFields().get(0).getLabel());
+    assertEquals(1, result.getAvailableTargetFields().size());
+    assertEquals("Column X", result.getAvailableTargetFields().get(0).getLabel());
   }
 
   @Test
@@ -315,10 +315,10 @@ class EntityTypeServiceAvailableJoinsTest {
     doReturn(customEt).when(entityTypeFlatteningService).getFlattenedEntityType(any(CustomEntityType.class), any(), eq(true));
 
     // When there's a request for target entity type fields with the custom entity type and target entity type
-    AvailableJoins result = entityTypeService.getAvailableJoins(new CustomEntityType().id(customEtId.toString()), null, targetEtId, null);
+    AvailableJoinsResponse result = entityTypeService.getAvailableJoins(new CustomEntityType().id(customEtId.toString()), null, targetEtId, null);
 
     // Then it should return an empty list since there are no joinable fields
-    assertTrue(result.getAvailableTargetEntityTypeFields().isEmpty());
+    assertTrue(result.getAvailableTargetFields().isEmpty());
   }
 
   @Test
@@ -356,12 +356,12 @@ class EntityTypeServiceAvailableJoinsTest {
     doReturn(customEt).when(entityTypeFlatteningService).getFlattenedEntityType(any(CustomEntityType.class), any(), eq(true));
 
     // When there's a request for available joins with the custom entity type
-    AvailableJoins result = entityTypeService.getAvailableJoins(new CustomEntityType().id(customEtId.toString()), null, null, null);
+    AvailableJoinsResponse result = entityTypeService.getAvailableJoins(new CustomEntityType().id(customEtId.toString()), null, null, null);
 
     // Then it should include the target entity type in the available target entity types
-    assertNotNull(result.getTargetEntityTypes());
-    assertEquals(1, result.getTargetEntityTypes().size());
-    assertEquals(targetEtId.toString(), result.getTargetEntityTypes().get(0).getValue());
+    assertNotNull(result.getAvailableTargetIds());
+    assertEquals(1, result.getAvailableTargetIds().size());
+    assertEquals(targetEtId.toString(), result.getAvailableTargetIds().get(0).getValue());
   }
 
   @Test
@@ -384,17 +384,17 @@ class EntityTypeServiceAvailableJoinsTest {
     doReturn(customEt).when(entityTypeFlatteningService).getFlattenedEntityType(any(CustomEntityType.class), any(), eq(true));
 
     // When there's a request for available joins with the custom entity type and no specific field
-    AvailableJoins result = entityTypeService.getAvailableJoins(new CustomEntityType().id(customEtId.toString()), null, null, null);
+    AvailableJoinsResponse result = entityTypeService.getAvailableJoins(new CustomEntityType().id(customEtId.toString()), null, null, null);
 
     // Then it should include both target entity types in the available target entity types
-    assertNotNull(result.getTargetEntityTypes());
+    assertNotNull(result.getAvailableTargetIds());
 
     // And it should include the custom entity type field that can be used for joins
-    assertNotNull(result.getCustomEntityTypeFields());
-    assertEquals(1, result.getCustomEntityTypeFields().size());
+    assertNotNull(result.getAvailableSourceFields());
+    assertEquals(1, result.getAvailableSourceFields().size());
 
     // Verify field names are present
-    Set<String> customFieldNames = result.getCustomEntityTypeFields().stream()
+    Set<String> customFieldNames = result.getAvailableSourceFields().stream()
       .map(LabeledValue::getValue)
       .collect(Collectors.toSet());
     assertTrue(customFieldNames.contains("col1"));
@@ -450,14 +450,14 @@ class EntityTypeServiceAvailableJoinsTest {
     doReturn(customEt).when(entityTypeFlatteningService).getFlattenedEntityType(any(CustomEntityType.class), any(), eq(true));
 
     // When there's a request for available joins with the custom entity type and target entity type
-    AvailableJoins result = entityTypeService.getAvailableJoins(new CustomEntityType().id(customEtId.toString()), null, targetEtId, null);
+    AvailableJoinsResponse result = entityTypeService.getAvailableJoins(new CustomEntityType().id(customEtId.toString()), null, targetEtId, null);
 
     // Then it should include both custom entity type fields that can be used for joins
-    assertNotNull(result.getCustomEntityTypeFields());
-    assertEquals(2, result.getCustomEntityTypeFields().size());
+    assertNotNull(result.getAvailableSourceFields());
+    assertEquals(2, result.getAvailableSourceFields().size());
 
     // Verify field names are present
-    Set<String> customFieldNames = result.getCustomEntityTypeFields().stream()
+    Set<String> customFieldNames = result.getAvailableSourceFields().stream()
       .map(LabeledValue::getValue)
       .collect(Collectors.toSet());
     assertTrue(customFieldNames.contains("customField1"));
@@ -478,7 +478,7 @@ class EntityTypeServiceAvailableJoinsTest {
     doReturn(customEt).when(entityTypeFlatteningService).getFlattenedEntityType(any(CustomEntityType.class), any(), eq(true));
 
     // When there's a request for available joins with the custom entity type and specific field
-    AvailableJoins result = entityTypeService.getAvailableJoins(
+    AvailableJoinsResponse result = entityTypeService.getAvailableJoins(
       new CustomEntityType().id(customEtId.toString()),
       "colA",
       targetEtId,
@@ -486,10 +486,10 @@ class EntityTypeServiceAvailableJoinsTest {
     );
 
     // Then it should include the target field in the available target entity type fields
-    assertNotNull(result.getAvailableTargetEntityTypeFields());
-    assertEquals(1, result.getAvailableTargetEntityTypeFields().size());
-    assertEquals("colX", result.getAvailableTargetEntityTypeFields().get(0).getValue());
-    assertEquals("Column X", result.getAvailableTargetEntityTypeFields().get(0).getLabel());
+    assertNotNull(result.getAvailableTargetFields());
+    assertEquals(1, result.getAvailableTargetFields().size());
+    assertEquals("colX", result.getAvailableTargetFields().get(0).getValue());
+    assertEquals("Column X", result.getAvailableTargetFields().get(0).getLabel());
   }
 
   @Test
@@ -506,7 +506,7 @@ class EntityTypeServiceAvailableJoinsTest {
     doReturn(customEt).when(entityTypeFlatteningService).getFlattenedEntityType(any(CustomEntityType.class), any(), eq(true));
 
     // When there's a request for available joins with the custom entity type and target entity type
-    AvailableJoins result = entityTypeService.getAvailableJoins(
+    AvailableJoinsResponse result = entityTypeService.getAvailableJoins(
       new CustomEntityType().id(customEtId.toString()),
       null,
       targetEtId,
@@ -514,11 +514,11 @@ class EntityTypeServiceAvailableJoinsTest {
     );
 
     // Then it should include both custom fields in the custom entity type fields
-    assertNotNull(result.getCustomEntityTypeFields());
-    assertEquals(1, result.getCustomEntityTypeFields().size());
+    assertNotNull(result.getAvailableSourceFields());
+    assertEquals(1, result.getAvailableSourceFields().size());
 
     // Verify field names are present
-    Set<String> customFieldNames = result.getCustomEntityTypeFields().stream()
+    Set<String> customFieldNames = result.getAvailableSourceFields().stream()
       .map(LabeledValue::getValue)
       .collect(Collectors.toSet());
     assertTrue(customFieldNames.contains("colY"));
@@ -573,9 +573,9 @@ class EntityTypeServiceAvailableJoinsTest {
     doReturn(accessible).when(entityTypeService).getAccessibleEntityTypesById();
     doReturn(customEt).when(entityTypeFlatteningService).getFlattenedEntityType(any(CustomEntityType.class), any(), eq(true));
 
-    AvailableJoins result = entityTypeService.getAvailableJoins(new CustomEntityType().id(customEtId.toString()), null, targetEtId, null);
-    assertTrue(result.getCustomEntityTypeFields().isEmpty());
-    assertTrue(result.getAvailableTargetEntityTypeFields().isEmpty());
+    AvailableJoinsResponse result = entityTypeService.getAvailableJoins(new CustomEntityType().id(customEtId.toString()), null, targetEtId, null);
+    assertTrue(result.getAvailableSourceFields().isEmpty());
+    assertTrue(result.getAvailableTargetFields().isEmpty());
   }
 
   @Test


### PR DESCRIPTION
This commit restructures the available-joins API endpoint, to take all parameters in the request body, rather than some coming from the body and some from query parameters. This simplifies the API a little bit and avoids some annoying behavior