### PR TITLE
MODFQMMGR-897 Allow empty string custom ET IDs

### DIFF
--- a/src/main/java/org/folio/fqm/service/EntityTypeService.java
+++ b/src/main/java/org/folio/fqm/service/EntityTypeService.java
@@ -398,7 +398,7 @@ public class EntityTypeService {
     // UUID.fromString() will pad 0's onto invalid UUID strings to make valid UUIDs, which can lead to unexpected behavior.
     // This block ensures that the service accepts only valid UUID strings
     try {
-      if (customEntityTypeIdString == null) {
+      if (customEntityTypeIdString == null || customEntityTypeIdString.isEmpty()) {
         customEntityTypeId = UUID.randomUUID();
       } else {
         customEntityTypeId = UUID.fromString(customEntityTypeIdString);

--- a/src/test/java/org/folio/fqm/service/EntityTypeServiceTest.java
+++ b/src/test/java/org/folio/fqm/service/EntityTypeServiceTest.java
@@ -821,6 +821,28 @@ class EntityTypeServiceTest {
   }
 
   @Test
+  void createCustomEntityType_shouldGenerateId_whenIdIsEmptyString() {
+    UUID ownerId = UUID.randomUUID();
+    CustomEntityType customEntityType = new CustomEntityType()
+      .id("")
+      .shared(false)
+      .owner(ownerId)
+      .name("test")
+      ._private(false)
+      .isCustom(true);
+
+    when(clockService.now()).thenReturn(new Date());
+    when(executionContext.getUserId()).thenReturn(ownerId);
+
+    CustomEntityType result = entityTypeService.createCustomEntityType(customEntityType);
+
+    assertNotNull(result.getId(), "ID should be generated when input ID is empty string");
+    assertFalse(result.getId().isEmpty(), "Generated ID should not be empty");
+    assertDoesNotThrow(() -> UUID.fromString(result.getId()), "Generated ID should be a valid UUID");
+    verify(repo).createCustomEntityType(result);
+  }
+
+  @Test
   void createCustomEntityType_shouldThrowInvalidEntityTypeDefinitionException_whenIdIsInvalidUUID() {
     CustomEntityType customEntityType = new CustomEntityType()
       .id("not-a-uuid")


### PR DESCRIPTION
This commit updates the handling of custom entity type IDs (during ET creation) to allow for empty strings. When that happens, the ID is treated the same as null IDs: a new ID is generated.
