### PR TITLE
MODFQMMGR-1192 Stop using the user summary table for the Open Transactions ET

### DIFF
--- a/src/main/resources/entity-types/users/simple_user_transaction_summary.json5
+++ b/src/main/resources/entity-types/users/simple_user_transaction_summary.json5
@@ -8,22 +8,11 @@
       alias: 'users',
       target: 'src_users_users',
     },
-    {
-      type: 'db',
-      alias: 'src__circulation__patron_blocks__user_summary',
-      target: 'src__circulation__patron_blocks__user_summary',
-      join: {
-        type: 'left join',
-        joinTo: 'users',
-        condition: "(:this.jsonb ->> 'userId')::uuid = :that.id",
-      },
-    },
   ],
   requiredPermissions: [
     'users.collection.get',
     'accounts.collection.get', // for open_fees_fines_count
     'circulation.loans.collection.get', // for open_loans_count
-    'users-bl.transactions.get',
     'patron-blocks.automated-patron-blocks.collection.get', // for automated_blocks_count
   ],
   defaultSort: [
@@ -209,51 +198,70 @@
           limits.jsonb ->> 'patronGroupId' = users.jsonb ->> 'patronGroup' \
           AND CASE \
             WHEN conditions.id = '3d7c52dc-c732-4223-8bf8-e5917801386f'::uuid THEN \
-              COALESCE(jsonb_array_length(:src__circulation__patron_blocks__user_summary.jsonb -> 'openLoans'), 0) > (limits.jsonb ->> 'value')::numeric \
+              ( \
+                SELECT \
+                  COUNT(*) \
+                FROM \
+                  ${tenant_id}_mod_fqm_manager.src_circulation_loan loan \
+                WHERE \
+                  loan.jsonb ->> 'userId' = users.id::text \
+                  AND loan.jsonb -> 'status' ->> 'name' = 'Open' \
+              ) > (limits.jsonb ->> 'value')::numeric \
             WHEN conditions.id = '584fbd4f-6a34-4730-a6ca-73a6a6a9d845'::uuid THEN \
               ( \
                 SELECT \
                   COUNT(*) \
                 FROM \
-                  jsonb_array_elements(COALESCE(:src__circulation__patron_blocks__user_summary.jsonb -> 'openLoans', '[]'::jsonb)) AS loan(value) \
+                  ${tenant_id}_mod_fqm_manager.src_circulation_loan loan \
                 WHERE \
-                  (loan.value ->> 'dueDate')::timestamptz < current_timestamp \
+                  loan.jsonb ->> 'userId' = users.id::text \
+                  AND loan.jsonb -> 'status' ->> 'name' = 'Open' \
+                  AND (loan.jsonb ->> 'dueDate')::timestamptz < current_timestamp \
               ) > (limits.jsonb ->> 'value')::numeric \
             WHEN conditions.id = 'e5b45031-a202-4abb-917b-e1df9346fe2c'::uuid THEN \
               ( \
                 SELECT \
                   COUNT(*) \
                 FROM \
-                  jsonb_array_elements(COALESCE(:src__circulation__patron_blocks__user_summary.jsonb -> 'openLoans', '[]'::jsonb)) AS loan(value) \
+                  ${tenant_id}_mod_fqm_manager.src_circulation_loan loan \
                 WHERE \
-                  loan.value ->> 'recall' = 'true' \
-                  AND (loan.value ->> 'dueDate')::timestamptz < current_timestamp \
+                  loan.jsonb ->> 'userId' = users.id::text \
+                  AND loan.jsonb -> 'status' ->> 'name' = 'Open' \
+                  AND loan.jsonb ->> 'dueDateChangedByRecall' = 'true' \
+                  AND (loan.jsonb ->> 'dueDate')::timestamptz < current_timestamp \
               ) > (limits.jsonb ->> 'value')::numeric \
             WHEN conditions.id = '08530ac4-07f2-48e6-9dda-a97bc2bf7053'::uuid THEN \
               EXISTS ( \
                 SELECT \
                   1 \
                 FROM \
-                  jsonb_array_elements(COALESCE(:src__circulation__patron_blocks__user_summary.jsonb -> 'openLoans', '[]'::jsonb)) AS loan(value) \
+                  ${tenant_id}_mod_fqm_manager.src_circulation_loan loan \
                 WHERE \
-                  loan.value ->> 'recall' = 'true' \
-                  AND (loan.value ->> 'dueDate')::timestamptz < current_timestamp - ((limits.jsonb ->> 'value')::numeric::text || ' days')::interval \
+                  loan.jsonb ->> 'userId' = users.id::text \
+                  AND loan.jsonb -> 'status' ->> 'name' = 'Open' \
+                  AND loan.jsonb ->> 'dueDateChangedByRecall' = 'true' \
+                  AND (loan.jsonb ->> 'dueDate')::timestamptz < current_timestamp - ((limits.jsonb ->> 'value')::numeric::text || ' days')::interval \
               ) \
             WHEN conditions.id = '72b67965-5b73-4840-bc0b-be8f3f6e047e'::uuid THEN \
               ( \
                 SELECT \
                   COUNT(*) \
                 FROM \
-                  jsonb_array_elements(COALESCE(:src__circulation__patron_blocks__user_summary.jsonb -> 'openLoans', '[]'::jsonb)) AS loan(value) \
+                  ${tenant_id}_mod_fqm_manager.src_circulation_loan loan \
                 WHERE \
-                  loan.value ->> 'itemLost' = 'true' \
+                  loan.jsonb ->> 'userId' = users.id::text \
+                  AND loan.jsonb -> 'status' ->> 'name' = 'Open' \
+                  AND loan.jsonb ->> 'itemStatus' IN ('Declared lost', 'Aged to lost') \
               ) > (limits.jsonb ->> 'value')::numeric \
             WHEN conditions.id = 'cf7a0d5f-a327-4ca1-aa9e-dc55ec006b8a'::uuid THEN \
               ( \
                 SELECT \
-                  COALESCE(SUM((fee_fine.value ->> 'balance')::numeric), 0) \
+                  COALESCE(SUM((account.jsonb ->> 'remaining')::numeric), 0) \
                 FROM \
-                  jsonb_array_elements(COALESCE(:src__circulation__patron_blocks__user_summary.jsonb -> 'openFeesFines', '[]'::jsonb)) AS fee_fine(value) \
+                  ${tenant_id}_mod_fqm_manager.src__circulation__feesfines__accounts account \
+                WHERE \
+                  account.jsonb ->> 'userId' = users.id::text \
+                  AND account.jsonb -> 'status' ->> 'name' = 'Open' \
               ) > (limits.jsonb ->> 'value')::numeric \
             ELSE false \
           END \
@@ -280,8 +288,24 @@
         },
       ],
       valueGetter: "( \
-        COALESCE(jsonb_array_length(:src__circulation__patron_blocks__user_summary.jsonb -> 'openFeesFines'), 0) > 0 \
-        OR COALESCE(jsonb_array_length(:src__circulation__patron_blocks__user_summary.jsonb -> 'openLoans'), 0) > 0 \
+        EXISTS ( \
+          SELECT \
+            1 \
+          FROM \
+            ${tenant_id}_mod_fqm_manager.src__circulation__feesfines__accounts account \
+          WHERE \
+            account.jsonb ->> 'userId' = :users.id::text \
+            AND account.jsonb -> 'status' ->> 'name' = 'Open' \
+        ) \
+        OR EXISTS ( \
+          SELECT \
+            1 \
+          FROM \
+            ${tenant_id}_mod_fqm_manager.src_circulation_loan loan \
+          WHERE \
+            loan.jsonb ->> 'userId' = :users.id::text \
+            AND loan.jsonb -> 'status' ->> 'name' = 'Open' \
+        ) \
         OR EXISTS ( \
           SELECT \
             1 \
@@ -336,51 +360,70 @@
             limits.jsonb ->> 'patronGroupId' = users.jsonb ->> 'patronGroup' \
             AND CASE \
               WHEN conditions.id = '3d7c52dc-c732-4223-8bf8-e5917801386f'::uuid THEN \
