### PR TITLE
Temporarily add back config interface to module descriptor

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -539,6 +539,10 @@
     {
       "id": "item-note-types",
       "version": "1.0"
+    },
+    {
+      "id": "configuration",
+      "version": "2.0"
     }
   ],
   "optional": [


### PR DESCRIPTION
## Purpose
Add back config 2.0 to mod-fqm-manager's module descriptor. I removed it prematurely, since it's still necessary until [MODFQMMGR-746](https://folio-org.atlassian.net/browse/MODFQMMGR-746) is completed