### PR TITLE
MODFQMMGR-1107 Add patron group at checkout to Loans ET

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## 4.2.0 (Next)
 - [ERM-3998](https://folio-org.atlassian.net/browse/ERM-3998) Add agreement and organization simple entity types with db views and translations
+- [MODFQMMGR-1107](https://folio-org.atlassian.net/browse/MODFQMMGR-1107) Add patron group at checkout field to Loans ET, populated from the loan record and retained after loan anonymization
 
 # 4.1.x - Trillium
 

--- a/src/main/resources/entity-types/circulation/composite_loan_details.json5
+++ b/src/main/resources/entity-types/circulation/composite_loan_details.json5
@@ -102,11 +102,20 @@
     {
       alias: 'groups',
       type: 'entity-type',
-      targetId: 'e7717b38-4ff3-4fb9-ae09-b3d0c8400710',
+      targetId: 'e7717b38-4ff3-4fb9-ae09-b3d0c8400710',  // simple_group
       sourceField: 'users.group_id',
       targetField: 'id',
       essentialOnly: true,
       order: 40,
+    },
+    {
+      alias: 'groups_at_checkout',
+      type: 'entity-type',
+      targetId: 'e7717b38-4ff3-4fb9-ae09-b3d0c8400710', // simple_group
+      sourceField: 'loans.patron_group_id_at_checkout',
+      targetField: 'id',
+      essentialOnly: true,
+      order: 45,
     },
     {
       alias: 'holdings',

--- a/src/main/resources/entity-types/circulation/simple_loan.json5
+++ b/src/main/resources/entity-types/circulation/simple_loan.json5
@@ -383,6 +383,14 @@
       visibleByDefault: false,
       hidden: true,
       valueGetter: ":sourceAlias.jsonb->>'patronGroupIdAtCheckout'",
+      joinsTo: [
+        {
+          targetId: 'e7717b38-4ff3-4fb9-ae09-b3d0c8400710', // simple_group
+          targetField: 'id',
+          type: 'equality-cast-uuid',
+          direction: 'left',
+        },
+      ],
     },
     {
       name: 'due_date_changed_by_recall',

--- a/translations/mod-fqm-manager/en.json
+++ b/translations/mod-fqm-manager/en.json
@@ -882,6 +882,7 @@
   "entityType.composite_loan_details.cospi": "Check out service point",
   "entityType.composite_loan_details.created_by": "Loan created by",
   "entityType.composite_loan_details.groups": "Patron group",
+  "entityType.composite_loan_details.groups_at_checkout": "Patron group at checkout",
   "entityType.composite_loan_details.holdings": "Holdings",
   "entityType.composite_loan_details.instance": "Instances",
   "entityType.composite_loan_details.item_effective_library": "Item effective library at checkout",


### PR DESCRIPTION
The Loans ET already had the patron group, but this gets cleared when loans are anonymized. This commit adds the patron group at checkout, so that that information is still available
