### PR TITLE
MODFQMMGR-1104 Hide simple_srs_record id and externalId fields

### DIFF
--- a/src/main/resources/entity-types/srs/simple_srs_record.json5
+++ b/src/main/resources/entity-types/srs/simple_srs_record.json5
@@ -31,6 +31,7 @@
       queryable: true,
       visibleByDefault: false,
       essential: true,
+      hidden: true,
       valueGetter: ':record_lb.id',
     },
     {
@@ -101,6 +102,7 @@
       queryable: true,
       visibleByDefault: false,
       essential: true,
+      hidden: true,
       valueGetter: ':record_lb.external_id',
       sourceAlias: 'record_lb',
       joinsTo: [


### PR DESCRIPTION
## Purpose
Hide simple_srs_record id and externalId fields
https://folio-org.atlassian.net/browse/MODFQMMGR-1104

## Approach
Mark fields with `essential: false`

## Pre-Merge Checklist

If you are adding entity type(s), have you:
- [ ] Added the JSON5 definition to the `src/main/resources/entity-types` directory?
- [ ] Ensured that GETing the entity type at `/entity-types/{id}` works as expected?
- [ ] Added translations for all fields, per the [translation guidelines](/translations/README.md)? (Check this by ensuring `GET /entity-types/{id}` does not have `mod-fqm-manager.entityType.` in the response)
- [ ] Added views to liquibase, as applicable?
- [ ] Added required interfaces to the module descriptor?
- [ ] Checked that querying fields works correctly and all SQL is valid?

If you are changing/removing entity type(s), have you:
- [ ] Added migration code for any changes?