### PR TITLE
Add total record count to synchronous query API

### DIFF
--- a/src/main/java/org/folio/fqm/service/QueryManagementService.java
+++ b/src/main/java/org/folio/fqm/service/QueryManagementService.java
@@ -156,7 +156,10 @@ public class QueryManagementService {
     migrationService.throwExceptionIfQueryNeedsMigration(migratableQueryInformation);
 
     List<Map<String, Object>> queryResults = queryProcessorService.processQuery(entityType, query, fields, limit);
-    return new ResultsetPage().content(queryResults);
+    // NOTE: unlike the async query, which returns the total number of records matching the query, the synchronous query
+    // API returns the number of records included in this individual response, which may be less than the total number
+    // of records matching the query.
+    return new ResultsetPage().content(queryResults).totalRecords(queryResults.size());
   }
 
   /**

--- a/src/test/java/org/folio/fqm/service/QueryManagementServiceTest.java
+++ b/src/test/java/org/folio/fqm/service/QueryManagementServiceTest.java
@@ -270,7 +270,7 @@ class QueryManagementServiceTest {
       Map.of("id", resultIds.get(1).toString(), "field1", "value3", "field2", "value4")
     );
     List<String> fields = List.of("id", "field1", "field2");
-    ResultsetPage expectedResults = new ResultsetPage().content(expectedContent);
+    ResultsetPage expectedResults = new ResultsetPage().content(expectedContent).totalRecords(expectedContent.size());
     when(entityTypeService.getEntityTypeDefinition(entityTypeId,true)).thenReturn(entityType);
     when(fqlValidationService.validateFql(entityType, fqlQuery)).thenReturn(Map.of());
     when(queryProcessorService.processQuery(any(EntityType.class), eq(fqlQuery), eq(fields), eq(defaultLimit))).thenReturn(expectedContent);
@@ -298,7 +298,7 @@ class QueryManagementServiceTest {
       Map.of("id", resultIds.get(1).toString(), "field1", "value3", "field2", "value4")
     );
     List<String> fields = new ArrayList<>(List.of("field1", "field2"));
-    ResultsetPage expectedResults = new ResultsetPage().content(expectedContent);
+    ResultsetPage expectedResults = new ResultsetPage().content(expectedContent).totalRecords(expectedContent.size());
     when(entityTypeService.getEntityTypeDefinition(entityTypeId, true)).thenReturn(entityType);
     when(fqlValidationService.validateFql(entityType, fqlQuery)).thenReturn(Map.of());
     when(queryProcessorService.processQuery(any(EntityType.class), eq(fqlQuery), eq(List.of("field1", "field2", "id")), eq(defaultLimit)))
@@ -401,7 +401,7 @@ class QueryManagementServiceTest {
       Map.of("id", resultIds.get(0).toString()),
       Map.of("id", resultIds.get(1).toString())
     );
-    ResultsetPage expectedResults = new ResultsetPage().content(expectedContent);
+    ResultsetPage expectedResults = new ResultsetPage().content(expectedContent).totalRecords(expectedContent.size());
     when(entityTypeService.getEntityTypeDefinition(entityTypeId, true)).thenReturn(entityType);
     when(fqlValidationService.validateFql(entityType, fqlQuery)).thenReturn(Map.of());
     when(queryProcessorService.processQuery(any(EntityType.class), eq(fqlQuery), eq(List.of("id")), eq(defaultLimit)))


### PR DESCRIPTION
NOTE: unlike the async query, which returns the total number of records matching the query, the synchronous query
API returns the number of records included in this individual response, which may be less than the total number of records matching the query.