### PR TITLE
MODFQMMGR-1081 Add availableOperators to several fields

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   <properties>
     <!-- runtime dependencies -->
     <folio-spring-support.version>10.0.0</folio-spring-support.version>
-    <folio-query-tool-metadata.version>4.0.0</folio-query-tool-metadata.version>
+    <folio-query-tool-metadata.version>4.1.0-SNAPSHOT</folio-query-tool-metadata.version>
     <mapstruct.version>1.5.2.Final</mapstruct.version>
     <lib-fqm-query-processor.version>4.1.0</lib-fqm-query-processor.version>
     <snakeyaml.version>2.0</snakeyaml.version>

--- a/src/main/resources/entity-types/inventory/simple_holdings_record.json5
+++ b/src/main/resources/entity-types/inventory/simple_holdings_record.json5
@@ -132,6 +132,7 @@
       essential: true,
       filterValueGetter: "lower(${tenant_id}_mod_inventory_storage.f_unaccent(:sourceAlias.jsonb ->> 'hrid'))",
       valueFunction: 'lower(${tenant_id}_mod_inventory_storage.f_unaccent(:value))',
+      availableOperators: ['$eq', '$ne', '$in', '$contains', '$starts_with', '$empty'],
     },
     {
       name: 'call_number_type_id',

--- a/src/main/resources/entity-types/inventory/simple_instance.json5
+++ b/src/main/resources/entity-types/inventory/simple_instance.json5
@@ -241,6 +241,7 @@
       essential: true,
       filterValueGetter: "lower(${tenant_id}_mod_inventory_storage.f_unaccent(:sourceAlias.jsonb ->> 'hrid'::text))",
       valueFunction: 'lower(${tenant_id}_mod_inventory_storage.f_unaccent(:value))',
+      availableOperators: ['$eq', '$ne', '$in', '$contains', '$starts_with', '$empty'],
     },
     {
       name: 'source',

--- a/src/main/resources/entity-types/inventory/simple_item.json5
+++ b/src/main/resources/entity-types/inventory/simple_item.json5
@@ -37,6 +37,7 @@
       valueGetter: ":sourceAlias.jsonb ->> 'hrid'",
       filterValueGetter: "lower(${tenant_id}_mod_inventory_storage.f_unaccent(:sourceAlias.jsonb ->> 'hrid'::text))",
       valueFunction: 'lower(${tenant_id}_mod_inventory_storage.f_unaccent(:value))',
+      availableOperators: ['$eq', '$ne', '$in', '$contains', '$starts_with', '$empty'],
     },
     {
       name: 'notes',
@@ -244,6 +245,7 @@
       valueGetter: ":sourceAlias.jsonb->>'barcode'",
       filterValueGetter: "lower(:sourceAlias.jsonb ->> 'barcode'::text)",
       valueFunction: 'lower(:value)',
+      availableOperators: ['$eq', '$ne', '$in', '$contains', '$starts_with', '$empty'],
     },
     {
       name: 'version',

--- a/src/main/resources/entity-types/users/simple_user_details.json5
+++ b/src/main/resources/entity-types/users/simple_user_details.json5
@@ -476,6 +476,7 @@
       valueGetter: ":sourceAlias.jsonb->>'barcode'",
       filterValueGetter: "lower(${tenant_id}_mod_users.f_unaccent(:sourceAlias.jsonb ->> 'barcode'::text))",
       valueFunction: 'lower(${tenant_id}_mod_users.f_unaccent(:value))',
+      availableOperators: ['$eq', '$ne', '$in', '$contains', '$starts_with', '$empty'],
     },
     {
       name: 'external_system_id',

--- a/src/test/java/org/folio/fqm/service/EntityTypeFlatteningServiceTest.java
+++ b/src/test/java/org/folio/fqm/service/EntityTypeFlatteningServiceTest.java
@@ -956,6 +956,95 @@ class EntityTypeFlatteningServiceTest {
     assertThat(flattenedWithoutCustomFields.getColumns(), not(hasItem(hasProperty("name", equalTo("source_alias.custom_field")))));
   }
 
+  @Test
+  void testAvailableOperatorsPreservedInSelfColumns() {
+    EntityType simpleEntityType = new EntityType()
+      .id("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+      .name("simple_with_operators")
+      .columns(List.of(
+        new EntityTypeColumn()
+          .name("flagged_field")
+          .dataType(new StringType().dataType("stringType"))
+          .valueGetter(":src.flagged_field")
+          .availableOperators(List.of("$eq", "$ne", "$in", "$contains", "$starts_with", "$empty")),
+        new EntityTypeColumn()
+          .name("unflagged_field")
+          .dataType(new StringType().dataType("stringType"))
+          .valueGetter(":src.unflagged_field")
+      ))
+      .sources(List.of(new EntityTypeSourceDatabase().type("db").alias("src").target("some_table")));
+
+    when(entityTypeRepository.getEntityTypeDefinition(eq(UUID.fromString(simpleEntityType.getId())), any()))
+      .thenReturn(Optional.of(simpleEntityType));
+    when(userTenantService.getUserTenantsResponse(TENANT_ID)).thenReturn("{'totalRecords': 0}");
+
+    List<EntityTypeColumn> columns = entityTypeFlatteningService.getFlattenedEntityType(
+      UUID.fromString(simpleEntityType.getId()),
+      TENANT_ID,
+      false
+    ).getColumns();
+
+    assertThat(columns, hasItem(allOf(
+      hasProperty("name", equalTo("flagged_field")),
+      hasProperty("availableOperators", equalTo(List.of("$eq", "$ne", "$in", "$contains", "$starts_with", "$empty")))
+    )));
+    assertThat(columns, hasItem(allOf(
+      hasProperty("name", equalTo("unflagged_field")),
+      hasProperty("availableOperators", nullValue())
+    )));
+  }
+
+  @Test
+  void testAvailableOperatorsPreservedInInheritedColumns() {
+    EntityType childEntityType = new EntityType()
+      .id("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+      .name("child_with_operators")
+      .columns(List.of(
+        new EntityTypeColumn()
+          .name("flagged_field")
+          .dataType(new StringType().dataType("stringType"))
+          .valueGetter(":src.flagged_field")
+          .availableOperators(List.of("$eq", "$ne", "$in", "$contains", "$starts_with", "$empty")),
+        new EntityTypeColumn()
+          .name("unflagged_field")
+          .dataType(new StringType().dataType("stringType"))
+          .valueGetter(":src.unflagged_field")
+      ))
+      .sources(List.of(new EntityTypeSourceDatabase().type("db").alias("src").target("some_table")));
+
+    EntityType compositeEntityType = new EntityType()
+      .id("cccccccc-cccc-cccc-cccc-cccccccccccc")
+      .name("composite_with_operators")
+      .columns(List.of())
+      .sources(List.of(
+        new EntityTypeSourceEntityType()
+          .type("entity-type")
+          .alias("child")
+          .targetId(UUID.fromString(childEntityType.getId()))
+      ));
+
+    when(entityTypeRepository.getEntityTypeDefinition(eq(UUID.fromString(childEntityType.getId())), any()))
+      .thenReturn(Optional.of(childEntityType));
+    when(entityTypeRepository.getEntityTypeDefinition(eq(UUID.fromString(compositeEntityType.getId())), any()))
+      .thenReturn(Optional.of(compositeEntityType));
+    when(userTenantService.getUserTenantsResponse(TENANT_ID)).thenReturn("{'totalRecords': 0}");
+
+    List<EntityTypeColumn> columns = entityTypeFlatteningService.getFlattenedEntityType(
+      UUID.fromString(compositeEntityType.getId()),
+      TENANT_ID,
+      false
+    ).getColumns();
+
+    assertThat(columns, hasItem(allOf(
+      hasProperty("name", equalTo("child.flagged_field")),
+      hasProperty("availableOperators", equalTo(List.of("$eq", "$ne", "$in", "$contains", "$starts_with", "$empty")))
+    )));
+    assertThat(columns, hasItem(allOf(
+      hasProperty("name", equalTo("child.unflagged_field")),
+      hasProperty("availableOperators", nullValue())
+    )));
+  }
+
   @SneakyThrows
   private EntityType copyEntityType(EntityType originalEntityType) {
     ObjectMapper objectMapper = new ObjectMapper();


### PR DESCRIPTION
This commit also adds some tests to EntityTypeFlatteningServiceTest, to ensure the new availableOperators property is handled correctly when inheriting fields from a simple entity type into a composite