-                COALESCE(jsonb_array_length(:src__circulation__patron_blocks__user_summary.jsonb -> 'openLoans'), 0) > (limits.jsonb ->> 'value')::numeric \
+                ( \
+                  SELECT \
+                    COUNT(*) \
+                  FROM \
+                    ${tenant_id}_mod_fqm_manager.src_circulation_loan loan \
+                  WHERE \
+                    loan.jsonb ->> 'userId' = users.id::text \
+                    AND loan.jsonb -> 'status' ->> 'name' = 'Open' \
+                ) > (limits.jsonb ->> 'value')::numeric \
               WHEN conditions.id = '584fbd4f-6a34-4730-a6ca-73a6a6a9d845'::uuid THEN \
                 ( \
                   SELECT \
                     COUNT(*) \
                   FROM \
-                    jsonb_array_elements(COALESCE(:src__circulation__patron_blocks__user_summary.jsonb -> 'openLoans', '[]'::jsonb)) AS loan(value) \
+                    ${tenant_id}_mod_fqm_manager.src_circulation_loan loan \
                   WHERE \
-                    (loan.value ->> 'dueDate')::timestamptz < current_timestamp \
+                    loan.jsonb ->> 'userId' = users.id::text \
+                    AND loan.jsonb -> 'status' ->> 'name' = 'Open' \
+                    AND (loan.jsonb ->> 'dueDate')::timestamptz < current_timestamp \
                 ) > (limits.jsonb ->> 'value')::numeric \
               WHEN conditions.id = 'e5b45031-a202-4abb-917b-e1df9346fe2c'::uuid THEN \
                 ( \
                   SELECT \
                     COUNT(*) \
                   FROM \
-                    jsonb_array_elements(COALESCE(:src__circulation__patron_blocks__user_summary.jsonb -> 'openLoans', '[]'::jsonb)) AS loan(value) \
+                    ${tenant_id}_mod_fqm_manager.src_circulation_loan loan \
                   WHERE \
-                    loan.value ->> 'recall' = 'true' \
-                    AND (loan.value ->> 'dueDate')::timestamptz < current_timestamp \
+                    loan.jsonb ->> 'userId' = users.id::text \
+                    AND loan.jsonb -> 'status' ->> 'name' = 'Open' \
+                    AND loan.jsonb ->> 'dueDateChangedByRecall' = 'true' \
+                    AND (loan.jsonb ->> 'dueDate')::timestamptz < current_timestamp \
                 ) > (limits.jsonb ->> 'value')::numeric \
               WHEN conditions.id = '08530ac4-07f2-48e6-9dda-a97bc2bf7053'::uuid THEN \
                 EXISTS ( \
                   SELECT \
                     1 \
                   FROM \
-                    jsonb_array_elements(COALESCE(:src__circulation__patron_blocks__user_summary.jsonb -> 'openLoans', '[]'::jsonb)) AS loan(value) \
+                    ${tenant_id}_mod_fqm_manager.src_circulation_loan loan \
                   WHERE \
-                    loan.value ->> 'recall' = 'true' \
-                    AND (loan.value ->> 'dueDate')::timestamptz < current_timestamp - ((limits.jsonb ->> 'value')::numeric::text || ' days')::interval \
+                    loan.jsonb ->> 'userId' = users.id::text \
+                    AND loan.jsonb -> 'status' ->> 'name' = 'Open' \
+                    AND loan.jsonb ->> 'dueDateChangedByRecall' = 'true' \
+                    AND (loan.jsonb ->> 'dueDate')::timestamptz < current_timestamp - ((limits.jsonb ->> 'value')::numeric::text || ' days')::interval \
                 ) \
               WHEN conditions.id = '72b67965-5b73-4840-bc0b-be8f3f6e047e'::uuid THEN \
                 ( \
                   SELECT \
                     COUNT(*) \
                   FROM \
-                    jsonb_array_elements(COALESCE(:src__circulation__patron_blocks__user_summary.jsonb -> 'openLoans', '[]'::jsonb)) AS loan(value) \
+                    ${tenant_id}_mod_fqm_manager.src_circulation_loan loan \
                   WHERE \
-                    loan.value ->> 'itemLost' = 'true' \
+                    loan.jsonb ->> 'userId' = users.id::text \
+                    AND loan.jsonb -> 'status' ->> 'name' = 'Open' \
+                    AND loan.jsonb ->> 'itemStatus' IN ('Declared lost', 'Aged to lost') \
                 ) > (limits.jsonb ->> 'value')::numeric \
               WHEN conditions.id = 'cf7a0d5f-a327-4ca1-aa9e-dc55ec006b8a'::uuid THEN \
                 ( \
                   SELECT \
-                    COALESCE(SUM((fee_fine.value ->> 'balance')::numeric), 0) \
+                    COALESCE(SUM((account.jsonb ->> 'remaining')::numeric), 0) \
                   FROM \
-                    jsonb_array_elements(COALESCE(:src__circulation__patron_blocks__user_summary.jsonb -> 'openFeesFines', '[]'::jsonb)) AS fee_fine(value) \
+                    ${tenant_id}_mod_fqm_manager.src__circulation__feesfines__accounts account \
+                  WHERE \
+                    account.jsonb ->> 'userId' = users.id::text \
+                    AND account.jsonb -> 'status' ->> 'name' = 'Open' \
                 ) > (limits.jsonb ->> 'value')::numeric \
               ELSE false \
             END \


### PR DESCRIPTION
This commit aligns the automated_blocks_count and has_open_transactions fields in the Open Transactions entity type, so that it no longer retrieves that data from the user summary table, since that table isn't always accurate. Now, we get that data directly from the live data that backs the summary table.
