### PR TITLE
MODFQMMGR-1168 - Introducing Maven Pitest plugin and TestMate annotation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,9 @@
       src/main/java/org/folio/template/FolioSpringTemplateApplication.java
     </sonar.exclusions>
     <argLine>-Dfile.encoding=UTF-8</argLine>
+    <pitest.reportsDirectory>${project.build.directory}/pit-reports/${buildDate}</pitest.reportsDirectory>
+    <maven.build.timestamp.format>yyyy-MM-dd_HH-mm</maven.build.timestamp.format>
+    <buildDate>${maven.build.timestamp}</buildDate>
   </properties>
 
 
@@ -405,6 +408,35 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.pitest</groupId>
+        <artifactId>pitest-maven</artifactId>
+        <version>1.22.0</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.pitest</groupId>
+            <artifactId>pitest-junit5-plugin</artifactId>
+            <version>1.2.3</version>
+          </dependency>
+        </dependencies>
+        <configuration>
+          <timestampedReports>false</timestampedReports>
+          <reportsDirectory>${project.build.directory}/pit-reports/${buildDate}</reportsDirectory>
+          <targetClasses>
+            <param>org.folio.*</param>
+          </targetClasses>
+          <targetTests>
+            <param>org.folio.*Test</param>
+          </targetTests>
+          <mutators>STRONGER</mutators>
+          <threads>4</threads>
+          <outputFormats>
+            <param>HTML</param>
+            <param>XML</param>
+          </outputFormats>
+        </configuration>
       </plugin>
 
     </plugins>

--- a/src/test/java/org/folio/fqm/TestMate.java
+++ b/src/test/java/org/folio/fqm/TestMate.java
@@ -1,0 +1,14 @@
+package org.folio.fqm;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** Marker-annotation for TestMate-generated tests. */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface TestMate {
+  /** Test name. */
+  String name();
+}


### PR DESCRIPTION
## Purpose
Maven Pitest plugin and TestMate annotation. It is necessary to prepare module for TestMate integration.

## Approach
Adding Maven Pitest to pom.xml, implementing custom TestMate annotation.

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._

## Pre-Merge Checklist

If you are adding entity type(s), have you:
- [ ] Added the JSON5 definition to the `src/main/resources/entity-types` directory?
- [ ] Ensured that GETing the entity type at `/entity-types/{id}` works as expected?
- [ ] Added translations for all fields, per the [translation guidelines](/translations/README.md)? (Check this by ensuring `GET /entity-types/{id}` does not have `mod-fqm-manager.entityType.` in the response)
- [ ] Added views to liquibase, as applicable?
- [ ] Added required interfaces to the module descriptor?
- [ ] Checked that querying fields works correctly and all SQL is valid?

If you are changing/removing entity type(s), have you:
- [ ] Added migration code for any changes?