### PR TITLE
MODFQMMGR-907 - Composite item extension to support "holding_permanent_location.name" field

### DIFF
--- a/src/main/resources/entity-types/inventory/composite_item_details.json5
+++ b/src/main/resources/entity-types/inventory/composite_item_details.json5
@@ -138,6 +138,15 @@
       essentialOnly: true,
       order: 140,
     },
+    {
+      alias: 'holding_permanent_location',
+      type: 'entity-type',
+      targetId: '74ddf1a6-19e0-4d63-baf0-cd2da9a46ca4', // simple_locations
+      targetField: 'id',
+      sourceField: 'holdings.permanent_location_id',
+      essentialOnly: true,
+      order: 150
+    }
   ],
   defaultSort: [
     {

--- a/translations/mod-fqm-manager/en.json
+++ b/translations/mod-fqm-manager/en.json
@@ -55,6 +55,7 @@
   "entityType.composite_item_details.temporary_loan_type": "Temporary loan type",
   "entityType.composite_item_details.created_by_user": "Item created by",
   "entityType.composite_item_details.updated_by_user": "Item updated by",
+  "entityType.composite_item_details.holding_permanent_location": "Holdings record permanent location",
   "entityType.composite_fund": "Fund with ledger",
   "entityType.composite_fund.fund": "Fund",
   "entityType.composite_fund.fund_type": "Fund type",


### PR DESCRIPTION
[MODFQMMGR-907](https://folio-org.atlassian.net/browse/MODFQMMGR-907) - Composite item extension to support "holding_permanent_location.name" field

## Purpose
It is necessary for Bulk Operations to include the field "holding_permanent_location.name" in the composite item schema. 

## Approach
Adding new field in composite item schema.

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._

## Pre-Merge Checklist

If you are adding entity type(s), have you:
- [ ] Added the JSON5 definition to the `src/main/resources/entity-types` directory?
- [ ] Ensured that GETing the entity type at `/entity-types/{id}` works as expected?
- [ ] Added translations for all fields, per the [translation guidelines](/translations/README.md)? (Check this by ensuring `GET /entity-types/{id}` does not have `mod-fqm-manager.entityType.` in the response)
- [ ] Added views to liquibase, as applicable?
- [ ] Added required interfaces to the module descriptor?
- [ ] Checked that querying fields works correctly and all SQL is valid?

If you are changing/removing entity type(s), have you:
- [ ] Added migration code for any changes?