### PR TITLE
[MODFQMMGR-1134] Add invoice line entity to Order-Invoice-Analysis

### DIFF
--- a/src/main/resources/entity-types/orders/composite_order_invoice_analytics.json5
+++ b/src/main/resources/entity-types/orders/composite_order_invoice_analytics.json5
@@ -47,7 +47,7 @@
     {
       alias: 'invoice_line',
       type: 'entity-type',
-      targetId: '4999bd5f-3898-4b44-b283-e37bc9261ad8', // simple_invoice_line
+      targetId: '1373f063-8b86-48cc-832d-68b4d0dd44fc', // simple_invoice_line
       targetField: 'id',
       sourceField: 'invoice_line_fund_distribution.invoice_line_id',
       essentialOnly: true,

--- a/src/main/resources/entity-types/orders/composite_order_invoice_analytics.json5
+++ b/src/main/resources/entity-types/orders/composite_order_invoice_analytics.json5
@@ -45,6 +45,15 @@
       order: 40,
     },
     {
+      alias: 'invoice_line',
+      type: 'entity-type',
+      targetId: '4999bd5f-3898-4b44-b283-e37bc9261ad8', // simple_invoice_line
+      targetField: 'id',
+      sourceField: 'invoice_line_fund_distribution.invoice_line_id',
+      essentialOnly: true,
+      order: 45,
+    },
+    {
       alias: 'invoice',
       type: 'entity-type',
       targetId: '4d626ce1-1880-48d2-9d4c-81667fdc5dbb', // simple_invoice

--- a/translations/mod-fqm-manager/en.json
+++ b/translations/mod-fqm-manager/en.json
@@ -918,6 +918,7 @@
   "entityType.composite_order_invoice_analytics.invoice": "Invoice",
   "entityType.composite_order_invoice_analytics.bill_to": "Bill to",
   "entityType.composite_order_invoice_analytics.invoice_line_fund_distribution": "Invoice — Line",
+  "entityType.composite_order_invoice_analytics.invoice_line": "Invoice — Line",
   "entityType.composite_order_invoice_analytics.organization": "Organization",
   "entityType.composite_order_invoice_analytics.po": "PO",
   "entityType.composite_order_invoice_analytics.po_created_by": "PO created by",

--- a/translations/mod-fqm-manager/es.json
+++ b/translations/mod-fqm-manager/es.json
@@ -1938,6 +1938,7 @@
     "entityType.composite_order_invoice_analytics.po": "PO",
     "entityType.composite_order_invoice_analytics.pol": "PO line",
     "entityType.composite_order_invoice_analytics.invoice_line_fund_distribution": "Invoice",
+    "entityType.composite_invoice_line_fund_distribution.invoice_line": "Line",
     "entityType.composite_order_invoice_analytics.invoice": "Invoice",
     "entityType.composite_order_invoice_analytics.organization": "Organization",
     "entityType.composite_order_invoice_analytics.fiscal_year": "Fiscal year",

--- a/translations/mod-fqm-manager/es.json
+++ b/translations/mod-fqm-manager/es.json
@@ -1938,7 +1938,6 @@
     "entityType.composite_order_invoice_analytics.po": "PO",
     "entityType.composite_order_invoice_analytics.pol": "PO line",
     "entityType.composite_order_invoice_analytics.invoice_line_fund_distribution": "Invoice",
-    "entityType.composite_order_invoice_analytics.invoice_line": "Invoice — Line",
     "entityType.composite_order_invoice_analytics.invoice": "Invoice",
     "entityType.composite_order_invoice_analytics.organization": "Organization",
     "entityType.composite_order_invoice_analytics.fiscal_year": "Fiscal year",

--- a/translations/mod-fqm-manager/es.json
+++ b/translations/mod-fqm-manager/es.json
@@ -1938,6 +1938,7 @@
     "entityType.composite_order_invoice_analytics.po": "PO",
     "entityType.composite_order_invoice_analytics.pol": "PO line",
     "entityType.composite_order_invoice_analytics.invoice_line_fund_distribution": "Invoice",
+    "entityType.composite_order_invoice_analytics.invoice_line": "Invoice — Line",
     "entityType.composite_invoice_line_fund_distribution.invoice_line": "Line",
     "entityType.composite_order_invoice_analytics.invoice": "Invoice",
     "entityType.composite_order_invoice_analytics.organization": "Organization",

--- a/translations/mod-fqm-manager/es.json
+++ b/translations/mod-fqm-manager/es.json
@@ -1939,7 +1939,6 @@
     "entityType.composite_order_invoice_analytics.pol": "PO line",
     "entityType.composite_order_invoice_analytics.invoice_line_fund_distribution": "Invoice",
     "entityType.composite_order_invoice_analytics.invoice_line": "Invoice — Line",
-    "entityType.composite_invoice_line_fund_distribution.invoice_line": "Line",
     "entityType.composite_order_invoice_analytics.invoice": "Invoice",
     "entityType.composite_order_invoice_analytics.organization": "Organization",
     "entityType.composite_order_invoice_analytics.fiscal_year": "Fiscal year",


### PR DESCRIPTION
## Purpose
[[MODFQMMGR-1134] Add invoice line entity to Order-Invoice-Analysis](https://folio-org.atlassian.net/browse/MODFQMMGR-1134)

## Approach
Recent changes removed the invoice line fields by mistake, and now it is added as a separate entity type

## Pre-Merge Checklist

If you are adding entity type(s), have you:
- [x] Added the JSON5 definition to the `src/main/resources/entity-types` directory?
- [x] Ensured that GETing the entity type at `/entity-types/{id}` works as expected?
- [x] Added translations for all fields, per the [translation guidelines](/translations/README.md)? (Check this by ensuring `GET /entity-types/{id}` does not have `mod-fqm-manager.entityType.` in the response)
- [ ] Added views to liquibase, as applicable?
- [ ] Added required interfaces to the module descriptor?
- [x] Checked that querying fields works correctly and all SQL is valid?

If you are changing/removing entity type(s), have you:
- [ ] Added migration code for any changes?